### PR TITLE
Continuous deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,4 +19,3 @@ closed-lib
 
 # Node dependencies
 node_modules
-

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ closed-lib
 
 # Node dependencies
 node_modules
+
+# Build documentation
+docs

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: node app.js --port $PORT

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: node app.js --port $PORT
+web: node app.js --port $PORT --include example/localstorage

--- a/build-docs.sh
+++ b/build-docs.sh
@@ -2,11 +2,11 @@
 
 # Script to build and deploy docs to github pages.
 
-# Any Content currently visible on the website will be replaced by 
+# Any Content currently visible on the website will be replaced by
 # this process.
 
 OUTPUT_DIRECTORY="docs"
-REPOSITORY_URL="git@github.com:larkin/openmctweb.git"
+REPOSITORY_URL="git@github.com:nasa/openmctweb.git"
 
 BUILD_SHA=`git rev-parse head`
 

--- a/build-docs.sh
+++ b/build-docs.sh
@@ -1,9 +1,28 @@
 #!/bin/bash
 
-# Script to build and deploy docs to github pages.
+#*****************************************************************************
+#* Open MCT Web, Copyright (c) 2014-2015, United States Government
+#* as represented by the Administrator of the National Aeronautics and Space
+#* Administration. All rights reserved.
+#*
+#* Open MCT Web is licensed under the Apache License, Version 2.0 (the
+#* "License"); you may not use this file except in compliance with the License.
+#* You may obtain a copy of the License at
+#* http://www.apache.org/licenses/LICENSE-2.0.
+#*
+#* Unless required by applicable law or agreed to in writing, software
+#* distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#* WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#* License for the specific language governing permissions and limitations
+#* under the License.
+#*
+#* Open MCT Web includes source code licensed under additional open source
+#* licenses. See the Open Source Licenses file (LICENSES.md) included with
+#* this source code distribution or the Licensing information page available
+#* at runtime from the About dialog for additional information.
+#*****************************************************************************
 
-# Any Content currently visible on the website will be replaced by
-# this process.
+# Script to build and deploy docs to github pages.
 
 OUTPUT_DIRECTORY="docs"
 REPOSITORY_URL="git@github.com:nasa/openmctweb.git"
@@ -11,7 +30,7 @@ REPOSITORY_URL="git@github.com:nasa/openmctweb.git"
 BUILD_SHA=`git rev-parse head`
 
 # A remote will be created for the git repository we are pushing to.
-# Don't change the name.
+# Don't worry, as this entire directory will get trashed inbetween builds.
 REMOTE_NAME="documentation"
 WEBSITE_BRANCH="gh-pages"
 
@@ -19,7 +38,7 @@ WEBSITE_BRANCH="gh-pages"
 git config user.email "buildbot@circleci.com"
 git config user.name "BuildBot"
 
-# clean output directory
+# Clean output directory, JSDOC will recreate
 if [ -d $OUTPUT_DIRECTORY ]; then
     rm -rf $OUTPUT_DIRECTORY || exit 1
 fi

--- a/build-docs.sh
+++ b/build-docs.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+# Script to build and deploy docs to github pages.
+
+# Any Content currently visible on the website will be replaced by 
+# this process.
+
+OUTPUT_DIRECTORY="docs"
+REPOSITORY_URL="git@github.com:larkin/openmctweb.git"
+
+BUILD_SHA=`git rev-parse head`
+
+# A remote will be created for the git repository we are pushing to.
+# Don't change the name.
+REMOTE_NAME="documentation"
+WEBSITE_BRANCH="gh-pages"
+
+# Configure github for CircleCI user.
+git config --global user.email "buildbot@circleci.com"
+git config --global user.name "BuildBot"
+
+# clean output directory
+if [ -d $OUTPUT_DIRECTORY ]; then
+    rm -rf $OUTPUT_DIRECTORY || exit 1
+fi
+
+npm run-script jsdoc
+cd $OUTPUT_DIRECTORY || exit 1
+
+echo "git init"
+git init
+echo "git remote add $REMOTE_NAME $REPOSITORY_URL"
+git remote add $REMOTE_NAME $REPOSITORY_URL
+echo "git add ."
+git add .
+echo "git commit -m \"Generate docs from build $BUILD_SHA\""
+git commit -m "Generate docs from build $BUILD_SHA"
+
+echo "git push $REMOTE_NAME HEAD:$WEBSITE_BRANCH -f"
+git push $REMOTE_NAME HEAD:$WEBSITE_BRANCH -f
+
+echo "Documentation pushed gh-pages branch."

