### PR TITLE
[Development] Reload bundle file with each request

### DIFF
--- a/app.js
+++ b/app.js
@@ -14,8 +14,7 @@
         options = require('minimist')(process.argv.slice(2)),
         express = require('express'),
         app = express(),
-        fs = require('fs'),
-        bundles = JSON.parse(fs.readFileSync(BUNDLE_FILE, 'utf8'));
+        fs = require('fs');
 
     // Defaults
     options.port = options.port || options.p || 8080;
@@ -40,17 +39,19 @@
         process.exit(0);
     }
 
-    // Handle command line inclusions/exclusions
-    bundles = bundles.concat(options.include);
-    bundles = bundles.filter(function (bundle) {
-        return options.exclude.indexOf(bundle) === -1;
-    });
-    bundles = bundles.filter(function (bundle, index) { // Uniquify
-        return bundles.indexOf(bundle) === index;
-    });
-
     // Override bundles.json for HTTP requests
     app.use('/' + BUNDLE_FILE, function (req, res) {
+        var bundles = JSON.parse(fs.readFileSync(BUNDLE_FILE, 'utf8'));
+
+        // Handle command line inclusions/exclusions
+        bundles = bundles.concat(options.include);
+        bundles = bundles.filter(function (bundle) {
+            return options.exclude.indexOf(bundle) === -1;
+        });
+        bundles = bundles.filter(function (bundle, index) { // Uniquify
+            return bundles.indexOf(bundle) === index;
+        });
+
         res.send(JSON.stringify(bundles));
     });
 


### PR DESCRIPTION
Reload the bundle file from disk when requested, re-applying any
includes or excludes that were specified on the command line.

Allows a developer to make changes to bundles.json without having to
restart the server for them to take effect.

