### PR TITLE
[Plot] Improve plotting performance

### DIFF
--- a/platform/core/bundle.json
+++ b/platform/core/bundle.json
@@ -180,6 +180,11 @@
             {
                 "key": "now",
                 "implementation": "services/Now.js"
+            },
+            {
+                "key": "throttle",
+                "implementation": "services/Throttle.js",
+                "depends": [ "$timeout" ]
             }
         ],
         "roots": [

--- a/platform/core/src/services/Throttle.js
+++ b/platform/core/src/services/Throttle.js
@@ -4,7 +4,7 @@ define(
     [],
     function () {
         "use strict";
-        
+
         /**
          * Throttler for function executions, registered as the `throttle`
          * service.
@@ -13,7 +13,7 @@ define(
          *
          *     throttle(fn, delay, [apply])
          *
-         * Returns a function that, when invoked, will invoke `fn` after 
+         * Returns a function that, when invoked, will invoke `fn` after
          * `delay` milliseconds, only if no other invocations are pending.
          * The optional argument `apply` determines whether.
          *
@@ -28,36 +28,36 @@ define(
              * @param {Function} fn the function to throttle
              * @param {number} [delay] the delay, in milliseconds, before
              *        executing this function; defaults to 0.
-             * @param {boolean} apply true if a `$apply` call should be 
+             * @param {boolean} apply true if a `$apply` call should be
              *        invoked after this function executes; defaults to
              *        `false`.
              */
             return function (fn, delay, apply) {
                 var activeTimeout;
-                
+
                 // Clear active timeout, so that next invocation starts
                 // a new one.
                 function clearActiveTimeout() {
                     activeTimeout = undefined;
                 }
-                
+
                 // Defaults
                 delay = delay || 0;
                 apply = apply || false;
-                
+
                 return function () {
                     // Start a timeout if needed
                     if (!activeTimeout) {
                         activeTimeout = $timeout(fn, delay, apply);
                         activeTimeout.then(clearActiveTimeout);
                     }
-                    // Return whichever timeout is active (to get 
+                    // Return whichever timeout is active (to get
                     // a promise for the results of fn)
                     return activeTimeout;
                 };
             };
         }
-        
+
         return Throttle;
     }
 );

--- a/platform/core/src/services/Throttle.js
+++ b/platform/core/src/services/Throttle.js
@@ -1,0 +1,63 @@
+/*global define*/
+
+define(
+    [],
+    function () {
+        "use strict";
+        
+        /**
+         * Throttler for function executions, registered as the `throttle`
+         * service.
+         *
+         * Usage:
+         *
+         *     throttle(fn, delay, [apply])
+         *
+         * Returns a function that, when invoked, will invoke `fn` after 
+         * `delay` milliseconds, only if no other invocations are pending.
+         * The optional argument `apply` determines whether.
+         *
+         * The returned function will itself return a `Promise` which will
+         * resolve to the returned value of `fn` whenever that is invoked.
+         *
+         * @returns {Function}
+         */
+        function Throttle($timeout) {
+            /**
+             * Throttle this function.
+             * @param {Function} fn the function to throttle
+             * @param {number} [delay] the delay, in milliseconds, before
+             *        executing this function; defaults to 0.
+             * @param {boolean} apply true if a `$apply` call should be 
+             *        invoked after this function executes; defaults to
+             *        `false`.
+             */
+            return function (fn, delay, apply) {
+                var activeTimeout;
+                
+                // Clear active timeout, so that next invocation starts
+                // a new one.
+                function clearActiveTimeout() {
+                    activeTimeout = undefined;
+                }
+                
+                // Defaults
+                delay = delay || 0;
+                apply = apply || false;
+                
+                return function () {
+                    // Start a timeout if needed
+                    if (!activeTimeout) {
+                        activeTimeout = $timeout(fn, delay, apply);
+                        activeTimeout.then(clearActiveTimeout);
+                    }
+                    // Return whichever timeout is active (to get 
+                    // a promise for the results of fn)
+                    return activeTimeout;
+                };
+            };
+        }
+        
+        return Throttle;
+    }
+);