--- a/build-docs.sh
+++ b/build-docs.sh
@@ -16,8 +16,8 @@ REMOTE_NAME="documentation"
 WEBSITE_BRANCH="gh-pages"
 
 # Configure github for CircleCI user.
-git config --global user.email "buildbot@circleci.com"
-git config --global user.name "BuildBot"
+git config user.email "buildbot@circleci.com"
+git config user.name "BuildBot"
 
 # clean output directory
 if [ -d $OUTPUT_DIRECTORY ]; then
@@ -39,4 +39,4 @@ git commit -m "Generate docs from build $BUILD_SHA"
 echo "git push $REMOTE_NAME HEAD:$WEBSITE_BRANCH -f"
 git push $REMOTE_NAME HEAD:$WEBSITE_BRANCH -f
 
-echo "Documentation pushed gh-pages branch."
+echo "Documentation pushed to gh-pages branch."

--- a/build-docs.sh
+++ b/build-docs.sh
@@ -34,10 +34,6 @@ BUILD_SHA=`git rev-parse head`
 REMOTE_NAME="documentation"
 WEBSITE_BRANCH="gh-pages"
 
-# Configure github for CircleCI user.
-git config user.email "buildbot@circleci.com"
-git config user.name "BuildBot"
-
 # Clean output directory, JSDOC will recreate
 if [ -d $OUTPUT_DIRECTORY ]; then
     rm -rf $OUTPUT_DIRECTORY || exit 1
@@ -48,6 +44,11 @@ cd $OUTPUT_DIRECTORY || exit 1
 
 echo "git init"
 git init
+
+# Configure github for CircleCI user.
+git config user.email "buildbot@circleci.com"
+git config user.name "BuildBot"
+
 echo "git remote add $REMOTE_NAME $REPOSITORY_URL"
 git remote add $REMOTE_NAME $REPOSITORY_URL
 echo "git add ."

--- a/bundles.json
+++ b/bundles.json
@@ -20,6 +20,7 @@
     "platform/forms",
     "platform/persistence/queue",
     "platform/policy",
+    "platform/entanglement",
 
     "example/imagery",
     "example/persistence",

--- a/circle.yml
+++ b/circle.yml
@@ -3,3 +3,4 @@ deployment:
     branch: continuous-deployment
     commands:
       - ./build-docs.sh
+      - git push git@heroku.com:openmctweb-demo.git $CIRCLE_SHA1:refs/heads/master

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,5 @@
+deployment:
+  production:
+    branch: continuous-deployment
+    commands:
+      - ./build-docs.sh

--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,6 @@
 deployment:
   production:
-    branch: continuous-deployment
+    branch: master
     commands:
       - ./build-docs.sh
       - git push git@heroku.com:openmctweb-demo.git $CIRCLE_SHA1:refs/heads/master

--- a/example/localstorage/bundle.json
+++ b/example/localstorage/bundle.json
@@ -1,0 +1,18 @@
+{
+    "extensions": {
+        "components": [
+            {
+                "provides": "persistenceService",
+                "type": "provider",
+                "implementation": "LocalStoragePersistenceProvider.js",
+                "depends": [ "$q", "PERSISTENCE_SPACE" ]
+            }
+        ],
+        "constants": [
+            {
+                "key": "PERSISTENCE_SPACE",
+                "value": "mct"
+            }
+        ]
+    }
+}

