### PR TITLE
[Build] Start the WAR in an embedded Tomcat Servlet Container

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -176,6 +176,17 @@
                 </executions>
             </plugin>
 
+            <!-- To start this WAR in an embedded Tomcat Servlet Container -->
+            <plugin>
+                <groupId>org.apache.tomcat.maven</groupId>
+                <artifactId>tomcat7-maven-plugin</artifactId>
+                <version>2.2</version>
+                <configuration>
+                    <httpPort>8080</httpPort>
+                    <path>/mct</path>
+                </configuration>
+            </plugin>
+
         </plugins>
     </build>
 


### PR DESCRIPTION
Added tomcat7-maven-plugin config to deploy the WAR to an embedded Tomat 7 container:

```shell
$ mvn tomcat7:run-war
```

This can streamline deplyment untill you start using Gulp or Grunt to serve the app one day ;)