### PR TITLE
[Persistence] Include timestamp on creation

### DIFF
--- a/platform/commonUI/browse/bundle.json
+++ b/platform/commonUI/browse/bundle.json
@@ -142,7 +142,7 @@
                 "provides": "creationService",
                 "type": "provider",
                 "implementation": "creation/CreationService.js",
-                "depends": [ "persistenceService", "$q", "$log" ]
+                "depends": [ "persistenceService", "now", "$q", "$log" ]
             }
         ],
         "runs": [

--- a/platform/commonUI/browse/src/creation/CreationService.js
+++ b/platform/commonUI/browse/src/creation/CreationService.js
@@ -42,10 +42,11 @@ define(
          * @memberof platform/commonUI/browse
          * @constructor
          */
-        function CreationService(persistenceService, $q, $log) {
+        function CreationService(persistenceService, now, $q, $log) {
             this.persistenceService = persistenceService;
             this.$q = $q;
             this.$log = $log;
+            this.now = now;
         }
 
         /**
@@ -133,6 +134,7 @@ define(
             // 2. Create a model with that ID in the persistence space
             // 3. Add that ID to
             return self.$q.when(uuid()).then(function (id) {
+                model.persisted = self.now();
                 return doPersist(persistence.getSpace(), id, model);
             }).then(function (id) {
                 return addToComposition(id, parent, persistence);

--- a/platform/commonUI/browse/test/creation/CreationServiceSpec.js
+++ b/platform/commonUI/browse/test/creation/CreationServiceSpec.js
@@ -31,6 +31,7 @@ define(
 
         describe("The creation service", function () {
             var mockPersistenceService,
+                mockNow,
                 mockQ,
                 mockLog,
                 mockParentObject,
@@ -63,6 +64,7 @@ define(
                     "persistenceService",
                     [ "createObject" ]
                 );
+                mockNow = jasmine.createSpy('now');
                 mockQ = { when: mockPromise, reject: mockReject };
                 mockLog = jasmine.createSpyObj(
                     "$log",
@@ -103,6 +105,8 @@ define(
                     mockPromise(true)
                 );
 
+                mockNow.andReturn(12321);
+
                 mockParentObject.getCapability.andCallFake(function (key) {
                     return mockCapabilities[key];
                 });
@@ -123,6 +127,7 @@ define(
 
                 creationService = new CreationService(
                     mockPersistenceService,
+                    mockNow,
                     mockQ,
                     mockLog
                 );
@@ -199,6 +204,12 @@ define(
                 creationService.createObject(model, mockParentObject);
 
                 expect(mockLog.error).toHaveBeenCalled();
+            });
+
+            it("attaches a 'persisted' timestamp", function () {
+                var model = { someKey: "some value" };
+                creationService.createObject(model, mockParentObject);
+                expect(model.persisted).toEqual(mockNow());
             });
 
         });


### PR DESCRIPTION
Include a persisted timestamp when an object is first
created. nasa/openmctweb#139