### PR TITLE
[Composition] Consolidate composition changes

### DIFF
--- a/platform/commonUI/browse/src/creation/CreationService.js
+++ b/platform/commonUI/browse/src/creation/CreationService.js
@@ -97,17 +97,7 @@ define(
                     }
 
                     return parentPersistence.persist().then(function () {
-                        // Locate and return new Object in context of parent.
-                        return parent
-                            .useCapability('composition')
-                            .then(function (children) {
-                                var i;
-                                for (i = 0; i < children.length; i += 1) {
-                                    if (children[i].getId() === id) {
-                                        return children[i];
-                                    }
-                                }
-                            });
+                        return result;
                     });
                 });
             }

--- a/platform/commonUI/browse/src/creation/CreationService.js
+++ b/platform/commonUI/browse/src/creation/CreationService.js
@@ -87,12 +87,12 @@ define(
             // as a child contained by that parent.
             function addToComposition(id, parent, parentPersistence) {
                 var compositionCapability = parent.getCapability('composition'),
-                    mutationResult = compositionCapability &&
+                    addResult = compositionCapability &&
                         compositionCapability.add(id);
 
-                return self.$q.when(mutatationResult).then(function (result) {
+                return self.$q.when(addResult).then(function (result) {
                     if (!result) {
-                        self.$log.error("Could not mutate " + parent.getId());
+                        self.$log.error("Could not modify " + parent.getId());
                         return undefined;
                     }
 

--- a/platform/commonUI/browse/src/creation/CreationService.js
+++ b/platform/commonUI/browse/src/creation/CreationService.js
@@ -86,18 +86,9 @@ define(
             // composition, so that it will subsequently appear
             // as a child contained by that parent.
             function addToComposition(id, parent, parentPersistence) {
-                var mutatationResult = parent.useCapability("mutation", function (model) {
-                    if (Array.isArray(model.composition)) {
-                        // Don't add if the id is already there
-                        if (model.composition.indexOf(id) === -1) {
-                            model.composition.push(id);
-                        }
-                    } else {
-                        // This is abnormal; composition should be an array
-                        self.$log.warn(NO_COMPOSITION_WARNING + parent.getId());
-                        return false; // Cancel mutation
-                    }
-                });
+                var compositionCapability = parent.getCapability('composition'),
+                    mutationResult = compositionCapability &&
+                        compositionCapability.add(id);
 
                 return self.$q.when(mutatationResult).then(function (result) {
                     if (!result) {

--- a/platform/commonUI/browse/test/creation/CreationServiceSpec.js
+++ b/platform/commonUI/browse/test/creation/CreationServiceSpec.js
@@ -161,7 +161,7 @@ define(
                     mockDomainObject.getId.andReturn(id);
                     mockCompositionCapability.invoke
                         .andReturn(mockPromise([mockDomainObject]));
-                    return mockPromise(true);
+                    return mockPromise(mockDomainObject);
                 });
 
                 // Should find it in the composition

--- a/platform/commonUI/edit/src/actions/LinkAction.js
+++ b/platform/commonUI/edit/src/actions/LinkAction.js
@@ -36,19 +36,10 @@ define(
         function LinkAction(context) {
             this.domainObject = (context || {}).domainObject;
             this.selectedObject = (context || {}).selectedObject;
-            this.selectedId = this.selectedObject && this.selectedObject.getId();
         }
 
         LinkAction.prototype.perform = function () {
             var self = this;
-
-            // Add this domain object's identifier
-            function addId(model) {
-                if (Array.isArray(model.composition) &&
-                    model.composition.indexOf(self.selectedId) < 0) {
-                    model.composition.push(self.selectedId);
-                }
-            }
 
             // Persist changes to the domain object
             function doPersist() {
@@ -59,11 +50,13 @@ define(
 
             // Link these objects
             function doLink() {
-                return self.domainObject.useCapability("mutation", addId)
-                    .then(doPersist);
+                var composition = self.domainObject &&
+                        self.domainObject.getCapability('composition');
+                return composition && composition.add(self.selectedObject)
+                        .then(doPersist);
             }
 
-            return this.selectedId && doLink();
+            return this.selectedObject && doLink();
         };
 
         return LinkAction;

--- a/platform/commonUI/edit/src/actions/PropertiesDialog.js
+++ b/platform/commonUI/edit/src/actions/PropertiesDialog.js
@@ -54,6 +54,9 @@ define(
                         var row = Object.create(property.getDefinition());
                         row.key = index;
                         return row;
+                    }).filter(function (row) {
+                        // Only show properties which are editable
+                        return row.control;
                     })
                 }]
             };

--- a/platform/commonUI/edit/test/actions/PropertiesDialogSpec.js
+++ b/platform/commonUI/edit/test/actions/PropertiesDialogSpec.js
@@ -39,7 +39,7 @@ define(
                     return {
                         getValue: function (model) { return model[k]; },
                         setValue: function (model, v) { model[k] = v; },
-                        getDefinition: function () { return {}; }
+                        getDefinition: function () { return { control: 'textfield '}; }
                     };
                 });
 

--- a/platform/core/bundle.json
+++ b/platform/core/bundle.json
@@ -63,7 +63,12 @@
                 "provides": "modelService",
                 "type": "provider",
                 "implementation": "models/PersistedModelProvider.js",
-                "depends": [ "persistenceService", "$q", "PERSISTENCE_SPACE" ]
+                "depends": [
+                    "persistenceService",
+                    "$q",
+                    "PERSISTENCE_SPACE",
+                    "ADDITIONAL_PERSISTENCE_SPACES"
+                ]
             },
             {
                 "provides": "modelService",
@@ -214,6 +219,17 @@
                     "type": "folder",
                     "composition": []
                 }
+            }
+        ],
+        "constants": [
+            {
+                "key": "PERSISTENCE_SPACE",
+                "value": "mct"
+            },
+            {
+                "key": "ADDITIONAL_PERSISTENCE_SPACES",
+                "value": [],
+                "description": "An array of additional persistence spaces to load models from."
             }
         ]
     }

--- a/platform/core/src/capabilities/CompositionCapability.js
+++ b/platform/core/src/capabilities/CompositionCapability.js
@@ -63,8 +63,7 @@ define(
          */
         CompositionCapability.prototype.add = function (domainObject, index) {
             var id = typeof domainObject === 'string' ?
-                    domainObject : domainObject.getId(),
-                $q = this.$q;
+                    domainObject : domainObject.getId();
 
             function addIdToModel(model) {
                 var composition = model.composition,
@@ -73,7 +72,7 @@ define(
                 // If no index has been specified already and the id is already
                 // present, nothing to do. If the id is already at that index,
                 // also nothing to do, so cancel mutation.
-                if ((isNaN(index) && oldIndex !== -1) || (index === oldIndex) {
+                if ((isNaN(index) && oldIndex !== -1) || (index === oldIndex)) {
                     return false;
                 }
 

--- a/platform/core/src/capabilities/CompositionCapability.js
+++ b/platform/core/src/capabilities/CompositionCapability.js
@@ -65,7 +65,10 @@ define(
         CompositionCapability.prototype.add = function (domainObject, index) {
             var self = this,
                 id = typeof domainObject === 'string' ?
-                        domainObject : domainObject.getId();
+                        domainObject : domainObject.getId(),
+                model = self.domainObject.getModel(),
+                composition = model.composition,
+                oldIndex = composition.indexOf(id);
 
             // Find the object with the above id, used to contextualize
             function findObject(objects) {
@@ -82,16 +85,6 @@ define(
             }
 
             function addIdToModel(model) {
-                var composition = model.composition,
-                    oldIndex = composition.indexOf(id);
-
-                // If no index has been specified already and the id is already
-                // present, nothing to do. If the id is already at that index,
-                // also nothing to do, so cancel mutation.
-                if ((isNaN(index) && oldIndex !== -1) || (index === oldIndex)) {
-                    return false;
-                }
-
                 // Pick a specific index if needed.
                 index = isNaN(index) ? composition.length : index;
                 // Also, don't put past the end of the array
@@ -104,6 +97,13 @@ define(
 
                 // ...and add it back at the appropriate index.
                 model.composition.splice(index, 0, id);
+            }
+
+            // If no index has been specified already and the id is already
+            // present, nothing to do. If the id is already at that index,
+            // also nothing to do, so cancel mutation.
+            if ((isNaN(index) && oldIndex !== -1) || (index === oldIndex)) {
+                return contextualize(true);
             }
 
             return this.domainObject.useCapability('mutation', addIdToModel)

--- a/platform/core/src/capabilities/CompositionCapability.js
+++ b/platform/core/src/capabilities/CompositionCapability.js
@@ -51,6 +51,49 @@ define(
         }
 
         /**
+         * Add a domain object to the composition of the field.
+         * This mutates but does not persist the modified object.
+         *
+         * If no index is given, this is added to the end of the composition.
+         *
+         * @param {DomainObject|string} domainObject the domain object to add,
+         *        or simply its identifier
+         * @param {number} [index] the index at which to add the object
+         * @returns {Promise.<boolean>} the mutation result
+         */
+        CompositionCapability.prototype.add = function (domainObject, index) {
+            var id = typeof domainObject === 'string' ?
+                    domainObject : domainObject.getId();
+
+            function addIdToModel(model) {
+                var composition = model.composition,
+                    oldIndex = composition.indexOf(id);
+
+                // If no index has been specified already and the id is already
+                // present, nothing to do. If the id is already at that index,
+                // also nothing to do.
+                if ((isNaN(index) && oldIndex !== -1) || (index === oldIndex) {
+                    return;
+                }
+
+                // Pick a specific index if needed.
+                index = isNaN(index) ? composition.length : index;
+                // Also, don't put past the end of the array
+                index = Math.min(composition.length, index);
+
+                // Remove the existing instance of the id
+                if (oldIndex !== -1) {
+                    model.composition.splice(oldIndex, 1);
+                }
+
+                // ...and add it back at the appropriate index.
+                model.composition.splice(index, 0, id);
+            }
+
+            return this.domainObject.useCapability('mutation', addIdToModel);
+        };
+
+        /**
          * Request the composition of this object.
          * @returns {Promise.<DomainObject[]>} a list of all domain
          *     objects which compose this domain object.

--- a/platform/core/src/capabilities/CompositionCapability.js
+++ b/platform/core/src/capabilities/CompositionCapability.js
@@ -63,7 +63,8 @@ define(
          */
         CompositionCapability.prototype.add = function (domainObject, index) {
             var id = typeof domainObject === 'string' ?
-                    domainObject : domainObject.getId();
+                    domainObject : domainObject.getId(),
+                $q = this.$q;
 
             function addIdToModel(model) {
                 var composition = model.composition,
@@ -71,9 +72,9 @@ define(
 
                 // If no index has been specified already and the id is already
                 // present, nothing to do. If the id is already at that index,
-                // also nothing to do.
+                // also nothing to do, so cancel mutation.
                 if ((isNaN(index) && oldIndex !== -1) || (index === oldIndex) {
-                    return;
+                    return false;
                 }
 
                 // Pick a specific index if needed.

--- a/platform/core/src/models/PersistedModelProvider.js
+++ b/platform/core/src/models/PersistedModelProvider.js
@@ -52,10 +52,10 @@ define(
         // Take the most recently modified model, for cases where
         // multiple persistence spaces return models.
         function takeMostRecent(modelA, modelB) {
-            return (!modelA || modelA.modified === undefined) ? modelB :
-                    (!modelB || modelB.modified === undefined) ? modelA :
-                            modelA.modified > modelB.modified ? modelA :
-                                    modelB;
+            return (!modelB || modelB.modified === undefined) ? modelA :
+                    (!modelA || modelA.modified === undefined) ? modelB :
+                            modelB.modified > modelA.modified ? modelB :
+                                    modelA;
         }
 
         PersistedModelProvider.prototype.getModels = function (ids) {

--- a/platform/core/test/capabilities/CompositionCapabilitySpec.js
+++ b/platform/core/test/capabilities/CompositionCapabilitySpec.js
@@ -47,7 +47,7 @@ define(
             // so support that, but don't introduce complication of
             // native promises.
             function mockPromise(value) {
-                return {
+                return (value || {}).then ? value : {
                     then: function (callback) {
                         return mockPromise(callback(value));
                     }
@@ -109,6 +109,98 @@ define(
                 // Should have been added by a wrapper
                 expect(result[0].getCapability('context')).toBeDefined();
 
+            });
+
+            it("allows domain objects to be added", function () {
+                var result,
+                    testModel = { composition: [] },
+                    mockChild = jasmine.createSpyObj("child", DOMAIN_OBJECT_METHODS);
+
+                mockDomainObject.getModel.andReturn(testModel);
+                mockObjectService.getObjects.andReturn(mockPromise({a: mockChild}));
+                mockChild.getCapability.andReturn(undefined);
+                mockChild.getId.andReturn('a');
+
+                mockDomainObject.useCapability.andCallFake(function (key, mutator) {
+                    if (key === 'mutation') {
+                        mutator(testModel);
+                        return mockPromise(true);
+                    }
+                });
+
+                composition.add(mockChild).then(function (domainObject) {
+                    result = domainObject;
+                });
+
+                expect(testModel.composition).toEqual(['a']);
+
+                // Should have returned the added object in its new context
+                expect(result.getId()).toEqual('a');
+                expect(result.getCapability('context')).toBeDefined();
+                expect(result.getCapability('context').getParent())
+                    .toEqual(mockDomainObject);
+            });
+
+            it("does not re-add IDs which are already present", function () {
+                var result,
+                    testModel = { composition: [ 'a' ] },
+                    mockChild = jasmine.createSpyObj("child", DOMAIN_OBJECT_METHODS);
+
+                mockDomainObject.getModel.andReturn(testModel);
+                mockObjectService.getObjects.andReturn(mockPromise({a: mockChild}));
+                mockChild.getCapability.andReturn(undefined);
+                mockChild.getId.andReturn('a');
+
+                mockDomainObject.useCapability.andCallFake(function (key, mutator) {
+                    if (key === 'mutation') {
+                        mutator(testModel);
+                        return mockPromise(true);
+                    }
+                });
+
+                composition.add(mockChild).then(function (domainObject) {
+                    result = domainObject;
+                });
+
+                // Still just 'a'
+                expect(testModel.composition).toEqual(['a']);
+
+                // Should have returned the added object in its new context
+                expect(result.getId()).toEqual('a');
+                expect(result.getCapability('context')).toBeDefined();
+                expect(result.getCapability('context').getParent())
+                    .toEqual(mockDomainObject);
+            });
+
+            it("can add objects at a specified index", function () {
+                var result,
+                    testModel = { composition: [ 'a', 'b', 'c' ] },
+                    mockChild = jasmine.createSpyObj("child", DOMAIN_OBJECT_METHODS);
+
+                mockDomainObject.getModel.andReturn(testModel);
+                mockObjectService.getObjects.andReturn(mockPromise({a: mockChild}));
+                mockChild.getCapability.andReturn(undefined);
+                mockChild.getId.andReturn('a');
+
+                mockDomainObject.useCapability.andCallFake(function (key, mutator) {
+                    if (key === 'mutation') {
+                        mutator(testModel);
+                        return mockPromise(true);
+                    }
+                });
+
+                composition.add(mockChild, 1).then(function (domainObject) {
+                    result = domainObject;
+                });
+
+                // Still just 'a'
+                expect(testModel.composition).toEqual(['b', 'a', 'c']);
+
+                // Should have returned the added object in its new context
+                expect(result.getId()).toEqual('a');
+                expect(result.getCapability('context')).toBeDefined();
+                expect(result.getCapability('context').getParent())
+                    .toEqual(mockDomainObject);
             });
 
         });

--- a/platform/entanglement/src/actions/AbstractComposeAction.js
+++ b/platform/entanglement/src/actions/AbstractComposeAction.js
@@ -44,7 +44,8 @@ define(
          * @method platform/entanglement.AbstractComposeService#perform
          */
         /**
-         * Check if one object can be composed into another.
+         * Check if this composition change is valid for these objects.
+         *
          * @param {DomainObject} domainObject  the domain object to
          *    move, copy, or link.
          * @param {DomainObject} parent  the domain object whose composition

--- a/platform/entanglement/src/actions/AbstractComposeAction.js
+++ b/platform/entanglement/src/actions/AbstractComposeAction.js
@@ -32,7 +32,8 @@ define(
          * @private
          */
         /**
-         * Change the composition of the specified objects.
+         * Change the composition of the specified objects. Note that this
+         * should only be invoked after successfully validating.
          *
          * @param {DomainObject} domainObject  the domain object to
          *    move, copy, or link.

--- a/platform/entanglement/src/services/CopyService.js
+++ b/platform/entanglement/src/services/CopyService.js
@@ -64,6 +64,12 @@ define(
                 return self.perform(domainObject, parent);
             }
 
+            if (!this.validate(domainObject, parent)) {
+                throw new Error(
+                    "Tried to copy objects without validating first."
+                );
+            }
+
             if (domainObject.hasCapability('composition')) {
                 model.composition = [];
             }

--- a/platform/entanglement/src/services/LinkService.js
+++ b/platform/entanglement/src/services/LinkService.js
@@ -68,10 +68,10 @@ define(
                 }
             }
 
-            return composition.add(object).then(function () {
-                return parentObject.getCapability('persistence').persist();
-            }).then(function getObjectWithNewContext() {
-                return composition.invoke().then(findChild);
+            return composition.add(object).then(function (result) {
+                return parentObject.getCapability('persistence')
+                    .persist()
+                    .then(function () { return result; });
             });
         };
 

--- a/platform/entanglement/src/services/LinkService.js
+++ b/platform/entanglement/src/services/LinkService.js
@@ -53,15 +53,18 @@ define(
         };
 
         LinkService.prototype.perform = function (object, parentObject) {
-            // It is assumed here that validate has been called, and therefore
-            // that parentObject.hasCapability('composition').
-            var composition = parentObject.getCapability('composition');
+            if (!this.validate(object, parentObject)) {
+                throw new Error(
+                    "Tried to link objects without validating first."
+                );
+            }
 
-            return composition.add(object).then(function (objectInNewContext) {
-                return parentObject.getCapability('persistence')
-                    .persist()
-                    .then(function () { return objectInNewContext; });
-            });
+            return parentObject.getCapability('composition').add(object)
+                .then(function (objectInNewContext) {
+                    return parentObject.getCapability('persistence')
+                        .persist()
+                        .then(function () { return objectInNewContext; });
+                });
         };
 
         return LinkService;

--- a/platform/entanglement/src/services/LinkService.js
+++ b/platform/entanglement/src/services/LinkService.js
@@ -45,7 +45,7 @@ define(
             if (parentCandidate.getId() === object.getId()) {
                 return false;
             }
-            if (parentCandidate.getModel().composition.indexOf(object.getId()) !== -1) {
+            if ((parentCandidate.getModel().composition || []).indexOf(object.getId()) !== -1) {
                 return false;
             }
             return this.policyService.allow(

--- a/platform/entanglement/src/services/LinkService.js
+++ b/platform/entanglement/src/services/LinkService.js
@@ -52,10 +52,13 @@ define(
                 "composition",
                 parentCandidate.getCapability('type'),
                 object.getCapability('type')
-            );
+            ) && parentCandidate.hasCapability('composition');
         };
 
         LinkService.prototype.perform = function (object, parentObject) {
+            // Note that this was checked-for explicitly during validate step
+            var composition = parentObject.getCapability('composition');
+
             function findChild(children) {
                 var i;
                 for (i = 0; i < children.length; i += 1) {
@@ -65,16 +68,10 @@ define(
                 }
             }
 
-            return parentObject.useCapability('mutation', function (model) {
-                if (model.composition.indexOf(object.getId()) === -1) {
-                    model.composition.push(object.getId());
-                }
-            }).then(function () {
+            return composition.add(object).then(function () {
                 return parentObject.getCapability('persistence').persist();
             }).then(function getObjectWithNewContext() {
-                return parentObject
-                    .useCapability('composition')
-                    .then(findChild);
+                return composition.invoke().then(findChild);
             });
         };
 

--- a/platform/entanglement/src/services/LinkService.js
+++ b/platform/entanglement/src/services/LinkService.js
@@ -53,7 +53,8 @@ define(
         };
 
         LinkService.prototype.perform = function (object, parentObject) {
-            // Note that this was checked-for explicitly during validate step
+            // It is assumed here that validate has been called, and therefore
+            // that parentObject.hasCapability('composition').
             var composition = parentObject.getCapability('composition');
 
             return composition.add(object).then(function (result) {

--- a/platform/entanglement/src/services/LinkService.js
+++ b/platform/entanglement/src/services/LinkService.js
@@ -39,20 +39,17 @@ define(
         }
 
         LinkService.prototype.validate = function (object, parentCandidate) {
-            if (!parentCandidate || !parentCandidate.getId) {
-                return false;
-            }
-            if (parentCandidate.getId() === object.getId()) {
-                return false;
-            }
-            if ((parentCandidate.getModel().composition || []).indexOf(object.getId()) !== -1) {
-                return false;
-            }
-            return this.policyService.allow(
-                "composition",
-                parentCandidate.getCapability('type'),
-                object.getCapability('type')
-            ) && parentCandidate.hasCapability('composition');
+            var objectId = object.getId();
+            return !!parentCandidate &&
+                !!parentCandidate.getId &&
+                parentCandidate.getId() !== objectId &&
+                parentCandidate.hasCapability("composition") &&
+                parentCandidate.getModel().composition.indexOf(objectId) === -1 &&
+                this.policyService.allow(
+                    "composition",
+                    parentCandidate.getCapability('type'),
+                    object.getCapability('type')
+                );
         };
 
         LinkService.prototype.perform = function (object, parentObject) {

--- a/platform/entanglement/src/services/LinkService.js
+++ b/platform/entanglement/src/services/LinkService.js
@@ -57,10 +57,10 @@ define(
             // that parentObject.hasCapability('composition').
             var composition = parentObject.getCapability('composition');
 
-            return composition.add(object).then(function (result) {
+            return composition.add(object).then(function (objectInNewContext) {
                 return parentObject.getCapability('persistence')
                     .persist()
-                    .then(function () { return result; });
+                    .then(function () { return objectInNewContext; });
             });
         };
 

--- a/platform/entanglement/src/services/LinkService.js
+++ b/platform/entanglement/src/services/LinkService.js
@@ -45,14 +45,17 @@ define(
             if (parentCandidate.getId() === object.getId()) {
                 return false;
             }
-            if ((parentCandidate.getModel().composition || []).indexOf(object.getId()) !== -1) {
+            if (!parentCandidate.hasCapability('composition')) {
+                return false;
+            }
+            if (parentCandidate.getModel().composition.indexOf(object.getId()) !== -1) {
                 return false;
             }
             return this.policyService.allow(
                 "composition",
                 parentCandidate.getCapability('type'),
                 object.getCapability('type')
-            ) && parentCandidate.hasCapability('composition');
+            );
         };
 
         LinkService.prototype.perform = function (object, parentObject) {

--- a/platform/entanglement/src/services/LinkService.js
+++ b/platform/entanglement/src/services/LinkService.js
@@ -39,17 +39,20 @@ define(
         }
 
         LinkService.prototype.validate = function (object, parentCandidate) {
-            var objectId = object.getId();
-            return !!parentCandidate &&
-                !!parentCandidate.getId &&
-                parentCandidate.getId() !== objectId &&
-                parentCandidate.hasCapability("composition") &&
-                parentCandidate.getModel().composition.indexOf(objectId) === -1 &&
-                this.policyService.allow(
-                    "composition",
-                    parentCandidate.getCapability('type'),
-                    object.getCapability('type')
-                );
+            if (!parentCandidate || !parentCandidate.getId) {
+                return false;
+            }
+            if (parentCandidate.getId() === object.getId()) {
+                return false;
+            }
+            if ((parentCandidate.getModel().composition || []).indexOf(object.getId()) !== -1) {
+                return false;
+            }
+            return this.policyService.allow(
+                "composition",
+                parentCandidate.getCapability('type'),
+                object.getCapability('type')
+            ) && parentCandidate.hasCapability('composition');
         };
 
         LinkService.prototype.perform = function (object, parentObject) {

--- a/platform/entanglement/src/services/LinkService.js
+++ b/platform/entanglement/src/services/LinkService.js
@@ -59,15 +59,6 @@ define(
             // Note that this was checked-for explicitly during validate step
             var composition = parentObject.getCapability('composition');
 
-            function findChild(children) {
-                var i;
-                for (i = 0; i < children.length; i += 1) {
-                    if (children[i].getId() === object.getId()) {
-                        return children[i];
-                    }
-                }
-            }
-
             return composition.add(object).then(function (result) {
                 return parentObject.getCapability('persistence')
                     .persist()

--- a/platform/entanglement/src/services/MoveService.js
+++ b/platform/entanglement/src/services/MoveService.js
@@ -82,6 +82,12 @@ define(
                 }
             }
 
+            if (!this.validate(object, parentObject)) {
+                throw new Error(
+                    "Tried to move objects without validating first."
+                );
+            }
+
             return this.linkService
                 .perform(object, parentObject)
                 .then(relocate)

--- a/platform/entanglement/test/services/CopyServiceSpec.js
+++ b/platform/entanglement/test/services/CopyServiceSpec.js
@@ -41,19 +41,24 @@ define(
         }
 
         describe("CopyService", function () {
+            var policyService;
+
+            beforeEach(function () {
+                policyService = jasmine.createSpyObj(
+                    'policyService',
+                    ['allow']
+                );
+                policyService.allow.andReturn(true);
+            });
+
             describe("validate", function () {
 
-                var policyService,
-                    copyService,
+                var copyService,
                     object,
                     parentCandidate,
                     validate;
 
                 beforeEach(function () {
-                    policyService = jasmine.createSpyObj(
-                        'policyService',
-                        ['allow']
-                    );
                     copyService = new CopyService(
                         null,
                         null,
@@ -148,7 +153,7 @@ define(
                         );
                         createObjectPromise = synchronousPromise(undefined);
                         creationService.createObject.andReturn(createObjectPromise);
-                        copyService = new CopyService(null, creationService);
+                        copyService = new CopyService(null, creationService, policyService);
                         copyResult = copyService.perform(object, newParent);
                         copyFinished = jasmine.createSpy('copyFinished');
                         copyResult.then(copyFinished);
@@ -180,7 +185,8 @@ define(
                 });
 
                 describe("on domainObject with composition", function () {
-                    var childObject,
+                    var newObject,
+                        childObject,
                         compositionCapability,
                         compositionPromise;
 
@@ -216,6 +222,17 @@ define(
                                 composition: compositionCapability
                             }
                         });
+                        newObject = domainObjectFactory({
+                            name: 'object',
+                            id: 'abc2',
+                            model: {
+                                name: 'some object',
+                                composition: []
+                            },
+                            capabilities: {
+                                composition: compositionCapability
+                            }
+                        });
                         newParent = domainObjectFactory({
                             name: 'newParent',
                             id: '456',
@@ -227,9 +244,11 @@ define(
                             'creationService',
                             ['createObject']
                         );
-                        createObjectPromise = synchronousPromise(undefined);
+                        policyService.allow.andReturn(true);
+
+                        createObjectPromise = synchronousPromise(newObject);
                         creationService.createObject.andReturn(createObjectPromise);
-                        copyService = new CopyService(mockQ, creationService);
+                        copyService = new CopyService(mockQ, creationService, policyService);
                         copyResult = copyService.perform(object, newParent);
                         copyFinished = jasmine.createSpy('copyFinished');
                         copyResult.then(copyFinished);

--- a/platform/entanglement/test/services/CopyServiceSpec.js
+++ b/platform/entanglement/test/services/CopyServiceSpec.js
@@ -48,7 +48,6 @@ define(
                     'policyService',
                     ['allow']
                 );
-                policyService.allow.andReturn(true);
             });
 
             describe("validate", function () {
@@ -138,6 +137,7 @@ define(
                     );
                     createObjectPromise = synchronousPromise(undefined);
                     creationService.createObject.andReturn(createObjectPromise);
+                    policyService.allow.andReturn(true);
                 });
 
                 describe("on domain object without composition", function () {
@@ -243,7 +243,6 @@ define(
                                 composition: []
                             }
                         });
-                        policyService.allow.andReturn(true);
 
                         createObjectPromise = synchronousPromise(newObject);
                         creationService.createObject.andReturn(createObjectPromise);

--- a/platform/entanglement/test/services/CopyServiceSpec.js
+++ b/platform/entanglement/test/services/CopyServiceSpec.js
@@ -285,6 +285,20 @@ define(
                     });
                 });
 
+                it("throws an expection when performed on invalid inputs", function () {
+                    var copyService =
+                        new CopyService(mockQ, creationService, policyService);
+
+                    function perform() {
+                        copyService.perform(object, newParent);
+                    }
+
+                    policyService.allow.andReturn(true);
+                    expect(perform).not.toThrow();
+                    policyService.allow.andReturn(false); // Cause validate to fail
+                    expect(perform).toThrow();
+                });
+
             });
         });
     }

--- a/platform/entanglement/test/services/LinkServiceSpec.js
+++ b/platform/entanglement/test/services/LinkServiceSpec.js
@@ -55,11 +55,18 @@ define(
                         name: 'object'
                     });
                     parentCandidate = domainObjectFactory({
-                        name: 'parentCandidate'
+                        name: 'parentCandidate',
+                        capabilities: {
+                            composition: jasmine.createSpyObj(
+                                'composition',
+                                ['invoke', 'add']
+                            )
+                        }
                     });
                     validate = function () {
                         return linkService.validate(object, parentCandidate);
                     };
+                    mockPolicyService.allow.andReturn(true);
                 });
 
                 it("does not allow invalid parentCandidate", function () {
@@ -78,6 +85,23 @@ define(
                     object.id = 'abc';
                     parentCandidate.id = 'xyz';
                     parentCandidate.model.composition = ['abc'];
+                    expect(validate()).toBe(false);
+                });
+
+                it("does not allow parents that contains object", function () {
+                    object.id = 'abc';
+                    parentCandidate.id = 'xyz';
+                    parentCandidate.model.composition = ['abc'];
+                    expect(validate()).toBe(false);
+                });
+
+                it("does not allow parents without composition", function () {
+                    parentCandidate = domainObjectFactory({
+                        name: 'parentCandidate'
+                    });
+                    object.id = 'abc';
+                    parentCandidate.id = 'xyz';
+                    parentCandidate.model.composition = undefined;
                     expect(validate()).toBe(false);
                 });
 
@@ -121,16 +145,16 @@ define(
                     linkedObject,
                     parentModel,
                     parentObject,
-                    mutationPromise,
                     compositionPromise,
                     persistencePromise,
+                    addPromise,
                     compositionCapability,
                     persistenceCapability;
 
                 beforeEach(function () {
-                    mutationPromise = new ControlledPromise();
                     compositionPromise = new ControlledPromise();
                     persistencePromise = new ControlledPromise();
+                    addPromise = new ControlledPromise();
                     persistenceCapability = jasmine.createSpyObj(
                         'persistenceCapability',
                         ['persist']
@@ -138,9 +162,10 @@ define(
                     persistenceCapability.persist.andReturn(persistencePromise);
                     compositionCapability = jasmine.createSpyObj(
                         'compositionCapability',
-                        ['invoke']
+                        ['invoke', 'add']
                     );
                     compositionCapability.invoke.andReturn(compositionPromise);
+                    compositionCapability.add.andReturn(addPromise);
                     parentModel = {
                         composition: []
                     };
@@ -151,7 +176,7 @@ define(
                             mutation: {
                                 invoke: function (mutator) {
                                     mutator(parentModel);
-                                    return mutationPromise;
+                                    return new ControlledPromise();
                                 }
                             },
                             persistence: persistenceCapability,
@@ -172,20 +197,17 @@ define(
                 });
 
 
-                it("modifies parent model composition", function () {
-                    expect(parentModel.composition.length).toBe(0);
+                it("adds to the parent's composition", function () {
+                    expect(compositionCapability.add).not.toHaveBeenCalled();
                     linkService.perform(object, parentObject);
-                    expect(parentObject.useCapability).toHaveBeenCalledWith(
-                        'mutation',
-                        jasmine.any(Function)
-                    );
-                    expect(parentModel.composition).toContain('xyz');
+                    expect(compositionCapability.add)
+                        .toHaveBeenCalledWith(object);
                 });
 
                 it("persists parent", function () {
                     linkService.perform(object, parentObject);
-                    expect(mutationPromise.then).toHaveBeenCalled();
-                    mutationPromise.resolve();
+                    expect(addPromise.then).toHaveBeenCalled();
+                    addPromise.resolve();
                     expect(parentObject.getCapability)
                         .toHaveBeenCalledWith('persistence');
                     expect(persistenceCapability.persist).toHaveBeenCalled();
@@ -197,7 +219,7 @@ define(
                     whenComplete = jasmine.createSpy('whenComplete');
                     returnPromise.then(whenComplete);
 
-                    mutationPromise.resolve();
+                    addPromise.resolve();
                     persistencePromise.resolve();
                     compositionPromise.resolve([linkedObject]);
                     expect(whenComplete).toHaveBeenCalledWith(linkedObject);

--- a/platform/entanglement/test/services/LinkServiceSpec.js
+++ b/platform/entanglement/test/services/LinkServiceSpec.js
@@ -220,6 +220,17 @@ define(
                     compositionPromise.resolve([linkedObject]);
                     expect(whenComplete).toHaveBeenCalledWith(linkedObject);
                 });
+
+                it("throws an expection when performed on invalid inputs", function () {
+                    function perform() {
+                        linkService.perform(object, parentObject);
+                    }
+
+                    mockPolicyService.allow.andReturn(true);
+                    expect(perform).not.toThrow();
+                    mockPolicyService.allow.andReturn(false); // Cause validate to fail
+                    expect(perform).toThrow();
+                });
             });
         });
     }

--- a/platform/entanglement/test/services/LinkServiceSpec.js
+++ b/platform/entanglement/test/services/LinkServiceSpec.js
@@ -97,7 +97,6 @@ define(
                     parentCandidate.hasCapability.andCallFake(function (c) {
                         return c !== 'composition';
                     });
-                    parentCandidate.model.composition = undefined;
                     expect(validate()).toBe(false);
                 });
 

--- a/platform/entanglement/test/services/LinkServiceSpec.js
+++ b/platform/entanglement/test/services/LinkServiceSpec.js
@@ -88,19 +88,15 @@ define(
                     expect(validate()).toBe(false);
                 });
 
-                it("does not allow parents that contains object", function () {
-                    object.id = 'abc';
-                    parentCandidate.id = 'xyz';
-                    parentCandidate.model.composition = ['abc'];
-                    expect(validate()).toBe(false);
-                });
-
                 it("does not allow parents without composition", function () {
                     parentCandidate = domainObjectFactory({
                         name: 'parentCandidate'
                     });
                     object.id = 'abc';
                     parentCandidate.id = 'xyz';
+                    parentCandidate.hasCapability.andCallFake(function (c) {
+                        return c !== 'composition';
+                    });
                     parentCandidate.model.composition = undefined;
                     expect(validate()).toBe(false);
                 });

--- a/platform/entanglement/test/services/LinkServiceSpec.js
+++ b/platform/entanglement/test/services/LinkServiceSpec.js
@@ -41,6 +41,7 @@ define(
                     'policyService',
                     ['allow']
                 );
+                mockPolicyService.allow.andReturn(true);
                 linkService = new LinkService(mockPolicyService);
             });
 
@@ -66,7 +67,6 @@ define(
                     validate = function () {
                         return linkService.validate(object, parentCandidate);
                     };
-                    mockPolicyService.allow.andReturn(true);
                 });
 
                 it("does not allow invalid parentCandidate", function () {

--- a/platform/entanglement/test/services/LinkServiceSpec.js
+++ b/platform/entanglement/test/services/LinkServiceSpec.js
@@ -20,7 +20,7 @@
  * at runtime from the About dialog for additional information.
  *****************************************************************************/
 
-/*global define,describe,beforeEach,it,jasmine,expect */
+/*global define,describe,beforeEach,it,jasmine,expect,spyOn */
 
 define(
     [
@@ -221,14 +221,15 @@ define(
                     expect(whenComplete).toHaveBeenCalledWith(linkedObject);
                 });
 
-                it("throws an expection when performed on invalid inputs", function () {
+                it("throws an error when performed on invalid inputs", function () {
                     function perform() {
                         linkService.perform(object, parentObject);
                     }
 
-                    mockPolicyService.allow.andReturn(true);
+                    spyOn(linkService, 'validate');
+                    linkService.validate.andReturn(true);
                     expect(perform).not.toThrow();
-                    mockPolicyService.allow.andReturn(false); // Cause validate to fail
+                    linkService.validate.andReturn(false);
                     expect(perform).toThrow();
                 });
             });

--- a/platform/entanglement/test/services/LinkServiceSpec.js
+++ b/platform/entanglement/test/services/LinkServiceSpec.js
@@ -207,7 +207,7 @@ define(
                 it("persists parent", function () {
                     linkService.perform(object, parentObject);
                     expect(addPromise.then).toHaveBeenCalled();
-                    addPromise.resolve();
+                    addPromise.resolve(linkedObject);
                     expect(parentObject.getCapability)
                         .toHaveBeenCalledWith('persistence');
                     expect(persistenceCapability.persist).toHaveBeenCalled();
@@ -219,7 +219,7 @@ define(
                     whenComplete = jasmine.createSpy('whenComplete');
                     returnPromise.then(whenComplete);
 
-                    addPromise.resolve();
+                    addPromise.resolve(linkedObject);
                     persistencePromise.resolve();
                     compositionPromise.resolve([linkedObject]);
                     expect(whenComplete).toHaveBeenCalledWith(linkedObject);

--- a/platform/entanglement/test/services/MoveServiceSpec.js
+++ b/platform/entanglement/test/services/MoveServiceSpec.js
@@ -20,7 +20,7 @@
  * at runtime from the About dialog for additional information.
  *****************************************************************************/
 
-/*global define,describe,beforeEach,it,jasmine,expect */
+/*global define,describe,beforeEach,it,jasmine,expect,spyOn */
 define(
     [
         '../../src/services/MoveService',
@@ -196,14 +196,15 @@ define(
                         .toHaveBeenCalledWith(jasmine.any(Function));
                 });
 
-                it("throws an expection when performed on invalid inputs", function () {
+                it("throws an error when performed on invalid inputs", function () {
                     function perform() {
                         moveService.perform(object, newParent);
                     }
 
-                    policyService.allow.andReturn(true);
+                    spyOn(moveService, "validate");
+                    moveService.validate.andReturn(true);
                     expect(perform).not.toThrow();
-                    policyService.allow.andReturn(false); // Cause validate to fail
+                    moveService.validate.andReturn(false);
                     expect(perform).toThrow();
                 });
 

--- a/platform/entanglement/test/services/MoveServiceSpec.js
+++ b/platform/entanglement/test/services/MoveServiceSpec.js
@@ -196,6 +196,17 @@ define(
                         .toHaveBeenCalledWith(jasmine.any(Function));
                 });
 
+                it("throws an expection when performed on invalid inputs", function () {
+                    function perform() {
+                        moveService.perform(object, newParent);
+                    }
+
+                    policyService.allow.andReturn(true);
+                    expect(perform).not.toThrow();
+                    policyService.allow.andReturn(false); // Cause validate to fail
+                    expect(perform).toThrow();
+                });
+
                 describe("when moving an original", function () {
                     beforeEach(function () {
                         locationCapability.getContextualLocation

--- a/platform/entanglement/test/services/MoveServiceSpec.js
+++ b/platform/entanglement/test/services/MoveServiceSpec.js
@@ -40,58 +40,57 @@ define(
 
             var moveService,
                 policyService,
+                object,
+                objectContextCapability,
+                currentParent,
+                parentCandidate,
                 linkService;
 
             beforeEach(function () {
+                objectContextCapability = jasmine.createSpyObj(
+                    'objectContextCapability',
+                    [
+                        'getParent'
+                    ]
+                );
+
+                object = domainObjectFactory({
+                    name: 'object',
+                    id: 'a',
+                    capabilities: {
+                        context: objectContextCapability,
+                        type: { type: 'object' }
+                    }
+                });
+
+                currentParent = domainObjectFactory({
+                    name: 'currentParent',
+                    id: 'b'
+                });
+
+                objectContextCapability.getParent.andReturn(currentParent);
+
+                parentCandidate = domainObjectFactory({
+                    name: 'parentCandidate',
+                    model: { composition: [] },
+                    id: 'c',
+                    capabilities: {
+                        type: { type: 'parentCandidate' }
+                    }
+                });
                 policyService = jasmine.createSpyObj(
                     'policyService',
                     ['allow']
                 );
                 linkService = new MockLinkService();
+                policyService.allow.andReturn(true);
                 moveService = new MoveService(policyService, linkService);
             });
 
             describe("validate", function () {
-                var object,
-                    objectContextCapability,
-                    currentParent,
-                    parentCandidate,
-                    validate;
+                var validate;
 
                 beforeEach(function () {
-
-                    objectContextCapability = jasmine.createSpyObj(
-                        'objectContextCapability',
-                        [
-                            'getParent'
-                        ]
-                    );
-
-                    object = domainObjectFactory({
-                        name: 'object',
-                        id: 'a',
-                        capabilities: {
-                            context: objectContextCapability,
-                            type: { type: 'object' }
-                        }
-                    });
-
-                    currentParent = domainObjectFactory({
-                        name: 'currentParent',
-                        id: 'b'
-                    });
-
-                    objectContextCapability.getParent.andReturn(currentParent);
-
-                    parentCandidate = domainObjectFactory({
-                        name: 'parentCandidate',
-                        model: { composition: [] },
-                        id: 'c',
-                        capabilities: {
-                            type: { type: 'parentCandidate' }
-                        }
-                    });
-
                     validate = function () {
                         return moveService.validate(object, parentCandidate);
                     };
@@ -145,14 +144,15 @@ define(
 
             describe("perform", function () {
 
-                var object,
-                    newParent,
-                    actionCapability,
+                var actionCapability,
                     locationCapability,
                     locationPromise,
+                    newParent,
                     moveResult;
 
                 beforeEach(function () {
+                    newParent = parentCandidate;
+
                     actionCapability = jasmine.createSpyObj(
                         'actionCapability',
                         ['perform']
@@ -175,7 +175,9 @@ define(
                         name: 'object',
                         capabilities: {
                             action: actionCapability,
-                            location: locationCapability
+                            location: locationCapability,
+                            context: objectContextCapability,
+                            type: { type: 'object' }
                         }
                     });
 


### PR DESCRIPTION
Handle adding new objects to the composition of other objects as part of the `composition` capability, instead of modifying the `composition` property directly in the model. nasa/openmctweb#97 

1.   Changes address original issue? Y
2.   Unit tests included and/or updated with changes? Y
3.   Command line build passes? Y
4.   Expect to pass code review? Y
