### PR TITLE
[Addressability] Use/populate URL

### DIFF
--- a/platform/commonUI/browse/bundle.json
+++ b/platform/commonUI/browse/bundle.json
@@ -14,7 +14,7 @@
             {
                 "key": "BrowseController",
                 "implementation": "BrowseController.js",
-                "depends": [ "$scope", "$routeParams", "objectService", "navigationService" ]
+                "depends": [ "$scope", "$route", "$location", "objectService", "navigationService" ]
             },
             {
                 "key": "CreateMenuController",

--- a/platform/commonUI/browse/bundle.json
+++ b/platform/commonUI/browse/bundle.json
@@ -2,7 +2,7 @@
     "extensions": {
         "routes": [
             {
-                "when": "/browse/:id*",
+                "when": "/browse/:ids*",
                 "templateUrl": "templates/browse.html"
             },
             {

--- a/platform/commonUI/browse/bundle.json
+++ b/platform/commonUI/browse/bundle.json
@@ -17,6 +17,11 @@
                 "depends": [ "$scope", "$route", "$location", "objectService", "navigationService" ]
             },
             {
+                "key": "BrowseObjectController",
+                "implementation": "BrowseObjectController.js",
+                "depends": [ "$scope", "$location" ]
+            },
+            {
                 "key": "CreateMenuController",
                 "implementation": "creation/CreateMenuController",
                 "depends": [ "$scope" ]

--- a/platform/commonUI/browse/bundle.json
+++ b/platform/commonUI/browse/bundle.json
@@ -2,7 +2,7 @@
     "extensions": {
         "routes": [
             {
-                "when": "/browse",
+                "when": "/browse/:id*",
                 "templateUrl": "templates/browse.html"
             },
             {
@@ -14,7 +14,7 @@
             {
                 "key": "BrowseController",
                 "implementation": "BrowseController.js",
-                "depends": [ "$scope", "objectService", "navigationService" ]
+                "depends": [ "$scope", "$routeParams", "objectService", "navigationService" ]
             },
             {
                 "key": "CreateMenuController",

--- a/platform/commonUI/browse/bundle.json
+++ b/platform/commonUI/browse/bundle.json
@@ -3,11 +3,13 @@
         "routes": [
             {
                 "when": "/browse/:ids*",
-                "templateUrl": "templates/browse.html"
+                "templateUrl": "templates/browse.html",
+                "reloadOnSearch": false
             },
             {
                 "when": "",
-                "templateUrl": "templates/browse.html"
+                "templateUrl": "templates/browse.html",
+                "reloadOnSearch": false
             }
         ],
         "controllers": [
@@ -19,7 +21,7 @@
             {
                 "key": "BrowseObjectController",
                 "implementation": "BrowseObjectController.js",
-                "depends": [ "$scope", "$location" ]
+                "depends": [ "$scope", "$location", "$route" ]
             },
             {
                 "key": "CreateMenuController",

--- a/platform/commonUI/browse/res/templates/browse-object.html
+++ b/platform/commonUI/browse/res/templates/browse-object.html
@@ -19,7 +19,7 @@
  this source code distribution or the Licensing information page available
  at runtime from the About dialog for additional information.
 -->
-<span>
+<span ng-controller="BrowseObjectController">
     <div class="object-browse-bar bar abs">
         <div class="items-select left abs">
             <mct-representation key="'object-header'" mct-object="domainObject">

--- a/platform/commonUI/browse/src/BrowseController.js
+++ b/platform/commonUI/browse/src/BrowseController.js
@@ -41,10 +41,20 @@ define(
          *
          * @constructor
          */
-        function BrowseController($scope, $routeParams, objectService, navigationService) {
+        function BrowseController($scope, $routeParams, $location, objectService, navigationService) {
             var path = [ROOT_ID].concat(
                 ($routeParams.ids || DEFAULT_PATH).split("/")
             );
+
+            function updateRoute(domainObject) {
+                var context = domainObject.getCapability('context'),
+                    objectPath = context.getPath(),
+                    ids = objectPath.map(function (domainObject) {
+                        return domainObject.getId();
+                    });
+
+                $location.path("/browse/" + ids.slice(1).join("/"));
+            }
 
             // Callback for updating the in-scope reference to the object
             // that is currently navigated-to.
@@ -52,6 +62,7 @@ define(
                 $scope.navigatedObject = domainObject;
                 $scope.treeModel.selectedObject = domainObject;
                 navigationService.setNavigation(domainObject);
+                updateRoute(domainObject);
             }
 
             function navigateTo(domainObject) {

--- a/platform/commonUI/browse/src/BrowseController.js
+++ b/platform/commonUI/browse/src/BrowseController.js
@@ -80,6 +80,7 @@ define(
                     // If not, pick a default as the last
                     // root-level component (usually "mine")
                     navigationService.setNavigation(domainObject);
+                    $scope.navigatedObject = domainObject;
                 } else {
                     // Otherwise, just expose the currently navigated object.
                     $scope.navigatedObject = navigationService.getNavigation();

--- a/platform/commonUI/browse/src/BrowseController.js
+++ b/platform/commonUI/browse/src/BrowseController.js
@@ -43,7 +43,7 @@ define(
          */
         function BrowseController($scope, $route, $location, objectService, navigationService) {
             var path = [ROOT_ID].concat(
-                ($route.current.ids || DEFAULT_PATH).split("/")
+                ($route.current.params.ids || DEFAULT_PATH).split("/")
             );
 
             function updateRoute(domainObject) {
@@ -73,13 +73,16 @@ define(
 
             function navigateTo(domainObject) {
                 // Check if an object has been navigated-to already...
-                if (!navigationService.getNavigation()) {
+                // If not, or if an ID path has been explicitly set in the URL,
+                // navigate to the URL-specified object.
+                if (!navigationService.getNavigation() || $route.current.params.ids) {
                     // If not, pick a default as the last
                     // root-level component (usually "mine")
                     navigationService.setNavigation(domainObject);
                 } else {
-                    // Otherwise, just expose it in the scope
+                    // Otherwise, just expose the currently navigated object.
                     $scope.navigatedObject = navigationService.getNavigation();
+                    updateRoute($scope.navigatedObject);
                 }
             }
 

--- a/platform/commonUI/browse/src/BrowseController.js
+++ b/platform/commonUI/browse/src/BrowseController.js
@@ -29,7 +29,8 @@ define(
     function () {
         "use strict";
 
-        var DEFAULT_PATH = "ROOT/mine";
+        var ROOT_ID = "ROOT",
+            DEFAULT_PATH = "mine";
 
         /**
          * The BrowseController is used to populate the initial scope in Browse
@@ -41,7 +42,9 @@ define(
          * @constructor
          */
         function BrowseController($scope, $routeParams, objectService, navigationService) {
-            var path = ($routeParams.ids || DEFAULT_PATH).split("/");
+            var path = [ROOT_ID].concat(
+                ($routeParams.ids || DEFAULT_PATH).split("/")
+            );
 
             // Callback for updating the in-scope reference to the object
             // that is currently navigated-to.

--- a/platform/commonUI/browse/src/BrowseController.js
+++ b/platform/commonUI/browse/src/BrowseController.js
@@ -41,9 +41,9 @@ define(
          *
          * @constructor
          */
-        function BrowseController($scope, $routeParams, $location, objectService, navigationService) {
+        function BrowseController($scope, $route, $location, objectService, navigationService) {
             var path = [ROOT_ID].concat(
-                ($routeParams.ids || DEFAULT_PATH).split("/")
+                ($route.current.ids || DEFAULT_PATH).split("/")
             );
 
             function updateRoute(domainObject) {
@@ -51,6 +51,12 @@ define(
                     objectPath = context.getPath(),
                     ids = objectPath.map(function (domainObject) {
                         return domainObject.getId();
+                    }),
+                    priorRoute = $route.current,
+                    // Act as if params HADN'T changed to avoid page reload
+                    unlisten = $scope.$on('$locationChangeSuccess', function () {
+                        $route.current = priorRoute;
+                        unlisten();
                     });
 
                 $location.path("/browse/" + ids.slice(1).join("/"));

--- a/platform/commonUI/browse/src/BrowseController.js
+++ b/platform/commonUI/browse/src/BrowseController.js
@@ -103,12 +103,22 @@ define(
                 if (composition) {
                     composition.then(function (c) {
                         var nextObject = findObject(c, path[index]);
-                        if (index + 1 >= path.length) {
-                            navigateTo(nextObject);
+                        if (nextObject) {
+                            if (index + 1 >= path.length) {
+                                navigateTo(nextObject);
+                            } else {
+                                doNavigate(nextObject, index + 1);
+                            }
                         } else {
-                            doNavigate(nextObject, index + 1);
+                            // Couldn't find the next element of the path
+                            // so navigate to the last path object we did find
+                            navigateTo(domainObject);
                         }
                     });
+                } else {
+                    // Similar to above case; this object has no composition,
+                    // so navigate to it instead of subsequent path elements.
+                    navigateTo(domainObject);
                 }
             }
 

--- a/platform/commonUI/browse/src/BrowseController.js
+++ b/platform/commonUI/browse/src/BrowseController.js
@@ -47,8 +47,9 @@ define(
             );
 
             function updateRoute(domainObject) {
-                var context = domainObject.getCapability('context'),
-                    objectPath = context.getPath(),
+                var context = domainObject &&
+                        domainObject.getCapability('context'),
+                    objectPath = context ? context.getPath() : [],
                     ids = objectPath.map(function (domainObject) {
                         return domainObject.getId();
                     }),

--- a/platform/commonUI/browse/src/BrowseController.js
+++ b/platform/commonUI/browse/src/BrowseController.js
@@ -40,7 +40,7 @@ define(
          *
          * @constructor
          */
-        function BrowseController($scope, objectService, navigationService) {
+        function BrowseController($scope, $routeParams, objectService, navigationService) {
             // Callback for updating the in-scope reference to the object
             // that is currently navigated-to.
             function setNavigation(domainObject) {

--- a/platform/commonUI/browse/src/BrowseController.js
+++ b/platform/commonUI/browse/src/BrowseController.js
@@ -55,10 +55,12 @@ define(
                     }),
                     priorRoute = $route.current,
                     // Act as if params HADN'T changed to avoid page reload
-                    unlisten = $scope.$on('$locationChangeSuccess', function () {
-                        $route.current = priorRoute;
-                        unlisten();
-                    });
+                    unlisten;
+
+                unlisten = $scope.$on('$locationChangeSuccess', function () {
+                    $route.current = priorRoute;
+                    unlisten();
+                });
 
                 $location.path("/browse/" + ids.slice(1).join("/"));
             }

--- a/platform/commonUI/browse/src/BrowseObjectController.js
+++ b/platform/commonUI/browse/src/BrowseObjectController.js
@@ -47,7 +47,14 @@ define(
                 }
             }
 
+            function updateQueryParam(viewKey) {
+                if (viewKey) {
+                    $location.search('view', viewKey);
+                }
+            }
+
             $scope.$watch('domainObject', setViewForDomainObject);
+            $scope.$watch('representation.selected.key', updateQueryParam);
         }
 
         return BrowseObjectController;

--- a/platform/commonUI/browse/src/BrowseObjectController.js
+++ b/platform/commonUI/browse/src/BrowseObjectController.js
@@ -21,53 +21,35 @@
  *****************************************************************************/
 /*global define,Promise*/
 
-/**
- * Module defining ViewSwitcherController. Created by vwoeltje on 11/7/14.
- */
 define(
     [],
     function () {
         "use strict";
 
         /**
-         * Controller for the view switcher; populates and maintains a list
-         * of applicable views for a represented domain object.
+         * Controller for the `browse-object` representation of a domain
+         * object (the right-hand side of Browse mode.)
          * @constructor
          */
-        function ViewSwitcherController($scope, $timeout) {
-            // If the view capability gets refreshed, try to
-            // keep the same option chosen.
-            function findMatchingOption(options, selected) {
-                var i;
+        function BrowseObjectController($scope, $location) {
+            function setViewForDomainObject(domainObject) {
+                var locationViewKey = $location.search().view;
 
-                if (selected) {
-                    for (i = 0; i < options.length; i += 1) {
-                        if (options[i].key === selected.key) {
-                            return options[i];
-                        }
+                function selectViewIfMatching(view) {
+                    if (view.key === locationViewKey) {
+                        $scope.representation.selected = view;
                     }
                 }
 
-                return options[0];
-            }
-
-            // Get list of views, read from capability
-            function updateOptions(views) {
-                if (Array.isArray(views)) {
-                    $timeout(function () {
-                        $scope.ngModel.selected = findMatchingOption(
-                            views,
-                            ($scope.ngModel || {}).selected
-                        );
-                    }, 0);
+                if (locationViewKey) {
+                    ((domainObject && domainObject.useCapability('view')) || [])
+                        .forEach(selectViewIfMatching);
                 }
             }
 
-            // Update view options when the in-scope results of using the
-            // view capability change.
-            $scope.$watch("view", updateOptions);
+            $scope.$watch('domainObject', setViewForDomainObject);
         }
 
-        return ViewSwitcherController;
+        return BrowseObjectController;
     }
 );

--- a/platform/commonUI/browse/src/BrowseObjectController.js
+++ b/platform/commonUI/browse/src/BrowseObjectController.js
@@ -37,6 +37,7 @@ define(
 
                 function selectViewIfMatching(view) {
                     if (view.key === locationViewKey) {
+                        $scope.representation = $scope.representation || {};
                         $scope.representation.selected = view;
                     }
                 }

--- a/platform/commonUI/browse/src/BrowseObjectController.js
+++ b/platform/commonUI/browse/src/BrowseObjectController.js
@@ -31,7 +31,7 @@ define(
          * object (the right-hand side of Browse mode.)
          * @constructor
          */
-        function BrowseObjectController($scope, $location) {
+        function BrowseObjectController($scope, $location, $route) {
             function setViewForDomainObject(domainObject) {
                 var locationViewKey = $location.search().view;
 
@@ -48,8 +48,14 @@ define(
             }
 
             function updateQueryParam(viewKey) {
+                var unlisten, priorRoute = $route.current;
+
                 if (viewKey) {
                     $location.search('view', viewKey);
+                    unlisten = $scope.$on('$locationChangeSuccess', function () {
+                        $route.current = priorRoute;
+                        unlisten();
+                    });
                 }
             }
 

--- a/platform/commonUI/browse/test/BrowseControllerSpec.js
+++ b/platform/commonUI/browse/test/BrowseControllerSpec.js
@@ -31,6 +31,8 @@ define(
 
         describe("The browse controller", function () {
             var mockScope,
+                mockRoute,
+                mockLocation,
                 mockObjectService,
                 mockNavigationService,
                 mockRootObject,
@@ -49,6 +51,11 @@ define(
                 mockScope = jasmine.createSpyObj(
                     "$scope",
                     [ "$on", "$watch" ]
+                );
+                mockRoute = { current: { params: {} } };
+                mockLocation = jasmine.createSpyObj(
+                    "$location",
+                    [ "path" ]
                 );
                 mockObjectService = jasmine.createSpyObj(
                     "objectService",
@@ -75,21 +82,25 @@ define(
                 mockObjectService.getObjects.andReturn(mockPromise({
                     ROOT: mockRootObject
                 }));
-
+                mockRootObject.useCapability.andReturn(mockPromise([
+                    mockDomainObject
+                ]));
+                mockDomainObject.getId.andReturn("mine");
 
                 controller = new BrowseController(
                     mockScope,
+                    mockRoute,
+                    mockLocation,
                     mockObjectService,
                     mockNavigationService
                 );
             });
 
             it("uses composition to set the navigated object, if there is none", function () {
-                mockRootObject.useCapability.andReturn(mockPromise([
-                    mockDomainObject
-                ]));
                 controller = new BrowseController(
                     mockScope,
+                    mockRoute,
+                    mockLocation,
                     mockObjectService,
                     mockNavigationService
                 );
@@ -98,12 +109,11 @@ define(
             });
 
             it("does not try to override navigation", function () {
-                // This behavior is needed if object navigation has been
-                // determined by query string parameters
-                mockRootObject.useCapability.andReturn(mockPromise([null]));
                 mockNavigationService.getNavigation.andReturn(mockDomainObject);
                 controller = new BrowseController(
                     mockScope,
+                    mockRoute,
+                    mockLocation,
                     mockObjectService,
                     mockNavigationService
                 );

--- a/platform/commonUI/browse/test/BrowseControllerSpec.js
+++ b/platform/commonUI/browse/test/BrowseControllerSpec.js
@@ -37,6 +37,7 @@ define(
                 mockNavigationService,
                 mockRootObject,
                 mockDomainObject,
+                mockNextObject,
                 controller;
 
             function mockPromise(value) {
@@ -78,6 +79,10 @@ define(
                     "domainObject",
                     [ "getId", "getCapability", "getModel", "useCapability" ]
                 );
+                mockNextObject = jasmine.createSpyObj(
+                    "nextObject",
+                    [ "getId", "getCapability", "getModel", "useCapability" ]
+                );
 
                 mockObjectService.getObjects.andReturn(mockPromise({
                     ROOT: mockRootObject
@@ -85,6 +90,11 @@ define(
                 mockRootObject.useCapability.andReturn(mockPromise([
                     mockDomainObject
                 ]));
+                mockDomainObject.useCapability.andReturn(mockPromise([
+                    mockNextObject
+                ]));
+                mockNextObject.useCapability.andReturn(undefined);
+                mockNextObject.getId.andReturn("next");
                 mockDomainObject.getId.andReturn("mine");
 
                 controller = new BrowseController(
@@ -138,6 +148,76 @@ define(
                 expect(mockNavigationService.removeListener).toHaveBeenCalledWith(
                     mockNavigationService.addListener.mostRecentCall.args[0]
                 );
+            });
+
+            it("uses route parameters to choose initially-navigated object", function () {
+                mockRoute.current.params.ids = "mine/next";
+                controller = new BrowseController(
+                    mockScope,
+                    mockRoute,
+                    mockLocation,
+                    mockObjectService,
+                    mockNavigationService
+                );
+                expect(mockScope.navigatedObject).toBe(mockNextObject);
+                expect(mockNavigationService.setNavigation)
+                    .toHaveBeenCalledWith(mockNextObject);
+            });
+
+            it("handles invalid IDs by going as far as possible", function () {
+                // Idea here is that if we get a bad path of IDs,
+                // browse controller should traverse down it until
+                // it hits an invalid ID.
+                mockRoute.current.params.ids = "mine/junk";
+                controller = new BrowseController(
+                    mockScope,
+                    mockRoute,
+                    mockLocation,
+                    mockObjectService,
+                    mockNavigationService
+                );
+                expect(mockScope.navigatedObject).toBe(mockDomainObject);
+                expect(mockNavigationService.setNavigation)
+                    .toHaveBeenCalledWith(mockDomainObject);
+            });
+
+            it("handles compositionless objects by going as far as possible", function () {
+                // Idea here is that if we get a path which passes
+                // through an object without a composition, browse controller
+                // should stop at it since remaining IDs cannot be loaded.
+                mockRoute.current.params.ids = "mine/next/junk";
+                controller = new BrowseController(
+                    mockScope,
+                    mockRoute,
+                    mockLocation,
+                    mockObjectService,
+                    mockNavigationService
+                );
+                expect(mockScope.navigatedObject).toBe(mockNextObject);
+                expect(mockNavigationService.setNavigation)
+                    .toHaveBeenCalledWith(mockNextObject);
+            });
+
+            it("updates the displayed route to reflect current navigation", function () {
+                var mockContext = jasmine.createSpyObj('context', ['getPath']),
+                    mockUnlisten = jasmine.createSpy('unlisten');
+
+                mockContext.getPath.andReturn(
+                    [mockRootObject, mockDomainObject, mockNextObject]
+                );
+                mockNextObject.getCapability.andCallFake(function (c) {
+                    return c === 'context' && mockContext;
+                });
+                mockScope.$on.andReturn(mockUnlisten);
+                // Provide a navigation change
+                mockNavigationService.addListener.mostRecentCall.args[0](
+                    mockNextObject
+                );
+                expect(mockLocation.path).toHaveBeenCalledWith("/browse/mine/next");
+
+                // Exercise the Angular workaround
+                mockScope.$on.mostRecentCall.args[1]();
+                expect(mockUnlisten).toHaveBeenCalled();
             });
 
         });

--- a/platform/commonUI/browse/test/BrowseObjectControllerSpec.js
+++ b/platform/commonUI/browse/test/BrowseObjectControllerSpec.js
@@ -1,0 +1,99 @@
+/*****************************************************************************
+ * Open MCT Web, Copyright (c) 2014-2015, United States Government
+ * as represented by the Administrator of the National Aeronautics and Space
+ * Administration. All rights reserved.
+ *
+ * Open MCT Web is licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * Open MCT Web includes source code licensed under additional open source
+ * licenses. See the Open Source Licenses file (LICENSES.md) included with
+ * this source code distribution or the Licensing information page available
+ * at runtime from the About dialog for additional information.
+ *****************************************************************************/
+/*global define,Promise,describe,it,expect,beforeEach,waitsFor,jasmine*/
+
+
+define(
+    ["../src/BrowseObjectController"],
+    function (BrowseObjectController) {
+        "use strict";
+
+        describe("The browse object controller", function () {
+            var mockScope,
+                mockLocation,
+                mockRoute,
+                mockUnlisten,
+                controller;
+
+            // Utility function; look for a $watch on scope and fire it
+            function fireWatch(expr, value) {
+                mockScope.$watch.calls.forEach(function (call) {
+                    if (call.args[0] === expr) {
+                        call.args[1](value);
+                    }
+                });
+            }
+
+            beforeEach(function () {
+                mockScope = jasmine.createSpyObj(
+                    "$scope",
+                    [ "$on", "$watch" ]
+                );
+                mockRoute = { current: { params: {} } };
+                mockLocation = jasmine.createSpyObj(
+                    "$location",
+                    [ "path", "search" ]
+                );
+                mockUnlisten = jasmine.createSpy("unlisten");
+
+                mockScope.$on.andReturn(mockUnlisten);
+
+                controller = new BrowseObjectController(
+                    mockScope,
+                    mockLocation,
+                    mockRoute
+                );
+            });
+
+            it("updates query parameters when selected view changes", function () {
+                fireWatch("representation.selected.key", "xyz");
+                expect(mockLocation.search).toHaveBeenCalledWith('view', "xyz");
+
+                // Exercise the Angular workaround
+                mockScope.$on.mostRecentCall.args[1]();
+                expect(mockUnlisten).toHaveBeenCalled();
+            });
+
+            it("sets the active view from query parameters", function () {
+                var mockDomainObject = jasmine.createSpyObj(
+                        "domainObject",
+                        ['getId', 'getModel', 'getCapability', 'useCapability']
+                    ),
+                    testViews = [
+                        { key: 'abc' },
+                        { key: 'def', someKey: 'some value' },
+                        { key: 'xyz' }
+                    ];
+
+                mockDomainObject.useCapability.andCallFake(function (c) {
+                    return (c === 'view') && testViews;
+                });
+                mockLocation.search.andReturn({ view: 'def' });
+
+                fireWatch('domainObject', mockDomainObject);
+                expect(mockScope.representation.selected)
+                    .toEqual(testViews[1]);
+            });
+
+        });
+    }
+);

--- a/platform/commonUI/browse/test/suite.json
+++ b/platform/commonUI/browse/test/suite.json
@@ -1,5 +1,6 @@
 [
     "BrowseController",
+    "BrowseObjectController",
     "creation/CreateAction",
     "creation/CreateActionProvider",
     "creation/CreateMenuController",

--- a/platform/commonUI/general/src/controllers/ViewSwitcherController.js
+++ b/platform/commonUI/general/src/controllers/ViewSwitcherController.js
@@ -53,7 +53,7 @@ define(
 
             // Get list of views, read from capability
             function updateOptions(views) {
-                if (Array.isArray(views) && !($scope.ngModel || {}).selected) {
+                if (Array.isArray(views)) {
                     $timeout(function () {
                         $scope.ngModel.selected = findMatchingOption(
                             views,

--- a/platform/commonUI/general/src/controllers/ViewSwitcherController.js
+++ b/platform/commonUI/general/src/controllers/ViewSwitcherController.js
@@ -53,7 +53,7 @@ define(
 
             // Get list of views, read from capability
             function updateOptions(views) {
-                if (Array.isArray(views)) {
+                if (Array.isArray(views) && !($scope.ngModel || {}).selected) {
                     $timeout(function () {
                         $scope.ngModel.selected = findMatchingOption(
                             views,


### PR DESCRIPTION
Use and populate URL for domain objects. Specifically:

* In Browse mode, follow the path of IDs to determine initial navigation state.
* Also use "view" query string parameter to select the current view
* Update both of the above to reflect changes during use

1. Changes address original issue? Y
2. Unit tests included and/or updated with changes? Y
3. Command line build passes? Y
4. Expect to pass code review? Y
5. Project-specific information isolated to appropriate branches? Y