### PR TITLE
[Search] Improve generic search performance

### DIFF
--- a/example/profiling/bundle.json
+++ b/example/profiling/bundle.json
@@ -4,6 +4,10 @@
             {
                 "implementation": "WatchIndicator.js",
                 "depends": ["$interval", "$rootScope"]
+            },
+            {
+                "implementation": "DigestIndicator.js",
+                "depends": ["$interval", "$rootScope"]
             }
         ]
     }

--- a/example/profiling/src/DigestIndicator.js
+++ b/example/profiling/src/DigestIndicator.js
@@ -1,0 +1,77 @@
+/*****************************************************************************
+ * Open MCT Web, Copyright (c) 2014-2015, United States Government
+ * as represented by the Administrator of the National Aeronautics and Space
+ * Administration. All rights reserved.
+ *
+ * Open MCT Web is licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * Open MCT Web includes source code licensed under additional open source
+ * licenses. See the Open Source Licenses file (LICENSES.md) included with
+ * this source code distribution or the Licensing information page available
+ * at runtime from the About dialog for additional information.
+ *****************************************************************************/
+/*global define*/
+
+define(
+    [],
+    function () {
+        "use strict";
+
+        /**
+         * Displays the number of digests that have occurred since the
+         * indicator was first instantiated.
+         * @constructor
+         * @param $interval Angular's $interval
+         * @implements {Indicator}
+         */
+        function DigestIndicator($interval, $rootScope) {
+            var digests = 0,
+                displayed = 0,
+                start = Date.now();
+
+            function update() {
+                var secs = (Date.now() - start) / 1000;
+                displayed = Math.round(digests / secs);
+            }
+
+            function increment() {
+                digests += 1;
+            }
+
+            $rootScope.$watch(increment);
+
+            // Update state every second
+            $interval(update, 1000);
+
+            // Provide initial state, too
+            update();
+
+            return {
+                getGlyph: function () {
+                    return ".";
+                },
+                getGlyphClass: function () {
+                    return undefined;
+                },
+                getText: function () {
+                    return displayed + " digests/sec";
+                },
+                getDescription: function () {
+                    return "";
+                }
+            };
+        }
+
+        return DigestIndicator;
+
+    }
+);

