### PR TITLE
Issue11

### DIFF
--- a/platform/representation/src/gestures/DropGesture.js
+++ b/platform/representation/src/gestures/DropGesture.js
@@ -112,6 +112,7 @@ define(
                     // Informs user that drag and drop is not allowed.
                      // window.alert("Cannot drag and drop objects during browse mode.");
                 }
+                
             }
 
             // We can only handle drops if we have access to actions...

--- a/platform/representation/src/gestures/DropGesture.js
+++ b/platform/representation/src/gestures/DropGesture.js
@@ -110,9 +110,8 @@ define(
                     }
                 } else {
                     // Informs user that drag and drop is not allowed.
-                     // window.alert("Cannot drag and drop objects during browse mode.");
+                    window.alert("Cannot drag and drop objects during browse mode.");
                 }
-                
             }
 
             // We can only handle drops if we have access to actions...

--- a/platform/representation/src/gestures/DropGesture.js
+++ b/platform/representation/src/gestures/DropGesture.js
@@ -108,10 +108,11 @@ define(
                             broadcastDrop(id, event);
                         });
                     }
-                } else {
-                    // Informs user that drag and drop is not allowed.
-                    window.alert("Cannot drag and drop objects during browse mode.");
                 }
+//                else {
+//                    // Informs user that drag and drop is not allowed.
+//                    window.alert("Cannot drag and drop objects during browse mode.");
+//                }
             }
 
             // We can only handle drops if we have access to actions...

--- a/platform/representation/src/gestures/DropGesture.js
+++ b/platform/representation/src/gestures/DropGesture.js
@@ -109,10 +109,7 @@ define(
                         });
                     }
                 }
-//                else {
-//                    // Informs user that drag and drop is not allowed.
-//                    window.alert("Cannot drag and drop objects during browse mode.");
-//                }
+                // TODO: Alert user if drag and drop is not allowed
             }
 
             // We can only handle drops if we have access to actions...

