### PR TITLE
[Identity] Provide an undefined identity

### DIFF
--- a/platform/identity/src/IdentityProvider.js
+++ b/platform/identity/src/IdentityProvider.js
@@ -30,20 +30,18 @@ define(
     function () {
         "use strict";
 
-        var UNKNOWN_USER = {
-            key: "unknown",
-            name: "Unknown User"
-        };
-
         /**
          * Default implementation of an identity service. Provides an
-         * unkown user.
+         * unknown user as an `undefined` value; this is present simply
+         * to ensure that there is always an `identityService` available
+         * for platform components to use.
+         *
          * @constructor
          * @implements {IdentityService}
          * @memberof platform/identity
          */
         function IdentityProvider($q) {
-            this.userPromise = $q.when(UNKNOWN_USER);
+            this.userPromise = $q.when(undefined);
         }
 
         IdentityProvider.prototype.getUser = function () {

--- a/platform/identity/test/IdentityProviderSpec.js
+++ b/platform/identity/test/IdentityProviderSpec.js
@@ -46,15 +46,12 @@ define(
                 provider = new IdentityProvider(mockQ);
             });
 
-            it("provides an unknown user", function () {
+            it("provides an undefined user", function () {
                 provider.getUser().then(mockCallback);
 
                 waitsFor(calledBack);
                 runs(function () {
-                    expect(mockCallback).toHaveBeenCalledWith({
-                        key: jasmine.any(String),
-                        name: jasmine.any(String)
-                    });
+                    expect(mockCallback).toHaveBeenCalledWith(undefined);
                 });
             });
 


### PR DESCRIPTION
Provide an undefined identity by default, instead of
an Unknown User. This suppresses display of identity-related
features (such as the identity indicator) while still
providing a default implementation of the identityService
for platform components to utilize. nasa/openmctweb#99

### Author Checklist

1. Changes address original issue? Y
2. Unit tests included and/or updated with changes? Y
3. Command line build passes? Y
4. Expect to pass code review? Y