--- a/platform/core/test/services/ThrottleSpec.js
+++ b/platform/core/test/services/ThrottleSpec.js
@@ -10,7 +10,7 @@ define(
                 mockTimeout,
                 mockFn,
                 mockPromise;
-            
+
             beforeEach(function () {
                 mockTimeout = jasmine.createSpy("$timeout");
                 mockPromise = jasmine.createSpyObj("promise", ["then"]);
@@ -18,7 +18,7 @@ define(
                 mockTimeout.andReturn(mockPromise);
                 throttle = new Throttle(mockTimeout);
             });
-            
+
             it("provides functions which run on a timeout", function () {
                 var throttled = throttle(mockFn);
                 // Verify precondition: Not called at throttle-time
@@ -26,7 +26,7 @@ define(
                 expect(throttled()).toEqual(mockPromise);
                 expect(mockTimeout).toHaveBeenCalledWith(mockFn, 0, false);
             });
-            
+
             it("schedules only one timeout at a time", function () {
                 var throttled = throttle(mockFn);
                 throttled();
@@ -34,7 +34,7 @@ define(
                 throttled();
                 expect(mockTimeout.calls.length).toEqual(1);
             });
-            
+
             it("schedules additional invocations after resolution", function () {
                 var throttled = throttle(mockFn);
                 throttled();

--- a/platform/core/test/services/ThrottleSpec.js
+++ b/platform/core/test/services/ThrottleSpec.js
@@ -1,0 +1,49 @@
+/*global define,Promise,describe,it,expect,beforeEach,waitsFor,jasmine*/
+
+define(
+    ["../../src/services/Throttle"],
+    function (Throttle) {
+        "use strict";
+
+        describe("The 'throttle' service", function () {
+            var throttle,
+                mockTimeout,
+                mockFn,
+                mockPromise;
+            
+            beforeEach(function () {
+                mockTimeout = jasmine.createSpy("$timeout");
+                mockPromise = jasmine.createSpyObj("promise", ["then"]);
+                mockFn = jasmine.createSpy("fn");
+                mockTimeout.andReturn(mockPromise);
+                throttle = new Throttle(mockTimeout);
+            });
+            
+            it("provides functions which run on a timeout", function () {
+                var throttled = throttle(mockFn);
+                // Verify precondition: Not called at throttle-time
+                expect(mockTimeout).not.toHaveBeenCalled();
+                expect(throttled()).toEqual(mockPromise);
+                expect(mockTimeout).toHaveBeenCalledWith(mockFn, 0, false);
+            });
+            
+            it("schedules only one timeout at a time", function () {
+                var throttled = throttle(mockFn);
+                throttled();
+                throttled();
+                throttled();
+                expect(mockTimeout.calls.length).toEqual(1);
+            });
+            
+            it("schedules additional invocations after resolution", function () {
+                var throttled = throttle(mockFn);
+                throttled();
+                mockPromise.then.mostRecentCall.args[0](); // Resolve timeout
+                throttled();
+                mockPromise.then.mostRecentCall.args[0]();
+                throttled();
+                expect(mockTimeout.calls.length).toEqual(3);
+            });
+        });
+    }
+);

--- a/platform/core/test/suite.json
+++ b/platform/core/test/suite.json
@@ -23,6 +23,7 @@
     "objects/DomainObjectProvider",
 
     "services/Now",
+    "services/Throttle",
 
     "types/MergeModels",
     "types/TypeCapability",

--- a/platform/features/plot/bundle.json
+++ b/platform/features/plot/bundle.json
@@ -22,7 +22,7 @@
             {
                 "key": "PlotController",
                 "implementation": "PlotController.js",
-                "depends": [ "$scope", "telemetryFormatter", "telemetryHandler" ]
+                "depends": [ "$scope", "telemetryFormatter", "telemetryHandler", "throttle" ]
             }
         ]
     }

--- a/platform/features/plot/src/PlotController.js
+++ b/platform/features/plot/src/PlotController.js
@@ -51,13 +51,14 @@ define(
          *
          * @constructor
          */
-        function PlotController($scope, telemetryFormatter, telemetryHandler) {
+        function PlotController($scope, telemetryFormatter, telemetryHandler, throttle) {
             var subPlotFactory = new SubPlotFactory(telemetryFormatter),
                 modeOptions = new PlotModeOptions([], subPlotFactory),
                 subplots = [],
                 cachedObjects = [],
                 updater,
                 handle,
+                scheduleUpdate,
                 domainOffset;
 
             // Populate the scope with axis information (specifically, options
@@ -89,9 +90,7 @@ define(
 
             // Update all sub-plots
             function update() {
-                modeOptions.getModeHandler()
-                    .getSubPlots()
-                    .forEach(updateSubplot);
+                scheduleUpdate();
             }
 
             // Reinstantiate the plot updater (e.g. because we have a
@@ -162,6 +161,12 @@ define(
 
             // Unsubscribe when the plot is destroyed
             $scope.$on("$destroy", releaseSubscription);
+            
+            // Create a throttled update function
+            scheduleUpdate = throttle(function () {
+                modeOptions.getModeHandler().getSubPlots()
+                    .forEach(updateSubplot);
+            });
 
             return {
                 /**

--- a/platform/features/plot/src/modes/PlotOverlayMode.js
+++ b/platform/features/plot/src/modes/PlotOverlayMode.js
@@ -62,8 +62,6 @@ define(
                         points: buf.getLength()
                     };
                 });
-
-                subplot.update();
             }
 
             return {

--- a/platform/features/plot/src/modes/PlotStackMode.js
+++ b/platform/features/plot/src/modes/PlotStackMode.js
@@ -58,8 +58,6 @@ define(
                     color: PlotPalette.getFloatColor(0),
                     points: buffer.getLength()
                 }];
-
-                subplot.update();
             }
 
             function plotTelemetry(prepared) {

--- a/platform/features/plot/test/PlotControllerSpec.js
+++ b/platform/features/plot/test/PlotControllerSpec.js
@@ -33,6 +33,7 @@ define(
             var mockScope,
                 mockFormatter,
                 mockHandler,
+                mockThrottle,
                 mockHandle,
                 mockDomainObject,
                 mockSeries,
@@ -56,6 +57,7 @@ define(
                     "telemetrySubscriber",
                     ["handle"]
                 );
+                mockThrottle = jasmine.createSpy("throttle");
                 mockHandle = jasmine.createSpyObj(
                     "subscription",
                     [
@@ -73,12 +75,18 @@ define(
                 );
 
                 mockHandler.handle.andReturn(mockHandle);
+                mockThrottle.andCallFake(function (fn) { return fn; });
                 mockHandle.getTelemetryObjects.andReturn([mockDomainObject]);
                 mockHandle.getMetadata.andReturn([{}]);
                 mockHandle.getDomainValue.andReturn(123);
                 mockHandle.getRangeValue.andReturn(42);
 
-                controller = new PlotController(mockScope, mockFormatter, mockHandler);
+                controller = new PlotController(
+                    mockScope,
+                    mockFormatter,
+                    mockHandler,
+                    mockThrottle
+                );
             });
 
             it("provides plot colors", function () {


### PR DESCRIPTION
Improve performance during plotting. Specifically:

* Refactor the telemetry queue (used as an alternative to a table for subscribers who wish to receive telemetry updates for every datum that arrives) to improve insertion performance characteristics.
* Throttle updates to plot axis labels. These potentially change every time new data comes in, but in cases where data is arriving faster than it can be displayed, these only need to be recalculated at display time.
* Add `throttle` as a utility service to support the above.

Partially addresses WTD-1202; specifically, addresses the largest performance issues identified during profiling of plot updates. WTD-1218 has been filed as a followup to address the more general problem of how an overloaded client presents itself (e.g. by freezing.)

1. Changes address original issue? Y <sup>1</sup>
2. Unit tests included and/or updated with changes? Y
3. Command line build passes? Y
4. Expect to pass code review? Y <sup>2</sup>
5. Project-specific information isolated to appropriate branches? Y

<sup>1</sup> Partially; issue is performance related so is a matter of degree. Filed followup issue for performance characteristics not addressed by these changes.
<sup>2</sup> Maybe! Interested in seeing if `throttle` should be `throttleService`, or maybe part of a more general service (or just start using underscore?)