### PR TITLE
[Info Bubble] Remove ID

### DIFF
--- a/platform/core/src/capabilities/MetadataCapability.js
+++ b/platform/core/src/capabilities/MetadataCapability.js
@@ -78,10 +78,6 @@ define(
                     {
                         name: "Type",
                         value: type && type.getName()
-                    },
-                    {
-                        name: "ID",
-                        value: domainObject.getId()
                     }
                 ];
             }

--- a/platform/core/test/capabilities/MetadataCapabilitySpec.js
+++ b/platform/core/test/capabilities/MetadataCapabilitySpec.js
@@ -92,7 +92,6 @@ define(
 
             it("reports generic properties", function () {
                 var properties = metadata.invoke();
-                expect(findValue(properties, 'ID')).toEqual("Test id");
                 expect(findValue(properties, 'Type')).toEqual("Test type");
             });
 


### PR DESCRIPTION
Don't show domain object id in info bubble; this is not
useful information to non-developers. (For developers,
this information can be retrieved from the URL by
navigating to a domain object.) WTD-1252

### Author Checklist

1. Changes address original issue? Y
2. Unit tests included and/or updated with changes? Y
3. Command line build passes? Y
4. Expect to pass code review? Y