### PR TITLE
[Entanglement] Add "Go To Original" action

### DIFF
--- a/platform/entanglement/bundle.json
+++ b/platform/entanglement/bundle.json
@@ -52,7 +52,8 @@
                 "key": "location",
                 "name": "Location Capability",
                 "description": "Provides a capability for retrieving the location of an object based upon it's context.",
-                "implementation": "capabilities/LocationCapability"
+                "implementation": "capabilities/LocationCapability",
+                "depends": [ "$q", "$injector" ]
             }
         ],
         "services": [

--- a/platform/entanglement/bundle.json
+++ b/platform/entanglement/bundle.json
@@ -30,6 +30,14 @@
                 "category": "contextual",
                 "implementation": "actions/LinkAction.js",
                 "depends": ["locationService", "linkService"]
+            },
+            {
+                "key": "follow",
+                "name": "Go To Original",
+                "description": "Go to the original, un-linked instance of this object.",
+                "glyph": "\u00F4",
+                "category": "contextual",
+                "implementation": "actions/GoToOriginalAction.js"
             }
         ],
         "components": [

--- a/platform/entanglement/src/actions/GoToOriginalAction.js
+++ b/platform/entanglement/src/actions/GoToOriginalAction.js
@@ -1,0 +1,62 @@
+/*****************************************************************************
+ * Open MCT Web, Copyright (c) 2014-2015, United States Government
+ * as represented by the Administrator of the National Aeronautics and Space
+ * Administration. All rights reserved.
+ *
+ * Open MCT Web is licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * Open MCT Web includes source code licensed under additional open source
+ * licenses. See the Open Source Licenses file (LICENSES.md) included with
+ * this source code distribution or the Licensing information page available
+ * at runtime from the About dialog for additional information.
+ *****************************************************************************/
+
+/*global define */
+define(
+    function () {
+        "use strict";
+
+        /**
+         * Implements the "Go To Original" action, which follows a link back
+         * to an original instance of an object.
+         *
+         * @implements {Action}
+         * @constructor
+         * @private
+         * @memberof platform/entanglement
+         * @param {ActionContext} context the context in which the action
+         *        will be performed
+         */
+        function GoToOriginalAction(context) {
+            this.domainObject = context.domainObject;
+        }
+
+        GoToOriginalAction.prototype.perform = function () {
+            return this.domainObject.getCapability("location").getOriginal()
+                .then(function (originalObject) {
+                    var actionCapability =
+                        originalObject.getCapability("action");
+                    return actionCapability &&
+                            actionCapability.perform("navigate");
+                });
+        };
+
+        GoToOriginalAction.appliesTo = function (context) {
+            var domainObject = context.domainObject;
+            return domainObject && domainObject.hasCapability("location")
+                && domainObject.getCapability("location").isLink();
+        };
+
+        return GoToOriginalAction;
+    }
+);
+

--- a/platform/entanglement/src/capabilities/LocationCapability.js
+++ b/platform/entanglement/src/capabilities/LocationCapability.js
@@ -12,10 +12,40 @@ define(
          *
          * @constructor
          */
-        function LocationCapability(domainObject) {
+        function LocationCapability($q, $injector, domainObject) {
             this.domainObject = domainObject;
+            this.$q = $q;
+            this.$injector = $injector;
             return this;
         }
+
+        /**
+         * Get an instance of this domain object in its original location.
+         *
+         * @returns {Promise.<DomainObject>} a promise for the original
+         *          instance of this domain object
+         */
+        LocationCapability.prototype.getOriginal = function () {
+            var id;
+
+            if (this.isOriginal()) {
+                return this.$q.when(this.domainObject);
+            }
+
+            id = this.domainObject.getId();
+
+            this.objectService =
+                this.objectService || this.$injector.get("objectService");
+
+            // Assume that an object will be correctly contextualized when
+            // loaded directly from the object service; this is true
+            // so long as LocatingObjectDecorator is present, and that
+            // decorator is also contained in this bundle.
+            return this.objectService.getObjects([id])
+                .then(function (objects) {
+                    return objects[id];
+                });
+        };
 
         /**
          * Set the primary location (the parent id) of the current domain
@@ -78,10 +108,6 @@ define(
             return !this.isLink();
         };
 
-        function createLocationCapability(domainObject) {
-            return new LocationCapability(domainObject);
-        }
-
-        return createLocationCapability;
+        return LocationCapability;
     }
 );

--- a/platform/entanglement/src/capabilities/LocationCapability.js
+++ b/platform/entanglement/src/capabilities/LocationCapability.js
@@ -1,3 +1,25 @@
+/*****************************************************************************
+ * Open MCT Web, Copyright (c) 2014-2015, United States Government
+ * as represented by the Administrator of the National Aeronautics and Space
+ * Administration. All rights reserved.
+ *
+ * Open MCT Web is licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * Open MCT Web includes source code licensed under additional open source
+ * licenses. See the Open Source Licenses file (LICENSES.md) included with
+ * this source code distribution or the Licensing information page available
+ * at runtime from the About dialog for additional information.
+ *****************************************************************************/
+
 /*global define */
 
 define(

--- a/platform/entanglement/test/actions/GoToOriginalActionSpec.js
+++ b/platform/entanglement/test/actions/GoToOriginalActionSpec.js
@@ -1,0 +1,95 @@
+/*****************************************************************************
+ * Open MCT Web, Copyright (c) 2014-2015, United States Government
+ * as represented by the Administrator of the National Aeronautics and Space
+ * Administration. All rights reserved.
+ *
+ * Open MCT Web is licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * Open MCT Web includes source code licensed under additional open source
+ * licenses. See the Open Source Licenses file (LICENSES.md) included with
+ * this source code distribution or the Licensing information page available
+ * at runtime from the About dialog for additional information.
+ *****************************************************************************/
+
+/*global define,describe,beforeEach,it,jasmine,expect */
+
+define(
+    [
+        '../../src/actions/GoToOriginalAction',
+        '../DomainObjectFactory',
+        '../ControlledPromise'
+    ],
+    function (GoToOriginalAction, domainObjectFactory, ControlledPromise) {
+        'use strict';
+
+        describe("The 'go to original' action", function () {
+            var testContext,
+                originalDomainObject,
+                mockLocationCapability,
+                mockOriginalActionCapability,
+                originalPromise,
+                action;
+
+            beforeEach(function () {
+                mockLocationCapability = jasmine.createSpyObj(
+                    'location',
+                    [ 'isLink', 'isOriginal', 'getOriginal' ]
+                );
+                mockOriginalActionCapability = jasmine.createSpyObj(
+                    'action',
+                    [ 'perform', 'getActions' ]
+                );
+                originalPromise = new ControlledPromise();
+                mockLocationCapability.getOriginal.andReturn(originalPromise);
+                mockLocationCapability.isLink.andReturn(true);
+                mockLocationCapability.isOriginal.andCallFake(function () {
+                    return !mockLocationCapability.isLink();
+                });
+                testContext = {
+                    domainObject: domainObjectFactory({
+                        capabilities: {
+                            location: mockLocationCapability
+                        }
+                    })
+                };
+                originalDomainObject = domainObjectFactory({
+                    capabilities: {
+                        action: mockOriginalActionCapability
+                    }
+                });
+
+                action = new GoToOriginalAction(testContext);
+            });
+
+            it("is applicable to links", function () {
+                expect(GoToOriginalAction.appliesTo(testContext))
+                    .toBeTruthy();
+            });
+
+            it("is not applicable to originals", function () {
+                mockLocationCapability.isLink.andReturn(false);
+                expect(GoToOriginalAction.appliesTo(testContext))
+                    .toBeFalsy();
+            });
+
+            it("navigates to original objects when performed", function () {
+                expect(mockOriginalActionCapability.perform)
+                    .not.toHaveBeenCalled();
+                action.perform();
+                originalPromise.resolve(originalDomainObject);
+                expect(mockOriginalActionCapability.perform)
+                    .toHaveBeenCalledWith('navigate');
+            });
+
+        });
+    }
+);

--- a/platform/entanglement/test/capabilities/LocationCapabilitySpec.js
+++ b/platform/entanglement/test/capabilities/LocationCapabilitySpec.js
@@ -1,3 +1,25 @@
+/*****************************************************************************
+ * Open MCT Web, Copyright (c) 2014-2015, United States Government
+ * as represented by the Administrator of the National Aeronautics and Space
+ * Administration. All rights reserved.
+ *
+ * Open MCT Web is licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * Open MCT Web includes source code licensed under additional open source
+ * licenses. See the Open Source Licenses file (LICENSES.md) included with
+ * this source code distribution or the Licensing information page available
+ * at runtime from the About dialog for additional information.
+ *****************************************************************************/
+
 /*global define,describe,it,expect,beforeEach,jasmine */
 
 define(

--- a/platform/entanglement/test/capabilities/LocationCapabilitySpec.js
+++ b/platform/entanglement/test/capabilities/LocationCapabilitySpec.js
@@ -7,6 +7,7 @@ define(
         '../ControlledPromise'
     ],
     function (LocationCapability, domainObjectFactory, ControlledPromise) {
+        'use strict';
 
         describe("LocationCapability", function () {
 
@@ -14,13 +15,16 @@ define(
                 var locationCapability,
                     persistencePromise,
                     mutationPromise,
+                    mockQ,
+                    mockInjector,
+                    mockObjectService,
                     domainObject;
 
                 beforeEach(function () {
                     domainObject = domainObjectFactory({
                         capabilities: {
                             context: {
-                                getParent: function() {
+                                getParent: function () {
                                     return domainObjectFactory({id: 'root'});
                                 }
                             },
@@ -34,6 +38,11 @@ define(
                             )
                         }
                     });
+
+                    mockQ = jasmine.createSpyObj("$q", ["when"]);
+                    mockInjector = jasmine.createSpyObj("$injector", ["get"]);
+                    mockObjectService =
+                        jasmine.createSpyObj("objectService", ["getObjects"]);
 
                     persistencePromise = new ControlledPromise();
                     domainObject.capabilities.persistence.persist.andReturn(
@@ -49,7 +58,11 @@ define(
                         }
                     );
 
-                    locationCapability = new LocationCapability(domainObject);
+                    locationCapability = new LocationCapability(
+                        mockQ,
+                        mockObjectService,
+                        domainObject
+                    );
                 });
 
                 it("returns contextual location", function () {

--- a/platform/entanglement/test/suite.json
+++ b/platform/entanglement/test/suite.json
@@ -1,5 +1,6 @@
 [
     "actions/AbstractComposeAction",
+    "actions/GoToOriginalAction",
     "services/CopyService",
     "services/LinkService",
     "services/MoveService",

--- a/platform/entanglement/test/suite.json
+++ b/platform/entanglement/test/suite.json
@@ -1,6 +1,9 @@
 [
     "actions/AbstractComposeAction",
+    "actions/CopyAction",
     "actions/GoToOriginalAction",
+    "actions/LinkAction",
+    "actions/MoveAction",
     "services/CopyService",
     "services/LinkService",
     "services/MoveService",


### PR DESCRIPTION
Adds a "Go To Original" action which navigates to an original instance of an object; see #147 

Summary of changes:

* Add a `getOriginal` method to `LocationCapability` which loads the original instance of an object.
  * This implementation relies upon `objectService` to return correctly-located originals; this is assured by `LocatingObjectDecorator` in the same bundle.
  * To avoid circular dependencies, a reference to `objectService` is obtained via the `$injector` instead of through normal means.
* Add a "Go To Original" action which performs a `navigate` action upon the original object instance.
* [Removed wrapper around `LocationCapability` constructor](https://github.com/nasa/openmctweb/pull/175/files#diff-2b5d6c42d31f28106f181af11fa6ad74L81); this is no longer necessary after b1654f70

Not directly related, but noted some specs (for Move, Copy, and Link actions) had been omitted from `suite.json` in this bundle; restored these, found that all are still passing, so including with this change set.