--- a/platform/representation/src/gestures/DropGesture.js
+++ b/platform/representation/src/gestures/DropGesture.js
@@ -43,7 +43,7 @@ define(
         function DropGesture(dndService, $q, element, domainObject) {
             var actionCapability = domainObject.getCapability('action'),
                 action; // Action for the drop, when it occurs
-
+            
             function broadcastDrop(id, event) {
                 // Find the relevant scope...
                 var scope = element && element.scope && element.scope(),
@@ -92,17 +92,26 @@ define(
 
             function drop(e) {
                 var event = (e || {}).originalEvent || e,
-                    id = event.dataTransfer.getData(GestureConstants.MCT_DRAG_TYPE);
-
-                // Handle the drop; add the dropped identifier to the
-                // destination domain object's composition, and persist
-                // the change.
-                if (id) {
-                    $q.when(action && action.perform()).then(function (result) {
-                        broadcastDrop(id, event);
-                    });
+                    id = event.dataTransfer.getData(GestureConstants.MCT_DRAG_TYPE),
+                    domainObjectType = domainObject.getModel().type;
+                
+                // If currently in edit mode allow drag and drop gestures to the
+                // domain object. An exception to this is folders which have drop
+                // gestures in browse mode.
+                if (domainObjectType === 'folder' || domainObject.hasCapability('editor')) {
+                
+                    // Handle the drop; add the dropped identifier to the
+                    // destination domain object's composition, and persist
+                    // the change.
+                    if (id) {
+                        $q.when(action && action.perform()).then(function (result) {
+                            broadcastDrop(id, event);
+                        });
+                    }
+                } else {
+                    // Informs user that drag and drop is not allowed.
+                     // window.alert("Cannot drag and drop objects during browse mode.");
                 }
-
             }
 
             // We can only handle drops if we have access to actions...

--- a/platform/representation/test/gestures/DropGestureSpec.js
+++ b/platform/representation/test/gestures/DropGestureSpec.js
@@ -131,7 +131,8 @@ define(
                 expect(mockEvent.preventDefault).toHaveBeenCalled();
                 expect(mockEvent.dataTransfer.dropEffect).toBeDefined();
             });
-
+            
+/*
             it("invokes compose on drop in browse", function () {
                 callbacks.dragover(mockEvent);
                 expect(mockAction.getActions).toHaveBeenCalledWith({
@@ -145,6 +146,7 @@ define(
                     expect((mockCompose.perform)).toHaveBeenCalled();
 //                }
             });
+*/
             
 //            it("invokes compose on drop in edit", function () {
 //                callbacks.dragover(mockEvent);
@@ -158,9 +160,70 @@ define(
 //                    expect((mockCompose.perform)).toHaveBeenCalled();
 //                }
 //            });            
+            
+            it("invokes compose on drop in edit mode", function () {
+                // Set the mockDomainObject to have the editor capability
+                mockDomainObject.hasCapability.andReturn(true);
+                
+                callbacks.dragover(mockEvent);
+                expect(mockAction.getActions).toHaveBeenCalledWith({
+                    key: 'compose',
+                    selectedObject: mockDraggedObject
+                });
+                callbacks.drop(mockEvent);
+                expect(mockCompose.perform).toHaveBeenCalled();
+            });
+            
+            
+            it("does not invoke compose on drop in browse mode for non-folders", function () {
+                // Set the mockDomainObject to not have the editor capability
+                mockDomainObject.hasCapability.andReturn(false);
+                // Set the mockDomainObject to not have a type of folder
+                mockDomainObject.getModel.andReturn({type: 'notAFolder'});
+                
+                callbacks.dragover(mockEvent);
+                expect(mockAction.getActions).toHaveBeenCalledWith({
+                    key: 'compose',
+                    selectedObject: mockDraggedObject
+                });
+                callbacks.drop(mockEvent);
+                expect(mockCompose.perform).not.toHaveBeenCalled();
+            });
+            
+            
+            it("invokes compose on drop in browse mode for folders", function () {
+                // Set the mockDomainObject to not have the editor capability
+                mockDomainObject.hasCapability.andReturn(false);
+                // Set the mockDomainObject to have a type of folder
+                mockDomainObject.getModel.andReturn({type: 'folder'});
 
+                callbacks.dragover(mockEvent);
+                expect(mockAction.getActions).toHaveBeenCalledWith({
+                    key: 'compose',
+                    selectedObject: mockDraggedObject
+                });
+                callbacks.drop(mockEvent);
+                expect(mockCompose.perform).toHaveBeenCalled();
+            });
+            
+            /*
+            it("does not invoke compose on drop in browse mode for non-folders", function () {
+                if (mockDomainObject.hasCapability('editor') === false && !(domainObject.getModel().type === 'folder')) {
+                    callbacks.dragover(mockEvent);
+                    expect(mockAction.getActions).toHaveBeenCalledWith({
+                        key: 'compose',
+                        selectedObject: mockDraggedObject
+                    });
+                    callbacks.drop(mockEvent);
+                    expect(mockCompose.perform).not.toHaveBeenCalled();
+                }
+            });
+            */
 
-            it("broadcasts drop position", function () {
+            it("broadcasts drop position (in edit mode)", function () {
+                // Set the mockDomainObject to have the editor capability
+                mockDomainObject.hasCapability.andReturn(true);
+                
                 testRect.left = 42;
                 testRect.top = 36;
                 mockEvent.pageX = 52;

--- a/platform/representation/test/gestures/DropGestureSpec.js
+++ b/platform/representation/test/gestures/DropGestureSpec.js
@@ -132,35 +132,6 @@ define(
                 expect(mockEvent.dataTransfer.dropEffect).toBeDefined();
             });
             
-/*
-            it("invokes compose on drop in browse", function () {
-                callbacks.dragover(mockEvent);
-                expect(mockAction.getActions).toHaveBeenCalledWith({
-                    key: 'compose',
-                    selectedObject: mockDraggedObject
-                });
-                callbacks.drop(mockEvent);
-                mockDomainObject.useCapability('browse');
-                var mockDomainObjectType = mockDomainObject.getModel().type;
-//                if (mockDomainObjectType === 'folder' || mockDomainObject.hasCapability('editor') {
-                    expect((mockCompose.perform)).toHaveBeenCalled();
-//                }
-            });
-*/
-            
-//            it("invokes compose on drop in edit", function () {
-//                callbacks.dragover(mockEvent);
-//                expect(mockAction.getActions).toHaveBeenCalledWith({
-//                    key: 'compose',
-//                    selectedObject: mockDraggedObject
-//                });
-//                callbacks.drop(mockEvent);
-//                mockDomainObject.useCapability('editor');
-//                if (mockDomainObjectType === 'folder' || mockDomainObject.hasCapability('editor') {
-//                    expect((mockCompose.perform)).toHaveBeenCalled();
-//                }
-//            });            
-            
             it("invokes compose on drop in edit mode", function () {
                 // Set the mockDomainObject to have the editor capability
                 mockDomainObject.hasCapability.andReturn(true);
@@ -206,20 +177,6 @@ define(
                 expect(mockCompose.perform).toHaveBeenCalled();
             });
             
-            /*
-            it("does not invoke compose on drop in browse mode for non-folders", function () {
-                if (mockDomainObject.hasCapability('editor') === false && !(domainObject.getModel().type === 'folder')) {
-                    callbacks.dragover(mockEvent);
-                    expect(mockAction.getActions).toHaveBeenCalledWith({
-                        key: 'compose',
-                        selectedObject: mockDraggedObject
-                    });
-                    callbacks.drop(mockEvent);
-                    expect(mockCompose.perform).not.toHaveBeenCalled();
-                }
-            });
-            */
-
             it("broadcasts drop position (in edit mode)", function () {
                 // Set the mockDomainObject to have the editor capability
                 mockDomainObject.hasCapability.andReturn(true);

--- a/platform/representation/test/gestures/DropGestureSpec.js
+++ b/platform/representation/test/gestures/DropGestureSpec.js
@@ -132,15 +132,32 @@ define(
                 expect(mockEvent.dataTransfer.dropEffect).toBeDefined();
             });
 
-            it("invokes compose on drop", function () {
+            it("invokes compose on drop in browse", function () {
                 callbacks.dragover(mockEvent);
                 expect(mockAction.getActions).toHaveBeenCalledWith({
                     key: 'compose',
                     selectedObject: mockDraggedObject
                 });
                 callbacks.drop(mockEvent);
-                expect(mockCompose.perform).toHaveBeenCalled();
+                mockDomainObject.useCapability('browse');
+                var mockDomainObjectType = mockDomainObject.getModel().type;
+//                if (mockDomainObjectType === 'folder' || mockDomainObject.hasCapability('editor') {
+                    expect((mockCompose.perform)).toHaveBeenCalled();
+//                }
             });
+            
+//            it("invokes compose on drop in edit", function () {
+//                callbacks.dragover(mockEvent);
+//                expect(mockAction.getActions).toHaveBeenCalledWith({
+//                    key: 'compose',
+//                    selectedObject: mockDraggedObject
+//                });
+//                callbacks.drop(mockEvent);
+//                mockDomainObject.useCapability('editor');
+//                if (mockDomainObjectType === 'folder' || mockDomainObject.hasCapability('editor') {
+//                    expect((mockCompose.perform)).toHaveBeenCalled();
+//                }
+//            });            
 
 
             it("broadcasts drop position", function () {


### PR DESCRIPTION
Drag and drop composition during different modes

Summary of changes:
* Disallowed drag and drop during browse mode for non-folders
* Allowed drag and drop during edit mode
* Currently does not explicitly alert user when a drag and drop is not allowed

1. Changes address original issue? Y
2. Unit tests included and/or updated with changes? Y
3. Command line build passes? Y
4. Expect to pass code review? Y
5. Project-specific information isolated to appropriate branches? Y