### PR TITLE
[Forms] Fix select control

### DIFF
--- a/platform/forms/res/templates/controls/select.html
+++ b/platform/forms/res/templates/controls/select.html
@@ -20,11 +20,11 @@
  at runtime from the About dialog for additional information.
 -->
 <div class='form-control select'>
-	<select
-	        ng-model="ngModel[field]"
-	        ng-options="opt.value as opt.name for opt in options"
-	        ng-required="ngRequired"
-	        name="mctControl">
-	    <option value="" ng-if="!ngModel[field]">- Select One -</option>
-	</select>
+    <select
+            ng-model="ngModel[field]"
+            ng-options="opt.value as opt.name for opt in options"
+            ng-required="ngRequired"
+            name="mctControl">
+        <option value="" ng-show="!ngModel[field]">- Select One -</option>
+    </select>
 </div>


### PR DESCRIPTION
Use ng-show instead of ng-if to suppress the
'Select One' option after user has chosen something
in a select box; the latter appears to be incompatible
with Angular 1.4.x. nasa/openmctweb#113