### PR TITLE
[Common UI] Reduce digest count

### DIFF
--- a/platform/commonUI/general/src/directives/MCTResize.js
+++ b/platform/commonUI/general/src/directives/MCTResize.js
@@ -73,6 +73,7 @@ define(
                             lastBounds.width !== bounds.width ||
                             lastBounds.height !== bounds.height) {
                         scope.$eval(attrs.mctResize, { bounds: bounds });
+                        scope.$apply(); // Trigger a digest
                         lastBounds = bounds;
                     }
                 }
@@ -85,7 +86,7 @@ define(
                         height: element[0].offsetHeight
                     });
                     if (active) {
-                        $timeout(onInterval, currentInterval());
+                        $timeout(onInterval, currentInterval(), false);
                     }
                 }
 


### PR DESCRIPTION
Reduce number of digest cycles triggered by mct-resize;
only trigger a new digest cycle when size actually
changes. #19.

1. Changes address original issue? Y 
2. Unit tests included and/or updated with changes? Y
3. Command line build passes? Y
4. Expect to pass code review? Y
5. Project-specific information isolated to appropriate branches? Y