### PR TITLE
[Menus] Dismiss menus when clicked

### DIFF
--- a/platform/representation/src/actions/ContextMenuAction.js
+++ b/platform/representation/src/actions/ContextMenuAction.js
@@ -31,7 +31,6 @@ define(
 
         var MENU_TEMPLATE = "<mct-representation key=\"'context-menu'\" " +
                 "mct-object=\"domainObject\" " +
-                "ng-click=\"dismiss()\" " +
                 "ng-class=\"menuClass\" " +
                 "ng-style=\"menuStyle\">" +
                 "</mct-representation>",
@@ -87,7 +86,6 @@ define(
                     "go-up": goUp,
                     "context-menu-holder": true
                 };
-                scope.dismiss = dismiss;
 
                 // Create the context menu
                 menu = $compile(MENU_TEMPLATE)(scope);
@@ -103,6 +101,7 @@ define(
                 // Dismiss the menu when body is clicked elsewhere
                 // ('mousedown' because 'click' breaks left-click context menus)
                 body.on('mousedown', dismiss);
+                menu.on('click', dismiss);
 
                 // Don't launch browser's context menu
                 actionContext.event.preventDefault();

--- a/platform/representation/src/actions/ContextMenuAction.js
+++ b/platform/representation/src/actions/ContextMenuAction.js
@@ -31,7 +31,8 @@ define(
 
         var MENU_TEMPLATE = "<mct-representation key=\"'context-menu'\" " +
                 "mct-object=\"domainObject\" " +
-                "ng-class=\"menuClass\"" +
+                "ng-click=\"dismiss()\" " +
+                "ng-class=\"menuClass\" " +
                 "ng-style=\"menuStyle\">" +
                 "</mct-representation>",
             dismissExistingMenu;
@@ -48,7 +49,7 @@ define(
          *                      should be performed
          */
         function ContextMenuAction($compile, $document, $window, $rootScope, actionContext) {
-            
+
             function perform() {
                 var winDim = [$window.innerWidth, $window.innerHeight],
                     eventCoors = [actionContext.event.pageX, actionContext.event.pageY],
@@ -62,7 +63,7 @@ define(
                 // Remove the context menu
                 function dismiss() {
                     menu.remove();
-                    body.off("click", dismiss);
+                    body.off("mousedown", dismiss);
                     dismissExistingMenu = undefined;
                 }
 
@@ -86,18 +87,19 @@ define(
                     "go-up": goUp,
                     "context-menu-holder": true
                 };
+                scope.dismiss = dismiss;
 
                 // Create the context menu
                 menu = $compile(MENU_TEMPLATE)(scope);
 
                 // Add the menu to the body
                 body.append(menu);
-                
+
                 // Stop propagation so that clicks on the menu do not close the menu
                 menu.on('mousedown', function (event) {
                     event.stopPropagation();
                 });
-                
+
                 // Dismiss the menu when body is clicked elsewhere
                 // ('mousedown' because 'click' breaks left-click context menus)
                 body.on('mousedown', dismiss);
@@ -105,7 +107,7 @@ define(
                 // Don't launch browser's context menu
                 actionContext.event.preventDefault();
             }
-            
+
             return {
                 perform: perform
             };

--- a/platform/representation/test/actions/ContextMenuActionSpec.js
+++ b/platform/representation/test/actions/ContextMenuActionSpec.js
@@ -69,7 +69,7 @@ define(
                 mockCompiledTemplate.andReturn(mockMenu);
                 mockDocument.find.andReturn(mockBody);
                 mockRootScope.$new.andReturn(mockScope);
-                
+
                 mockActionContext = {key: 'menu', domainObject: mockDomainObject, event: mockEvent};
 
                 action = new ContextMenuAction(
@@ -118,9 +118,9 @@ define(
             it("removes a menu when body is clicked", function () {
                 // Show the menu
                 action.perform();
-                
+
                 // Verify precondition
-                expect(mockBody.off).not.toHaveBeenCalled();
+                expect(mockBody.remove).not.toHaveBeenCalled();
 
                 // Find and fire body's mousedown listener
                 mockBody.on.calls.forEach(function (call) {
@@ -133,7 +133,28 @@ define(
                 expect(mockMenu.remove).toHaveBeenCalled();
 
                 // Listener should have been detached from body
-                expect(mockBody.off).toHaveBeenCalled();
+                expect(mockBody.off).toHaveBeenCalledWith(
+                    'mousedown',
+                    jasmine.any(Function)
+                );
+            });
+
+            it("removes a menu when it is clicked", function () {
+                // Show the menu
+                action.perform();
+
+                // Verify precondition
+                expect(mockMenu.remove).not.toHaveBeenCalled();
+
+                // Find and fire body's mousedown listener
+                mockMenu.on.calls.forEach(function (call) {
+                    if (call.args[0] === 'click') {
+                        call.args[1]();
+                    }
+                });
+
+                // Menu should have been removed
+                expect(mockMenu.remove).toHaveBeenCalled();
             });
         });
     }


### PR DESCRIPTION
Summary of changes:

* Listen for clicks and dismiss the menu when it is clicked
* Turn `off` the correct listener on the body once the menu is dismissed
* Misc. whitespace

Verified that this has desired behavior in Chrome (menu goes away when anything in it is clicked, and the action still happens; and menu goes away when clicking outside of it) for both right-click-launched menus and title-arrow-launched menus


    Changes address original issue? Y
    Unit tests included and/or updated with changes? Y
    Command line build passes? Y
    Expect to pass code review? Y
    Project-specific information isolated to appropriate branches? Y