--- a/example/localstorage/src/LocalStoragePersistenceProvider.js
+++ b/example/localstorage/src/LocalStoragePersistenceProvider.js
@@ -1,3 +1,4 @@
+/*global define,localStorage*/
 /**
  * Stubbed implementation of a persistence provider,
  * to permit objects to be created, saved, etc.
@@ -13,20 +14,21 @@ define(
                     as: function (value) {
                         return $q.when(value);
                     }
-                };
+                },
+                provider;
 
-            var setValue = function(key, value) {
+            function setValue(key, value) {
                 localStorage[key] = JSON.stringify(value);
-            };
+            }
 
-            var getValue = function(key) {
+            function getValue(key) {
                 if (localStorage[key]) {
                     return JSON.parse(localStorage[key]);
                 }
                 return {};
-            };
+            }
 
-            var provider = {
+            provider = {
                 listSpaces: function () {
                     return promises.as(spaces);
                 },

--- a/example/localstorage/src/LocalStoragePersistenceProvider.js
+++ b/example/localstorage/src/LocalStoragePersistenceProvider.js
@@ -1,3 +1,25 @@
+/*****************************************************************************
+ * Open MCT Web, Copyright (c) 2014-2015, United States Government
+ * as represented by the Administrator of the National Aeronautics and Space
+ * Administration. All rights reserved.
+ *
+ * Open MCT Web is licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * Open MCT Web includes source code licensed under additional open source
+ * licenses. See the Open Source Licenses file (LICENSES.md) included with
+ * this source code distribution or the Licensing information page available
+ * at runtime from the About dialog for additional information.
+ *****************************************************************************/
+
 /*global define,localStorage*/
 /**
  * Stubbed implementation of a persistence provider,

--- a/example/localstorage/src/LocalStoragePersistenceProvider.js
+++ b/example/localstorage/src/LocalStoragePersistenceProvider.js
@@ -1,0 +1,62 @@
+/**
+ * Stubbed implementation of a persistence provider,
+ * to permit objects to be created, saved, etc.
+ */
+define(
+    [],
+    function () {
+        'use strict';
+
+        function BrowserPersistenceProvider($q, SPACE) {
+            var spaces = SPACE ? [SPACE] : [],
+                promises = {
+                    as: function (value) {
+                        return $q.when(value);
+                    }
+                };
+
+            var setValue = function(key, value) {
+                localStorage[key] = JSON.stringify(value);
+            };
+
+            var getValue = function(key) {
+                if (localStorage[key]) {
+                    return JSON.parse(localStorage[key]);
+                }
+                return {};
+            };
+
+            var provider = {
+                listSpaces: function () {
+                    return promises.as(spaces);
+                },
+                listObjects: function (space) {
+                    var space_obj = getValue(space);
+                    return promises.as(Object.keys(space_obj));
+                },
+                createObject: function (space, key, value) {
+                    var space_obj = getValue(space);
+                    space_obj[key] = value;
+                    setValue(space, space_obj);
+                    return promises.as(true);
+                },
+                readObject: function (space, key) {
+                    var space_obj = getValue(space);
+                    return promises.as(space_obj[key]);
+                },
+                deleteObject: function (space, key, value) {
+                    var space_obj = getValue(space);
+                    delete space_obj[key];
+                    return promises.as(true);
+                }
+            };
+
+            provider.updateObject = provider.createObject;
+
+            return provider;
+
+        }
+
+        return BrowserPersistenceProvider;
+    }
+);

