### PR TITLE
[Documentation] Add table of contents

### DIFF
--- a/docs/gendocs.js
+++ b/docs/gendocs.js
@@ -30,7 +30,8 @@
 var CONSTANTS = {
         DIAGRAM_WIDTH: 800,
         DIAGRAM_HEIGHT: 500
-    };
+    },
+    TOC_HEAD = "# Table of Contents";
 
 GLOBAL.window = GLOBAL.window ||  GLOBAL; // nomnoml expects window to be defined
 (function () {
@@ -44,6 +45,7 @@ GLOBAL.window = GLOBAL.window ||  GLOBAL; // nomnoml expects window to be define
         split = require("split"),
         stream = require("stream"),
         nomnoml = require('nomnoml'),
+        toc = require("markdown-toc"),
         Canvas = require('canvas'),
         options = require("minimist")(process.argv.slice(2));
 
@@ -110,6 +112,9 @@ GLOBAL.window = GLOBAL.window ||  GLOBAL; // nomnoml expects window to be define
             done();
         };
         transform._flush = function (done) {
+            // Prepend table of contents
+            markdown =
+                [ TOC_HEAD, toc(markdown).content, "", markdown ].join("\n");
             this.push("<html><body>\n");
             this.push(marked(markdown));
             this.push("\n</body></html>\n");
@@ -133,8 +138,8 @@ GLOBAL.window = GLOBAL.window ||  GLOBAL; // nomnoml expects window to be define
         customRenderer.link = function (href, title, text) {
             // ...but only if they look like relative paths
             return (href || "").indexOf(":") === -1 && href[0] !== "/" ?
-                renderer.link(href.replace(/\.md/, ".html"), title, text) :
-                renderer.link.apply(renderer, arguments);
+                    renderer.link(href.replace(/\.md/, ".html"), title, text) :
+                    renderer.link.apply(renderer, arguments);
         };
         return customRenderer;
     }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "split": "^1.0.0",
     "mkdirp": "^0.5.1",
     "nomnoml": "^0.0.3",
-    "canvas": "^1.2.7"
+    "canvas": "^1.2.7",
+    "markdown-toc": "^0.11.7"
   },
   "scripts": {
     "start": "node app.js",


### PR DESCRIPTION
Add table of contents to generated documents, without
modifying document sources; nasa/openmctweb#189.

Summary of changes:
* Add table of contents using [markdown-toc](https://github.com/jonschlinkert/markdown-toc)
* Normalize whitespace