### PR TITLE
[Edit] No more useless tooltips

### DIFF
--- a/platform/commonUI/edit/res/templates/edit-object.html
+++ b/platform/commonUI/edit/res/templates/edit-object.html
@@ -65,7 +65,7 @@
                     ng-style="{ bottom: (hSplitter.state()+8) + 'px', top: '0px' }"
                     ng-controller="ToggleController as toggle"
                     >
-                    <mct-container key="accordion" title="Library">
+                    <mct-container key="accordion" label="Library">
                         <mct-representation key="'tree'"
                                             alias="foo1"
                                             mct-object="editPanes.getRoot()">
@@ -85,7 +85,7 @@
                     ng-style="{ bottom: '0px', height: (hSplitter.state()-4) + 'px'}"
                     ng-controller="ToggleController as toggle"
                     >
-                    <mct-container key="accordion" title="Elements">
+                    <mct-container key="accordion" label="Elements">
                         <mct-representation key="'edit-elements'" mct-object="domainObject">
                         </mct-representation>
                     </mct-container>

--- a/platform/commonUI/general/bundle.json
+++ b/platform/commonUI/general/bundle.json
@@ -164,7 +164,7 @@
             {
                 "key": "accordion",
                 "templateUrl": "templates/containers/accordion.html",
-                "attributes": [ "title" ]
+                "attributes": [ "label" ]
             }
         ],
         "representations": [

--- a/platform/commonUI/general/res/templates/containers/accordion.html
+++ b/platform/commonUI/general/res/templates/containers/accordion.html
@@ -20,7 +20,7 @@
  at runtime from the About dialog for additional information.
 -->
 <div class="accordion-head" ng-click="toggle.toggle()">
-    {{container.title}}
+    {{container.label}}
 </div>
 <div class="accordion-contents"
      ng-show="!toggle.isActive()"


### PR DESCRIPTION
Changed the attribute of 'title' on mct-container to 'label'. This made the tooltips over the Library and Element panes in Edit mode disappear. #46.

1. Changes address original issue? Y
2. Unit tests included and/or updated with changes? Y
3. Command line build passes? Y
4. Expect to pass code review? Y
5. Project-specific information isolated to appropriate branches? Y