--- a/jsdoc.json
+++ b/jsdoc.json
@@ -1,0 +1,10 @@
+{
+    "source": {
+        "include": [
+            "example/",
+            "platform/"
+        ],
+        "includePattern": "(example|platform)/.+\\.js$",
+        "excludePattern": ".+\\Spec\\.js$|lib/.+"
+    }
+}

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,3 +1,25 @@
+/*****************************************************************************
+ * Open MCT Web, Copyright (c) 2014-2015, United States Government
+ * as represented by the Administrator of the National Aeronautics and Space
+ * Administration. All rights reserved.
+ *
+ * Open MCT Web is licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * Open MCT Web includes source code licensed under additional open source
+ * licenses. See the Open Source Licenses file (LICENSES.md) included with
+ * this source code distribution or the Licensing information page available
+ * at runtime from the About dialog for additional information.
+ *****************************************************************************/
+
 /*global module*/
 module.exports = function(config) {
     config.set({

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,3 +1,4 @@
+/*global module*/
 module.exports = function(config) {
     config.set({
 

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,0 +1,56 @@
+module.exports = function(config) {
+    config.set({
+
+        // Base path that will be used to resolve all file patterns.
+        basePath: '',
+
+        // Frameworks to use
+        // Available frameworks: https://npmjs.org/browse/keyword/karma-adapter
+        frameworks: ['jasmine', 'requirejs'],
+
+        // List of files / patterns to load in the browser.
+        // By default, files are also included in a script tag.
+        files: [
+            '**/moment*',
+            {pattern: 'example/**/*.js', included: false},
+            {pattern: 'platform/**/*.js', included: false},
+            {pattern: 'warp/**/*.js', included: false},
+            'test-main.js'
+        ],
+
+        // List of files to exclude.
+        exclude: [
+            'platform/framework/src/Main.js'
+        ],
+
+        // Preprocess matching files before serving them to the browser.
+        // https://npmjs.org/browse/keyword/karma-preprocessor
+        preprocessors: {},
+
+        // Test results reporter to use
+        // Possible values: 'dots', 'progress'
+        // Available reporters: https://npmjs.org/browse/keyword/karma-reporter
+        reporters: ['progress'],
+
+        // Web server port.
+        port: 9876,
+
+        // Wnable / disable colors in the output (reporters and logs).
+        colors: true,
+
+        logLevel: config.LOG_INFO,
+
+        // Rerun tests when any file changes.
+        autoWatch: true,
+
+        // Specify browsers to run tests in.
+        // available browser launchers: https://npmjs.org/browse/keyword/karma-launcher
+        browsers: [
+            'Chrome'
+        ],
+
+        // Continuous Integration mode.
+        // If true, Karma captures browsers, runs the tests and exits.
+        singleRun: false
+    });
+};

--- a/package.json
+++ b/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "open-mct-web",
+  "version": "0.7.2",
+  "description": "The OpenMCTWeb core platform",
+  "dependencies": {
+    "express": "^4.13.1",
+    "minimist": "^1.1.1"
+  },
+  "devDependencies": {
+    "jasmine-core": "^2.3.0",
+    "jsdoc": "^3.3.2",
+    "jshint": "^2.7.0",
+    "karma": "^0.12.31",
+    "karma-chrome-launcher": "^0.1.8",
+    "karma-cli": "0.0.4",
+    "karma-jasmine": "^0.1.5",
+    "karma-phantomjs-launcher": "^0.1.4",
+    "karma-requirejs": "^0.2.2",
+    "requirejs": "^2.1.17"
+  },
+  "scripts": {
+    "start": "node app.js",
+    "test": "karma start --single-run",
+    "jshint": "jshint platform example || exit 0",
+    "jsdoc": "jsdoc -c jsdoc.json -r -d docs"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/nasa/openmctweb.git"
+  },
+  "author": "",
+  "license": "Apache-2.0"
+}

--- a/platform/core/src/objects/DomainObject.js
+++ b/platform/core/src/objects/DomainObject.js
@@ -35,7 +35,7 @@ define(
          *
          * @param {string} id the object's unique identifier
          * @param {object} model the "JSONifiable" state of the object
-         * @param {Object.<string, Capability|function} capabilities all
+         * @param {Object.<string, Capability>|function} capabilities all
          *        capabilities to be exposed by this object
          * @constructor
          */

--- a/platform/framework/src/resolve/BundleResolver.js
+++ b/platform/framework/src/resolve/BundleResolver.js
@@ -45,7 +45,7 @@ define(
              * into one large object containing resolved extensions from
              * all bundles (in the same form.)
              *
-             * @param {Object.<string, object[]>[]} resolvedBundles
+             * @param {Object.<string, object[]>|Array} resolvedBundles
              * @returns {Object.<string, object[]>}
              */
             function mergeResolvedBundles(resolvedBundles) {

--- a/test-main.js
+++ b/test-main.js
@@ -1,0 +1,40 @@
+var allTestFiles = [];
+var TEST_REGEXP = /(Spec)\.js$/;
+
+var pathToModule = function(path) {
+    return path.replace(/^\/base\//, '').replace(/\.js$/, '');
+};
+
+Object.keys(window.__karma__.files).forEach(function(file) {
+    if (TEST_REGEXP.test(file)) {
+        // Normalize paths to RequireJS module names.
+        allTestFiles.push(pathToModule(file));
+    }
+});
+
+// We will be handling es6-promise loading with a shim.
+allTestFiles.unshift('es6-promise');
+
+require.config({
+    // Karma serves files from the basePath defined in karma.conf.js
+    baseUrl: '/base',
+
+    paths: {
+        'es6-promise': 'platform/framework/lib/es6-promise-2.0.0.min',
+        'moment-duration-format': 'warp/clock/lib/moment-duration-format'
+    },
+    shim: {
+        'es6-promise': {
+            init: function () {
+                console.log('I was inited!');
+                window.Promise = window.Promise || ES6Promise.Promise;
+            }
+        }
+    },
+
+    // dynamically load all test files
+    deps: allTestFiles,
+
+    // we have to kickoff jasmine, as it is asynchronous
+    callback: window.__karma__.start
+});

--- a/test-main.js
+++ b/test-main.js
@@ -1,3 +1,25 @@
+/*****************************************************************************
+ * Open MCT Web, Copyright (c) 2014-2015, United States Government
+ * as represented by the Administrator of the National Aeronautics and Space
+ * Administration. All rights reserved.
+ *
+ * Open MCT Web is licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * Open MCT Web includes source code licensed under additional open source
+ * licenses. See the Open Source Licenses file (LICENSES.md) included with
+ * this source code distribution or the Licensing information page available
+ * at runtime from the About dialog for additional information.
+ *****************************************************************************/
+
 /*global require,window*/
 var allTestFiles = [];
 var TEST_REGEXP = /(Spec)\.js$/;

--- a/test-main.js
+++ b/test-main.js
@@ -1,3 +1,4 @@
+/*global require,window*/
 var allTestFiles = [];
 var TEST_REGEXP = /(Spec)\.js$/;
 
@@ -12,7 +13,7 @@ Object.keys(window.__karma__.files).forEach(function(file) {
     }
 });
 
-// We will be handling es6-promise loading with a shim.
+// Force es6-promise to load.
 allTestFiles.unshift('es6-promise');
 
 require.config({
@@ -22,14 +23,6 @@ require.config({
     paths: {
         'es6-promise': 'platform/framework/lib/es6-promise-2.0.0.min',
         'moment-duration-format': 'warp/clock/lib/moment-duration-format'
-    },
-    shim: {
-        'es6-promise': {
-            init: function () {
-                console.log('I was inited!');
-                window.Promise = window.Promise || ES6Promise.Promise;
-            }
-        }
     },
 
     // dynamically load all test files


### PR DESCRIPTION
Adds continuous integration provided by CircleCI.  On a successful test run, JSDoc is executed and docs are published to http://nasa.github.io/openmctweb/.  A demo version of the app is also deployed to https://openmctweb-demo.herokuapp.com/.

Also adds a npm package file which serves as a task runner.
`npm install` will install all node dependencies.
`npm start` will start a local development server.
`npm test` will run all tests.
`npm run-script jshint` will run jshint (different than jslint) against all files.
`npm run-script jsdoc` will generate JSDoc for project.

Also adds a basic LocalStoragePersistenceProvider so that demo data is persisted.

Currently, the documentation exported by JSDoc is of little value, I will open a follow-up task for reformatting code so that JSDoc works properly.