### PR TITLE
[Location] Add contexts to domain objects by location

### DIFF
--- a/platform/core/bundle.json
+++ b/platform/core/bundle.json
@@ -149,7 +149,7 @@
             {
                 "key": "composition",
                 "implementation": "capabilities/CompositionCapability.js",
-                "depends": [ "$injector" ]
+                "depends": [ "$injector", "contextualize" ]
             },
             {
                 "key": "relationship",
@@ -204,6 +204,11 @@
             {
                 "key": "topic",
                 "implementation": "services/Topic.js"
+            },
+            {
+                "key": "contextualize",
+                "implementation": "services/Contextualize.js",
+                "depends": [ "$log" ]
             }
         ],
         "roots": [

--- a/platform/core/src/capabilities/ContextCapability.js
+++ b/platform/core/src/capabilities/ContextCapability.js
@@ -84,7 +84,7 @@ define(
                 parentContext =
                     parentObject && parentObject.getCapability('context'),
                 parentPath = parentContext ?
-                    parentContext.getPath() : [ this.parentObject ];
+                        parentContext.getPath() : [ this.parentObject ];
 
             return parentPath.concat([this.domainObject]);
         };

--- a/platform/core/src/services/Contextualize.js
+++ b/platform/core/src/services/Contextualize.js
@@ -1,0 +1,78 @@
+/*****************************************************************************
+ * Open MCT Web, Copyright (c) 2014-2015, United States Government
+ * as represented by the Administrator of the National Aeronautics and Space
+ * Administration. All rights reserved.
+ *
+ * Open MCT Web is licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * Open MCT Web includes source code licensed under additional open source
+ * licenses. See the Open Source Licenses file (LICENSES.md) included with
+ * this source code distribution or the Licensing information page available
+ * at runtime from the About dialog for additional information.
+ *****************************************************************************/
+/*global define*/
+
+define(
+    ['../capabilities/ContextualDomainObject'],
+    function (ContextualDomainObject) {
+        "use strict";
+
+        /**
+         * Wrap a domain object such that it has a `context` capability
+         * referring to a specific parent.
+         *
+         * Usage:
+         *
+         *     contextualize(domainObject, parentObject)
+         *
+         * Attempting to contextualize an object with a parent that does
+         * not include that object in its composition may have
+         * unpredictable results; a warning will be logged if this occurs.
+         *
+         * @returns {Function}
+         * @memberof platform/core
+         */
+        function Contextualize($log) {
+            function validate(id, parentObject) {
+                var model = parentObject && parentObject.getModel(),
+                    composition = (model || {}).composition || [];
+                if (composition.indexOf(id) === -1) {
+                    $log.warn([
+                        "Attempted to contextualize",
+                        id,
+                        "in",
+                        parentObject && parentObject.getId(),
+                        "but that object does not contain",
+                        id,
+                        "in its composition.",
+                        "Unexpected behavior may follow."
+                    ].join(" "));
+                }
+            }
+
+            /**
+             * Contextualize this domain object.
+             * @param {DomainObject} domainObject the domain object
+             *        to wrap with a context
+             * @param {DomainObject} parentObject the domain object
+             *        which should appear as the contextual parent
+             */
+            return function (domainObject, parentObject) {
+                validate(domainObject.getId(), parentObject);
+                return new ContextualDomainObject(domainObject, parentObject);
+            };
+        }
+
+        return Contextualize;
+    }
+);
+

--- a/platform/core/test/capabilities/CompositionCapabilitySpec.js
+++ b/platform/core/test/capabilities/CompositionCapabilitySpec.js
@@ -25,8 +25,11 @@
  * CompositionCapabilitySpec. Created by vwoeltje on 11/6/14.
  */
 define(
-    ["../../src/capabilities/CompositionCapability"],
-    function (CompositionCapability) {
+    [
+        "../../src/capabilities/CompositionCapability",
+        "../../src/capabilities/ContextualDomainObject"
+    ],
+    function (CompositionCapability, ContextualDomainObject) {
         "use strict";
 
         var DOMAIN_OBJECT_METHODS = [
@@ -40,6 +43,7 @@ define(
         describe("The composition capability", function () {
             var mockDomainObject,
                 mockInjector,
+                mockContextualize,
                 mockObjectService,
                 composition;
 
@@ -70,11 +74,19 @@ define(
                         return (name === "objectService") && mockObjectService;
                     }
                 };
+                mockContextualize = jasmine.createSpy('contextualize');
+
+                // Provide a minimal (e.g. no error-checking) implementation
+                // of contextualize for simplicity
+                mockContextualize.andCallFake(function (domainObject, parentObject) {
+                    return new ContextualDomainObject(domainObject, parentObject);
+                });
 
                 mockObjectService.getObjects.andReturn(mockPromise([]));
 
                 composition = new CompositionCapability(
                     mockInjector,
+                    mockContextualize,
                     mockDomainObject
                 );
             });

--- a/platform/core/test/services/ContextualizeSpec.js
+++ b/platform/core/test/services/ContextualizeSpec.js
@@ -1,0 +1,90 @@
+/*****************************************************************************
+ * Open MCT Web, Copyright (c) 2014-2015, United States Government
+ * as represented by the Administrator of the National Aeronautics and Space
+ * Administration. All rights reserved.
+ *
+ * Open MCT Web is licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * Open MCT Web includes source code licensed under additional open source
+ * licenses. See the Open Source Licenses file (LICENSES.md) included with
+ * this source code distribution or the Licensing information page available
+ * at runtime from the About dialog for additional information.
+ *****************************************************************************/
+/*global define,Promise,describe,it,expect,beforeEach,waitsFor,jasmine*/
+
+define(
+    ["../../src/services/Contextualize"],
+    function (Contextualize) {
+        "use strict";
+
+        var DOMAIN_OBJECT_METHODS = [
+            'getId',
+            'getModel',
+            'getCapability',
+            'hasCapability',
+            'useCapability'
+        ];
+
+        describe("The 'contextualize' service", function () {
+            var mockLog,
+                mockDomainObject,
+                mockParentObject,
+                testParentModel,
+                contextualize;
+
+            beforeEach(function () {
+                testParentModel = { composition: ["abc"] };
+
+                mockLog = jasmine.createSpyObj(
+                    "$log",
+                    [ "error", "warn", "info", "debug" ]
+                );
+
+                mockDomainObject =
+                    jasmine.createSpyObj('domainObject', DOMAIN_OBJECT_METHODS);
+                mockParentObject =
+                    jasmine.createSpyObj('parentObject', DOMAIN_OBJECT_METHODS);
+
+                mockDomainObject.getId.andReturn("abc");
+                mockDomainObject.getModel.andReturn({});
+                mockParentObject.getId.andReturn("parent");
+                mockParentObject.getModel.andReturn(testParentModel);
+
+                contextualize = new Contextualize(mockLog);
+            });
+
+            it("attaches a context capability", function () {
+                var contextualizedObject =
+                    contextualize(mockDomainObject, mockParentObject);
+
+                expect(contextualizedObject.getId()).toEqual("abc");
+                expect(contextualizedObject.getCapability("context"))
+                    .toBeDefined();
+                expect(contextualizedObject.getCapability("context").getParent())
+                    .toBe(mockParentObject);
+            });
+
+            it("issues a warning if composition does not match", function () {
+                // Precondition - normally it should not issue a warning
+                contextualize(mockDomainObject, mockParentObject);
+                expect(mockLog.warn).not.toHaveBeenCalled();
+
+                testParentModel.composition = ["xyz"];
+
+                contextualize(mockDomainObject, mockParentObject);
+                expect(mockLog.warn).toHaveBeenCalled();
+            });
+
+
+        });
+    }
+);

--- a/platform/core/test/suite.json
+++ b/platform/core/test/suite.json
@@ -24,6 +24,7 @@
     "objects/DomainObject",
     "objects/DomainObjectProvider",
 
+    "services/Contextualize",
     "services/Now",
     "services/Throttle",
     "services/Topic",

--- a/platform/entanglement/bundle.json
+++ b/platform/entanglement/bundle.json
@@ -37,6 +37,12 @@
                 "type": "decorator",
                 "provides": "creationService",
                 "implementation": "services/LocatingCreationDecorator.js"
+            },
+            {
+                "type": "decorator",
+                "provides": "objectService",
+                "implementation": "services/LocatingObjectDecorator.js",
+                "depends": ["contextualize", "$q", "$log"]
             }
         ],
         "controllers": [

--- a/platform/entanglement/src/services/LocatingObjectDecorator.js
+++ b/platform/entanglement/src/services/LocatingObjectDecorator.js
@@ -1,0 +1,88 @@
+/*****************************************************************************
+ * Open MCT Web, Copyright (c) 2014-2015, United States Government
+ * as represented by the Administrator of the National Aeronautics and Space
+ * Administration. All rights reserved.
+ *
+ * Open MCT Web is licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * Open MCT Web includes source code licensed under additional open source
+ * licenses. See the Open Source Licenses file (LICENSES.md) included with
+ * this source code distribution or the Licensing information page available
+ * at runtime from the About dialog for additional information.
+ *****************************************************************************/
+
+/*global define */
+
+define(
+    function () {
+        "use strict";
+
+        /**
+         * Ensures that domain objects are loaded with a context capability
+         * that reflects their location.
+         * @constructor
+         * @implements {ObjectService}
+         * @memberof platform/entanglement
+         */
+        function LocatingObjectDecorator(contextualize, $q, $log, objectService) {
+            this.contextualize = contextualize;
+            this.$log = $log;
+            this.objectService = objectService;
+            this.$q = $q;
+        }
+
+        LocatingObjectDecorator.prototype.getObjects = function (ids) {
+            var $q = this.$q,
+                $log = this.$log,
+                contextualize = this.contextualize,
+                objectService = this.objectService,
+                result = {};
+
+            function loadObjectInContext(id, exclude) {
+                function attachContextById(domainObject, locationId) {
+                    return loadObjectInContext(locationId, exclude)
+                        .then(function (parent) {
+                            return contextualize(domainObject, parent);
+                        });
+                }
+
+                function attachContextForLocation(domainObject) {
+                    var model = domainObject && domainObject.getModel(),
+                        location = (model || {}).location;
+
+                    // Don't pursue a context if we encounter this
+                    // object again during this sequence of invocations.
+                    exclude[id] = true;
+
+                    return location ?
+                            attachContextById(domainObject, location) :
+                            domainObject;
+                }
+
+                return objectService.getObjects([id]).then(function (objects) {
+                    return exclude[id] ?
+                            objects[id] : // Don't loop indefinitely.
+                            attachContextForLocation(objects[id]);
+                });
+            }
+
+            ids.forEach(function (id) {
+                result[id] = loadObjectInContext(id, {});
+            });
+
+            return $q.all(result);
+        };
+
+        return LocatingObjectDecorator;
+    }
+);
+

--- a/platform/entanglement/src/services/LocatingObjectDecorator.js
+++ b/platform/entanglement/src/services/LocatingObjectDecorator.js
@@ -69,9 +69,18 @@ define(
                 }
 
                 return objectService.getObjects([id]).then(function (objects) {
-                    return exclude[id] ?
-                            objects[id] : // Don't loop indefinitely.
-                            attachContextForLocation(objects[id]);
+                    if (exclude[id]) {
+                        $log.warn([
+                            "LocatingObjectDecorator detected a cycle",
+                            "while attempted to define a context for",
+                            id + ";",
+                            "no context will be added and unexpected behavior",
+                            "may follow."
+                        ].join(" "));
+                        return objects[id];
+                    }
+
+                    return attachContextForLocation(objects[id]);
                 });
             }
 

--- a/platform/entanglement/test/services/LocatingObjectDecoratorSpec.js
+++ b/platform/entanglement/test/services/LocatingObjectDecoratorSpec.js
@@ -1,0 +1,135 @@
+/*****************************************************************************
+ * Open MCT Web, Copyright (c) 2014-2015, United States Government
+ * as represented by the Administrator of the National Aeronautics and Space
+ * Administration. All rights reserved.
+ *
+ * Open MCT Web is licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * Open MCT Web includes source code licensed under additional open source
+ * licenses. See the Open Source Licenses file (LICENSES.md) included with
+ * this source code distribution or the Licensing information page available
+ * at runtime from the About dialog for additional information.
+ *****************************************************************************/
+
+/*global define,describe,beforeEach,it,jasmine,expect */
+
+define(
+    [
+        '../../src/services/LocatingObjectDecorator'
+    ],
+    function (LocatingObjectDecorator) {
+        "use strict";
+
+        describe("LocatingObjectDecorator", function () {
+            var mockContextualize,
+                mockQ,
+                mockLog,
+                mockObjectService,
+                mockCallback,
+                testObjects,
+                testModels,
+                decorator;
+
+            function testPromise(v) {
+                return (v || {}).then ? v : {
+                    then: function (callback) {
+                        return testPromise(callback(v));
+                    }
+                };
+            }
+
+            beforeEach(function () {
+                // A <- B <- C
+                // D <-> E, to verify cycle detection
+                testModels = {
+                    a: { name: "A" },
+                    b: { name: "B", location: "a" },
+                    c: { name: "C", location: "b" },
+                    d: { name: "D", location: "e" },
+                    e: { name: "E", location: "d" }
+                };
+                testObjects = {};
+
+                mockContextualize = jasmine.createSpy("contextualize");
+                mockQ = jasmine.createSpyObj("$q", ["when", "all"]);
+                mockLog =
+                    jasmine.createSpyObj("$log", ["error", "warn", "info", "debug"]);
+                mockObjectService =
+                    jasmine.createSpyObj("objectService", ["getObjects"]);
+
+                mockContextualize.andCallFake(function (domainObject, parentObject) {
+                    // Not really what contextualize does, but easy to test!
+                    return {
+                        testObject: domainObject,
+                        testParent: parentObject
+                    };
+                });
+
+                mockQ.when.andCallFake(testPromise);
+                mockQ.all.andCallFake(function (promises) {
+                    var result = {};
+                    Object.keys(promises).forEach(function (k) {
+                        promises[k].then(function (v) { result[k] = v; });
+                    });
+                    return testPromise(result);
+                });
+
+                mockObjectService.getObjects.andReturn(testPromise(testObjects));
+
+                mockCallback = jasmine.createSpy("callback");
+
+                Object.keys(testModels).forEach(function (id) {
+                    testObjects[id] = jasmine.createSpyObj(
+                        "domainObject-" + id,
+                        [ "getId", "getModel", "getCapability" ]
+                    );
+                    testObjects[id].getId.andReturn(id);
+                    testObjects[id].getModel.andReturn(testModels[id]);
+                });
+
+                decorator = new LocatingObjectDecorator(
+                    mockContextualize,
+                    mockQ,
+                    mockLog,
+                    mockObjectService
+                );
+            });
+
+            it("contextualizes domain objects by location", function () {
+                decorator.getObjects(['b', 'c']).then(mockCallback);
+                expect(mockCallback).toHaveBeenCalledWith({
+                    b: {
+                        testObject: testObjects.b,
+                        testParent: testObjects.a
+                    },
+                    c: {
+                        testObject: testObjects.c,
+                        testParent: {
+                            testObject: testObjects.b,
+                            testParent: testObjects.a
+                        }
+                    }
+                });
+            });
+
+            it("warns on cycle detection", function () {
+                // Base case, no cycle, no warning
+                decorator.getObjects(['a', 'b', 'c']);
+                expect(mockLog.warn).not.toHaveBeenCalled();
+
+                decorator.getObjects(['e']);
+                expect(mockLog.warn).toHaveBeenCalled();
+            });
+
+        });
+    }
+);

--- a/platform/entanglement/test/suite.json
+++ b/platform/entanglement/test/suite.json
@@ -5,5 +5,6 @@
     "services/MoveService",
     "services/LocationService",
     "services/LocatingCreationDecorator",
+    "services/LocatingObjectDecorator",
     "capabilities/LocationCapability"
 ]


### PR DESCRIPTION
When objects have a defined `location`, use this to construct a default `context` (which may be overridden by the `composition` capability later - or it may not.)

Summary of changes:
* Separate out contextualization of domain objects from the `composition` capability into a separate verb-like service `contextualize`
  * Attempting to leverage `composition` for this task directly from the `objectService` decorator in the next bullet would result in O(n^2) behavior at best (where n is tree depth), since `composition` also _uses_ the `objectService`
* Add an `objectService` decorator to the `platform/entanglement` bundle that places loaded objects in the context of their `location` (using `contextualize` from above)

### Author Checklist

1. Changes address original issue? Y
2. Unit tests included and/or updated with changes? Y
3. Command line build passes? Y
4. Expect to pass code review? Y