--- a/platform/core/src/capabilities/MutationCapability.js
+++ b/platform/core/src/capabilities/MutationCapability.js
@@ -171,7 +171,7 @@ define(
          * @memberof platform/core.MutationCapability#
          */
         MutationCapability.prototype.listen = function (listener) {
-            return this.mutationTopic.listen(listener);
+            return this.specificMutationTopic.listen(listener);
         };
 
         /**

--- a/platform/core/src/capabilities/MutationCapability.js
+++ b/platform/core/src/capabilities/MutationCapability.js
@@ -127,9 +127,7 @@ define(
                 useTimestamp = arguments.length > 1;
 
             function notifyListeners(model) {
-                // Broadcast a general event...
                 generalTopic.notify(domainObject);
-                // ...and also notify listeners watching this specific object.
                 specificTopic.notify(model);
             }
 

--- a/platform/core/src/capabilities/MutationCapability.js
+++ b/platform/core/src/capabilities/MutationCapability.js
@@ -29,7 +29,8 @@ define(
     function () {
         "use strict";
 
-        var TOPIC_PREFIX = "mutation:";
+        var GENERAL_TOPIC = "mutation",
+            TOPIC_PREFIX = "mutation:";
 
         // Utility function to overwrite a destination object
         // with the contents of a source object.
@@ -78,7 +79,11 @@ define(
          * @implements {Capability}
          */
         function MutationCapability(topic, now, domainObject) {
-            this.mutationTopic = topic(TOPIC_PREFIX + domainObject.getId());
+            this.generalMutationTopic =
+                topic(GENERAL_TOPIC);
+            this.specificMutationTopic =
+                topic(TOPIC_PREFIX + domainObject.getId());
+
             this.now = now;
             this.domainObject = domainObject;
         }
@@ -115,10 +120,18 @@ define(
             // mutator function has a temporary copy to work with.
             var domainObject = this.domainObject,
                 now = this.now,
-                t = this.mutationTopic,
+                generalTopic = this.generalMutationTopic,
+                specificTopic = this.specificMutationTopic,
                 model = domainObject.getModel(),
                 clone = JSON.parse(JSON.stringify(model)),
                 useTimestamp = arguments.length > 1;
+
+            function notifyListeners(model) {
+                // Broadcast a general event...
+                generalTopic.notify(domainObject);
+                // ...and also notify listeners watching this specific object.
+                specificTopic.notify(model);
+            }
 
             // Function to handle copying values to the actual
             function handleMutation(mutationResult) {
@@ -136,7 +149,7 @@ define(
                         copyValues(model, result);
                     }
                     model.modified = useTimestamp ? timestamp : now();
-                    t.notify(model);
+                    notifyListeners(model);
                 }
 
                 // Report the result of the mutation

--- a/platform/core/src/services/Throttle.js
+++ b/platform/core/src/services/Throttle.js
@@ -61,18 +61,14 @@ define(
              * @memberof platform/core.Throttle#
              */
             return function (fn, delay, apply) {
-                var activeTimeout,
+                var promise, // Promise for the result of throttled function
                     args = [];
 
-                // Clear active timeout, so that next invocation starts
-                // a new one.
-                function clearActiveTimeout() {
-                    activeTimeout = undefined;
-                }
-
-                // Invoke the function with the latest supplied arguments.
                 function invoke() {
-                    fn.apply(null, args);
+                    // Clear the active timeout so a new one starts next time.
+                    promise = undefined;
+                    // Invoke the function with the latest supplied arguments.
+                    return fn.apply(null, args);
                 }
 
                 // Defaults
@@ -83,13 +79,10 @@ define(
                     // Store arguments from this invocation
                     args = Array.prototype.slice.apply(arguments, [0]);
                     // Start a timeout if needed
-                    if (!activeTimeout) {
-                        activeTimeout = $timeout(invoke, delay, apply);
-                        activeTimeout.then(clearActiveTimeout);
-                    }
+                    promise = promise || $timeout(invoke, delay, apply);
                     // Return whichever timeout is active (to get
                     // a promise for the results of fn)
-                    return activeTimeout;
+                    return promise;
                 };
             };
         }

--- a/platform/core/src/services/Throttle.js
+++ b/platform/core/src/services/Throttle.js
@@ -61,7 +61,7 @@ define(
              * @memberof platform/core.Throttle#
              */
             return function (fn, delay, apply) {
-                var promise, // Promise for the result of throttled function
+                var promise,
                     args = [];
 
                 function invoke() {

--- a/platform/core/test/services/ThrottleSpec.js
+++ b/platform/core/test/services/ThrottleSpec.js
@@ -45,7 +45,9 @@ define(
                 // Verify precondition: Not called at throttle-time
                 expect(mockTimeout).not.toHaveBeenCalled();
                 expect(throttled()).toEqual(mockPromise);
-                expect(mockTimeout).toHaveBeenCalledWith(mockFn, 0, false);
+                expect(mockFn).not.toHaveBeenCalled();
+                expect(mockTimeout)
+                    .toHaveBeenCalledWith(jasmine.any(Function), 0, false);
             });
 
             it("schedules only one timeout at a time", function () {
@@ -59,10 +61,11 @@ define(
             it("schedules additional invocations after resolution", function () {
                 var throttled = throttle(mockFn);
                 throttled();
-                mockPromise.then.mostRecentCall.args[0](); // Resolve timeout
+                mockTimeout.mostRecentCall.args[0](); // Resolve timeout
                 throttled();
-                mockPromise.then.mostRecentCall.args[0]();
+                mockTimeout.mostRecentCall.args[0]();
                 throttled();
+                mockTimeout.mostRecentCall.args[0]();
                 expect(mockTimeout.calls.length).toEqual(3);
             });
         });

--- a/platform/search/bundle.json
+++ b/platform/search/bundle.json
@@ -45,7 +45,14 @@
                 "provides": "searchService",
                 "type": "provider",
                 "implementation": "services/GenericSearchProvider.js",
-                "depends": [ "$q", "$timeout", "objectService", "workerService", "GENERIC_SEARCH_ROOTS" ]
+                "depends": [
+                    "$q",
+                    "$timeout",
+                    "objectService",
+                    "workerService",
+                    "topic",
+                    "GENERIC_SEARCH_ROOTS"
+                ]
             },
             {
                 "provides": "searchService",

--- a/platform/search/bundle.json
+++ b/platform/search/bundle.json
@@ -47,6 +47,7 @@
                 "implementation": "services/GenericSearchProvider.js",
                 "depends": [
                     "$q",
+                    "$log",
                     "throttle",
                     "objectService",
                     "workerService",

--- a/platform/search/bundle.json
+++ b/platform/search/bundle.json
@@ -47,7 +47,7 @@
                 "implementation": "services/GenericSearchProvider.js",
                 "depends": [
                     "$q",
-                    "$timeout",
+                    "throttle",
                     "objectService",
                     "workerService",
                     "topic",

--- a/platform/search/src/services/GenericSearchProvider.js
+++ b/platform/search/src/services/GenericSearchProvider.js
@@ -41,6 +41,7 @@ define(
          *
          * @constructor
          * @param $q Angular's $q, for promise consolidation.
+         * @param $log Anglar's $log, for logging.
          * @param {Function} throttle a function to throttle function invocations
          * @param {ObjectService} objectService The service from which
          *        domain objects can be gotten.
@@ -49,12 +50,13 @@ define(
          * @param {GENERIC_SEARCH_ROOTS} ROOTS An array of the root
          *        domain objects' IDs.
          */
-        function GenericSearchProvider($q, throttle, objectService, workerService, topic, ROOTS) {
+        function GenericSearchProvider($q, $log, throttle, objectService, workerService, topic, ROOTS) {
             var indexed = {},
                 pendingQueries = {},
                 toIndex = {},
                 worker = workerService.run('genericSearchWorker'),
                 mutationTopic = topic("mutation"),
+                indexingStarted = Date.now(),
                 scheduleFlush;
 
             this.worker = worker;
@@ -132,6 +134,11 @@ define(
                 });
 
                 if (ids.length < 1) {
+                    $log.info([
+                        'GenericSearch finished indexing after ',
+                        ((Date.now() - indexingStarted) / 1000).toFixed(2),
+                        ' seconds.'
+                    ].join(''));
                     return;
                 }
 

--- a/platform/search/src/services/GenericSearchProvider.js
+++ b/platform/search/src/services/GenericSearchProvider.js
@@ -126,13 +126,23 @@ define(
                     indexItem(node);
                     indexed[id] = true;
 
+
                     // If this node has children, index those
                     if (node && node.hasCapability && node.hasCapability('composition')) {
                         // Make sure that this is async, so doesn't block up page
                         $timeout(function () {
                             // Get the children...
-                            node.useCapability('composition').then(indexItems);
-                        }, 0, false);
+                            node.useCapability('composition').then(function (children) {
+                                $timeout(function () {
+                                    // ... then index the children
+                                    if (children.constructor === Array) {
+                                        indexItems(children);
+                                    } else {
+                                        indexItems([children]);
+                                    }
+                                }, 0);
+                            });
+                        }, 0);
                     }
                 });
             }

--- a/platform/search/src/services/GenericSearchProvider.js
+++ b/platform/search/src/services/GenericSearchProvider.js
@@ -126,23 +126,13 @@ define(
                     indexItem(node);
                     indexed[id] = true;
 
-
                     // If this node has children, index those
                     if (node && node.hasCapability && node.hasCapability('composition')) {
                         // Make sure that this is async, so doesn't block up page
                         $timeout(function () {
                             // Get the children...
-                            node.useCapability('composition').then(function (children) {
-                                $timeout(function () {
-                                    // ... then index the children
-                                    if (children.constructor === Array) {
-                                        indexItems(children);
-                                    } else {
-                                        indexItems([children]);
-                                    }
-                                }, 0);
-                            });
-                        }, 0);
+                            node.useCapability('composition').then(indexItems);
+                        }, 0, false);
                     }
                 });
             }

--- a/platform/search/src/services/GenericSearchProvider.js
+++ b/platform/search/src/services/GenericSearchProvider.js
@@ -171,6 +171,7 @@ define(
 
             // Re-index items when they are mutated
             mutationTopic.listen(function (domainObject) {
+                indexed[domainObject.getId()] = false;
                 indexItems([domainObject]);
             });
         }

--- a/platform/search/src/services/GenericSearchProvider.js
+++ b/platform/search/src/services/GenericSearchProvider.js
@@ -32,7 +32,7 @@ define(
         var DEFAULT_MAX_RESULTS = 100,
             DEFAULT_TIMEOUT = 1000,
             MAX_CONCURRENT_REQUESTS = 100,
-            FLUSH_INTERVAL = 180,
+            FLUSH_INTERVAL = 0,
             stopTime;
 
         /**

--- a/platform/search/src/services/GenericSearchProvider.js
+++ b/platform/search/src/services/GenericSearchProvider.js
@@ -52,6 +52,7 @@ define(
          */
         function GenericSearchProvider($q, $log, throttle, objectService, workerService, topic, ROOTS) {
             var indexed = {},
+                pendingIndex = {},
                 pendingQueries = {},
                 toRequest = [],
                 worker = workerService.run('genericSearchWorker'),
@@ -68,8 +69,9 @@ define(
 
             function scheduleIdsForIndexing(ids) {
                 ids.forEach(function (id) {
-                    if (!indexed[id]) {
+                    if (!indexed[id] && !pendingIndex[id]) {
                         indexed[id] = true;
+                        pendingIndex[id] = true;
                         toRequest.push(id);
                     }
                 });
@@ -129,6 +131,7 @@ define(
             function requestAndIndex(id) {
                 pendingRequests += 1;
                 objectService.getObjects([id]).then(function (objects) {
+                    delete pendingIndex[id];
                     if (objects[id]) {
                         indexItem(objects[id]);
                     }


### PR DESCRIPTION
Addresses #141.

Summary of changes:
* Broadcast mutations on one global topic to avoid the need to attach mutation listeners per-object; this allows components which are interested in observing all mutations (such as GenericSearch) to maintain a single listener, instead of one per object, reducing memory usage.
* Cherry-pick a fix to `throttle` from #104 to resolve a race condition there.
* Change approach to indexing in GenericSearch to (a) avoid the use of capabilities, and (b) spread out requests for objects over time. In both cases, the intent is to reduce the CPU utilization and/or time spent associated with initial indexing. More detail is in comments on #141
* Add an indicator to `example/profiling` to report number of digest cycles per second, to aid in diagnosing performance related issues such as this.

### Author Checklist

1. Changes address original issue? Y
2. Unit tests included and/or updated with changes? Y
3. Command line build passes? Y
4. Expect to pass code review? Y