### PR TITLE
[Platform] Tweak misc. items to support clocks/timers

### DIFF
--- a/platform/commonUI/browse/src/creation/CreateWizard.js
+++ b/platform/commonUI/browse/src/creation/CreateWizard.js
@@ -45,8 +45,9 @@ define(
                 properties = type.getProperties();
 
             function validateLocation(locatingObject) {
-                var locatingType = locatingObject.getCapability('type');
-                return policyService.allow(
+                var locatingType = locatingObject &&
+                        locatingObject.getCapability('type');
+                return locatingType && policyService.allow(
                     "composition",
                     locatingType,
                     type

--- a/platform/containment/bundle.json
+++ b/platform/containment/bundle.json
@@ -13,6 +13,11 @@
                 "message": "Objects of this type cannot be modified."
             },
             {
+                "category": "composition",
+                "implementation": "CompositionModelPolicy.js",
+                "message": "Objects of this type cannot contain other objects."
+            },
+            {
                 "category": "action",
                 "implementation": "ComposeActionPolicy.js",
                 "depends": [ "$injector" ],

--- a/platform/containment/src/CompositionModelPolicy.js
+++ b/platform/containment/src/CompositionModelPolicy.js
@@ -1,0 +1,28 @@
+/*global define*/
+
+define(
+    [],
+    function () {
+        "use strict";
+
+        /**
+         * Policy allowing composition only for domain object types which
+         * have a composition property.
+         */
+        function CompositionModelPolicy() {
+            return {
+                /**
+                 * Is the type identified by the candidate allowed to
+                 * contain the type described by the context?
+                 */
+                allow: function (candidate, context) {
+                    return Array.isArray(
+                        (candidate.getInitialModel() || {}).composition
+                    );
+                }
+            };
+        }
+
+        return CompositionModelPolicy;
+    }
+);

--- a/platform/containment/test/CompositionModelPolicySpec.js
+++ b/platform/containment/test/CompositionModelPolicySpec.js
@@ -1,0 +1,26 @@
+/*global define,Promise,describe,it,expect,beforeEach,waitsFor,jasmine*/
+
+define(
+    ["../src/CompositionModelPolicy"],
+    function (CompositionModelPolicy) {
+        "use strict";
+
+        describe("The composition model policy", function () {
+            var mockType,
+                policy;
+
+            beforeEach(function () {
+                mockType = jasmine.createSpyObj('type', ['getInitialModel']);
+                policy = new CompositionModelPolicy();
+            });
+
+            it("only allows composition for types which will have a composition property", function () {
+                mockType.getInitialModel.andReturn({});
+                expect(policy.allow(mockType)).toBeFalsy();
+                mockType.getInitialModel.andReturn({ composition: [] });
+                expect(policy.allow(mockType)).toBeTruthy();
+            });
+        });
+
+    }
+);

--- a/platform/containment/test/CompositionMutabilityPolicySpec.js
+++ b/platform/containment/test/CompositionMutabilityPolicySpec.js
@@ -35,7 +35,7 @@ define(
                 policy = new CompositionMutabilityPolicy();
             });
 
-            it("only allows composition for types which will have a composition capability", function () {
+            it("only allows composition for types which can be created/modified", function () {
                 expect(policy.allow(mockType)).toBeFalsy();
                 mockType.hasFeature.andReturn(true);
                 expect(policy.allow(mockType)).toBeTruthy();

--- a/platform/containment/test/suite.json
+++ b/platform/containment/test/suite.json
@@ -1,6 +1,7 @@
 [
     "CapabilityTable",
     "ComposeActionPolicy",
+    "CompositionModelPolicy",
     "CompositionMutabilityPolicy",
     "CompositionPolicy",
     "ContainmentTable"

--- a/platform/core/src/capabilities/MutationCapability.js
+++ b/platform/core/src/capabilities/MutationCapability.js
@@ -77,7 +77,8 @@ define(
                 // Get the object's model and clone it, so the
                 // mutator function has a temporary copy to work with.
                 var model = domainObject.getModel(),
-                    clone = JSON.parse(JSON.stringify(model));
+                    clone = JSON.parse(JSON.stringify(model)),
+                    useTimestamp = arguments.length > 1;
 
                 // Function to handle copying values to the actual
                 function handleMutation(mutationResult) {
@@ -94,8 +95,7 @@ define(
                         if (model !== result) {
                             copyValues(model, result);
                         }
-                        model.modified = (typeof timestamp === 'number') ?
-                                timestamp : now();
+                        model.modified = useTimestamp ? timestamp : now();
                     }
 
                     // Report the result of the mutation

--- a/platform/forms/res/templates/controls/datetime.html
+++ b/platform/forms/res/templates/controls/datetime.html
@@ -38,7 +38,7 @@
                        placeholder="YYYY-DDD"
                        ng-pattern="/\d\d\d\d-\d\d\d/"
                        ng-model='datetime.date'
-                       ng-required='true'/>
+                       ng-required='ngRequired || partiallyComplete'/>
             </span>
             <span class='field control time sm'>
                 <input type='text'
@@ -49,7 +49,7 @@
                        integer
                        ng-pattern='/\d+/'
                        ng-model="datetime.hour"
-                       ng-required='true'/>
+                       ng-required='ngRequired || partiallyComplete'/>
             </span>
             <span class='field control time sm'>
                 <input type='text'
@@ -60,7 +60,7 @@
                        integer
                        ng-pattern='/\d+/'
                        ng-model="datetime.min"
-                       ng-required='true'/>
+                       ng-required='ngRequired || partiallyComplete'/>
             </span>
             <span class='field control time sm'>
                 <input type='text'
@@ -71,7 +71,7 @@
                        integer
                        ng-pattern='/\d+/'
                        ng-model="datetime.sec"
-                       ng-required='true'/>
+                       ng-required='ngRequired || partiallyComplete'/>
             </span>
             <span class='field control timezone'>
                 UTC

--- a/platform/forms/src/controllers/DateTimeController.js
+++ b/platform/forms/src/controllers/DateTimeController.js
@@ -68,13 +68,35 @@ define(
                 }
             }
 
+            function updateDateTime(value) {
+                var m;
+                if (value !== undefined) {
+                    m = moment.utc(value);
+                    $scope.datetime = {
+                        date: m.format(DATE_FORMAT),
+                        hour: m.format("H"),
+                        min: m.format("m"),
+                        sec: m.format("s")
+                    };
+                } else {
+                    $scope.datetime = {};
+                }
+            }
+
+            // ...and update form values when actual field in model changes
+            $scope.$watch("ngModel[field]", updateDateTime);
+
             // Update value whenever any field changes.
             $scope.$watch("datetime.date", update);
             $scope.$watch("datetime.hour", update);
             $scope.$watch("datetime.min", update);
             $scope.$watch("datetime.sec", update);
 
-            $scope.datetime = {};
+            // Initialize forms values
+            updateDateTime(
+                ($scope.ngModel && $scope.field) ?
+                        $scope.ngModel[$scope.field] : undefined
+            );
         }
 
         return DateTimeController;

--- a/platform/forms/src/controllers/DateTimeController.js
+++ b/platform/forms/src/controllers/DateTimeController.js
@@ -52,6 +52,20 @@ define(
                 if (fullDateTime.isValid()) {
                     $scope.ngModel[$scope.field] = fullDateTime.valueOf();
                 }
+
+                // If anything is complete, say so in scope; there are
+                // ng-required usages that will update off of this (to
+                // allow datetime to be optional while still permitting
+                // incomplete input)
+                $scope.partiallyComplete =
+                    Object.keys($scope.datetime).some(function (key) {
+                        return $scope.datetime[key];
+                    });
+
+                // Treat empty input as an undefined value
+                if (!$scope.partiallyComplete) {
+                    $scope.ngModel[$scope.field] = undefined;
+                }
             }
 
             // Update value whenever any field changes.

--- a/platform/forms/test/controllers/DateTimeControllerSpec.js
+++ b/platform/forms/test/controllers/DateTimeControllerSpec.js
@@ -57,6 +57,33 @@ define(
                 expect(mockScope.ngModel.test).toEqual(1417215313000);
             });
 
+            it("reports when form input is partially complete", function () {
+                // This is needed to flag the control's state as invalid
+                // when it is partially complete without having it treated
+                // as required.
+                mockScope.ngModel = {};
+                mockScope.field = "test";
+                mockScope.datetime.date = "2014-332";
+                mockScope.datetime.hour = 22;
+                mockScope.datetime.min = 55;
+                // mockScope.datetime.sec = 13;
+
+                mockScope.$watch.mostRecentCall.args[1]();
+
+                expect(mockScope.partiallyComplete).toBeTruthy();
+            });
+
+            it("reports 'undefined' for empty input", function () {
+                mockScope.ngModel = { test: 12345 };
+                mockScope.field = "test";
+                mockScope.$watch.mostRecentCall.args[1]();
+                // Clear all inputs
+                mockScope.datetime = {};
+                mockScope.$watch.mostRecentCall.args[1]();
+
+                // Should have cleared out the time stamp
+                expect(mockScope.ngModel.test).toBeUndefined();
+            });
         });
     }
 );


### PR DESCRIPTION
Summary of changes:

* Add a composition policy which requires destinations to actually have a composition 
  property in their model.
  * In the context of clocks/timers, this prevents being able to create a Timer in a Timer.
* Allow date-time controller to be optional (previously, its internal use of `ng-required` meant 
  that it was treated as required whenever it appeared in a form)
  * Specifically, treat individual fields as required only if (a) input it partially complete or 
    (b) the control has been explicitly marked as required.
* Change explicit-setting-of-timestamp during mutation to allow this timestamp to be explicitly 
   undefined
  * Previously, would default to current timestamp if the argument was non-numeric; 
    instead, check number of arguments and simply accept whatever was passed 
    (using `now()` only when that argument was actually omitted)
  * This specifically supports auto-refresh behavior of clocks/timers; refresh has [a 
    check](https://github.com/nasa/openmctweb/blob/ca4f37b25971efc91e08098741b09ed96ffe6f9f/platform/core/src/capabilities/PersistenceCapability.js#L101) on the modification time, which should be undefined after creation, but it also tries to [preserve the modification time](https://github.com/nasa/openmctweb/blob/ca4f37b25971efc91e08098741b09ed96ffe6f9f/platform/core/src/capabilities/PersistenceCapability.js#L51-L54) upon refresh. Since `modified` is undefined upon creation, after one refresh cycle the next refresh will fail without this change.

1.    Changes address original issue? Y
2.    Unit tests included and/or updated with changes? Y
3.    Command line build passes? Y
4.    Expect to pass code review? Y
5.    Project-specific information isolated to appropriate branches? Y

Support clocks/timers, WTD-1221