### PR TITLE
[Template] Move ng-click to parent node

### DIFF
--- a/platform/commonUI/browse/res/templates/create/create-menu.html
+++ b/platform/commonUI/browse/res/templates/create/create-menu.html
@@ -23,9 +23,8 @@
     <div class="pane left menu-items">
         <ul>
 
-            <li ng-repeat="createAction in createActions">
+            <li ng-repeat="createAction in createActions" ng-click="createAction.perform()">
                 <a
-                   ng-click="createAction.perform()"
                    ng-mouseover="representation.activeMetadata = createAction.getMetadata()"
                    ng-mouseleave="representation.activeMetadata = undefined">
                     <span class="ui-symbol icon type-icon">


### PR DESCRIPTION
Move the ng-click directive to the li element to match the element that receives hover styles.

Fixes nasa/openmctweb#60.

# Author Checklist
Changes address original issue? Y
Unit tests included and/or updated with changes? N/A
Command line build passes? Y
Expect to pass code review? Y
Project-specific information isolated to appropriate branches? Y
