### PR TITLE
[Time Controller] Allow text entry of dates

### DIFF
--- a/platform/commonUI/general/res/templates/controls/time-controller.html
+++ b/platform/commonUI/general/res/templates/controls/time-controller.html
@@ -25,7 +25,10 @@
         <span class="l-time-range-input" ng-controller="ToggleController as t1">
             <!--<span class="lbl">Start</span>-->
             <span class="s-btn time-range-start">
-                <input type="text" ng-model="boundsModel.start"></input>
+                <input type="text"
+                       ng-model="boundsModel.start"
+                       ng-class="{ error: !boundsModel.startValid }">
+                </input>
                 <a class="ui-symbol icon icon-calendar" ng-click="t1.toggle()"></a>
                 <mct-popup ng-if="t1.isActive()">
                     <div mct-click-elsewhere="t1.setState(false)">
@@ -44,7 +47,10 @@
         <span class="l-time-range-input" ng-controller="ToggleController as t2">
             <!--<span class="lbl">End</span>-->
             <span class="s-btn l-time-range-input">
-                <input type="text" ng-model="boundsModel.end"></input>
+                <input type="text"
+                       ng-model="boundsModel.end"
+                       ng-class="{ error: !boundsModel.endValid }">
+                </input>
                 <a class="ui-symbol icon icon-calendar" ng-click="t2.toggle()">
                 </a>
                 <mct-popup ng-if="t2.isActive()">

--- a/platform/commonUI/general/res/templates/controls/time-controller.html
+++ b/platform/commonUI/general/res/templates/controls/time-controller.html
@@ -21,82 +21,84 @@
 -->
 <!-- MINE -->
 <div class="l-time-controller" ng-controller="TimeRangeController">
-	<div class="l-time-range-inputs-holder">
-		<span class="l-time-range-inputs-elem ui-symbol type-icon">&#x43;</span>
-	    <span class="l-time-range-input" ng-controller="ToggleController as t1">
-	        <!--<span class="lbl">Start</span>-->
-		    <span class="s-btn time-range-start" ng-click="t1.toggle()">
-		        <span class="val">{{startOuterText}}</span>
-	            <a class="ui-symbol icon icon-calendar"></a>
-	            <mct-popup ng-if="t1.isActive()">
-		            <div mct-click-elsewhere="t1.setState(false)">
-			            <mct-control key="'datetime-picker'"
-			                         ng-model="ngModel.outer"
-			                         field="'start'"
-			                         options="{ hours: true }">
-			            </mct-control>
-		            </div>
-	            </mct-popup>
-		    </span>
-	    </span>
+    <div class="l-time-range-inputs-holder">
+        <span class="l-time-range-inputs-elem ui-symbol type-icon">&#x43;</span>
+        <span class="l-time-range-input" ng-controller="ToggleController as t1">
+            <!--<span class="lbl">Start</span>-->
+            <span class="s-btn time-range-start">
+                <input type="text" ng-model="boundsModel.start"></input>
+                <a class="ui-symbol icon icon-calendar" ng-click="t1.toggle()">
+                </a>
+                <mct-popup ng-if="t1.isActive()">
+                    <div mct-click-elsewhere="t1.setState(false)">
+                        <mct-control key="'datetime-picker'"
+                                     ng-model="ngModel.outer"
+                                     field="'start'"
+                                     options="{ hours: true }">
+                        </mct-control>
+                    </div>
+                </mct-popup>
+            </span>
+        </span>
 
-		<span class="l-time-range-inputs-elem lbl">to</span>
+        <span class="l-time-range-inputs-elem lbl">to</span>
 
-	    <span class="l-time-range-input" ng-controller="ToggleController as t2">
-	        <!--<span class="lbl">End</span>-->
-		    <span class="s-btn l-time-range-input" ng-click="t2.toggle()">
-			    <span class="val">{{endOuterText}}</span>
-	            <a class="ui-symbol icon icon-calendar"></a>
-	            <mct-popup ng-if="t2.isActive()">
-		            <div mct-click-elsewhere="t2.setState(false)">
-			            <mct-control key="'datetime-picker'"
-			                         ng-model="ngModel.outer"
-			                         field="'end'"
-			                         options="{ hours: true }">
-			            </mct-control>
-		            </div>
-	            </mct-popup>
-		    </span>&nbsp;
-	    </span>
-	</div>
+        <span class="l-time-range-input" ng-controller="ToggleController as t2">
+            <!--<span class="lbl">End</span>-->
+            <span class="s-btn l-time-range-input">
+                <input type="text" ng-model="boundsModel.end"></input>
+                <a class="ui-symbol icon icon-calendar" ng-click="t2.toggle()">
+                </a>
+                <mct-popup ng-if="t2.isActive()">
+                    <div mct-click-elsewhere="t2.setState(false)">
+                        <mct-control key="'datetime-picker'"
+                                     ng-model="ngModel.outer"
+                                     field="'end'"
+                                     options="{ hours: true }">
+                        </mct-control>
+                    </div>
+                </mct-popup>
+            </span>&nbsp;
+        </span>
+    </div>
 
-	<div class="l-time-range-slider-holder">
-		<div class="l-time-range-slider">
-			<div class="slider"
-			     mct-resize="spanWidth = bounds.width">
-				<div class="knob knob-l"
-				     mct-drag-down="startLeftDrag()"
-				     mct-drag="leftDrag(delta[0])"
-				     ng-style="{ left: startInnerPct }">
-					<div class="range-value">{{startInnerText}}</div>
-				</div>
-				<div class="knob knob-r"
-				     mct-drag-down="startRightDrag()"
-				     mct-drag="rightDrag(delta[0])"
-				     ng-style="{ right: endInnerPct }">
-					<div class="range-value">{{endInnerText}}</div>
-				</div>
-				<div class="slot range-holder">
-					<div class="range"
-					     mct-drag-down="startMiddleDrag()"
-					     mct-drag="middleDrag(delta[0])"
-					     ng-style="{ left: startInnerPct, right: endInnerPct}">
-						<div class="toi-line"></div>
-					</div>
-				</div>
-			</div>
-		</div>
-	</div>
+    <div class="l-time-range-slider-holder">
+        <div class="l-time-range-slider">
+            <div class="slider"
+                 mct-resize="spanWidth = bounds.width">
+                <div class="knob knob-l"
+                     mct-drag-down="startLeftDrag()"
+                     mct-drag="leftDrag(delta[0])"
+                     ng-style="{ left: startInnerPct }">
+                    <div class="range-value">{{startInnerText}}</div>
+                </div>
+                <div class="knob knob-r"
+                     mct-drag-down="startRightDrag()"
+                     mct-drag="rightDrag(delta[0])"
+                     ng-style="{ right: endInnerPct }">
+                    <div class="range-value">{{endInnerText}}</div>
+                </div>
+                <div class="slot range-holder">
+                    <div class="range"
+                         mct-drag-down="startMiddleDrag()"
+                         mct-drag="middleDrag(delta[0])"
+                         ng-style="{ left: startInnerPct, right: endInnerPct}">
+                        <div class="toi-line"></div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
 
-	<div class="l-time-range-ticks-holder">
-		<div class="l-time-range-ticks">
-			<div
-				ng-repeat="tick in ticks"
-				ng-style="{ left: $index * (100 / (ticks.length - 1)) + '%' }"
-				class="tick tick-x"
-				>
-				<span class="l-time-range-tick-label">{{tick}}</span>
-			</div>
-		</div>
-	</div>
+    <div class="l-time-range-ticks-holder">
+        <div class="l-time-range-ticks">
+            <div
+                ng-repeat="tick in ticks"
+                ng-style="{ left: $index * (100 / (ticks.length - 1)) + '%' }"
+                class="tick tick-x"
+                >
+                <span class="l-time-range-tick-label">{{tick}}</span>
+            </div>
+        </div>
+    </div>
 </div>

--- a/platform/commonUI/general/src/controllers/TimeRangeController.js
+++ b/platform/commonUI/general/src/controllers/TimeRangeController.js
@@ -26,9 +26,8 @@ define(
     function (moment) {
         "use strict";
 
-        var
-				DATE_FORMAT = "YYYY-MM-DD HH:mm:ss",
-				TICK_SPACING_PX = 150;
+        var DATE_FORMAT = "YYYY-MM-DD HH:mm:ss",
+            TICK_SPACING_PX = 150;
 
         /**
          * @memberof platform/commonUI/general
@@ -99,8 +98,8 @@ define(
                 ngModel.inner = ngModel.inner || copyBounds(ngModel.outer);
 
                 // First, dates for the date pickers for outer bounds
-                $scope.startOuterDate = new Date(ngModel.outer.start);
-                $scope.endOuterDate = new Date(ngModel.outer.end);
+                $scope.boundsModel.start = formatTimestamp(ngModel.outer.start);
+                $scope.boundsModel.end = formatTimestamp(ngModel.outer.end);
 
                 // Then various updates for the inner span
                 updateViewForInnerSpanFromModel(ngModel);
@@ -210,6 +209,7 @@ define(
 
             $scope.state = false;
             $scope.ticks = [];
+            $scope.boundsModel = {};
 
             // Initialize scope to defaults
             updateViewFromModel($scope.ngModel);

--- a/platform/commonUI/general/src/controllers/TimeRangeController.js
+++ b/platform/commonUI/general/src/controllers/TimeRangeController.js
@@ -43,6 +43,15 @@ define(
                 return moment.utc(ts).format(DATE_FORMAT);
             }
 
+            function parseTimestamp(text) {
+                var m = moment.utc(text, DATE_FORMAT);
+                if (m.isValid()) {
+                    return m.valueOf();
+                } else {
+                    throw new Error("Could not parse " + text);
+                }
+            }
+
             // From 0.0-1.0 to "0%"-"1%"
             function toPercent(p) {
                 return (100 * p) + "%";
@@ -214,6 +223,22 @@ define(
                 updateViewForInnerSpanFromModel(ngModel);
             }
 
+            function updateStartFromText(value) {
+                try {
+                    updateOuterStart(parseTimestamp(value));
+                } catch (e) {
+                    return;
+                }
+            }
+
+            function updateEndFromText(value) {
+                try {
+                    updateOuterEnd(parseTimestamp(value));
+                } catch (e) {
+                    return;
+                }
+            }
+
             $scope.startLeftDrag = startLeftDrag;
             $scope.startRightDrag = startRightDrag;
             $scope.startMiddleDrag = startMiddleDrag;
@@ -232,6 +257,8 @@ define(
             $scope.$watch("spanWidth", updateSpanWidth);
             $scope.$watch("ngModel.outer.start", updateOuterStart);
             $scope.$watch("ngModel.outer.end", updateOuterEnd);
+            $scope.$watch("boundsModel.start", updateStartFromText);
+            $scope.$watch("boundsModel.end", updateEndFromText);
         }
 
         return TimeConductorController;

--- a/platform/commonUI/general/src/controllers/TimeRangeController.js
+++ b/platform/commonUI/general/src/controllers/TimeRangeController.js
@@ -247,7 +247,9 @@ define(
                 try {
                     updateOuterStart(parseTimestamp(value));
                     updateBoundsTextForProperty($scope.ngModel, 'end');
+                    $scope.boundsModel.startValid = true;
                 } catch (e) {
+                    $scope.boundsModel.startValid = false;
                     return;
                 }
             }
@@ -256,7 +258,9 @@ define(
                 try {
                     updateOuterEnd(parseTimestamp(value));
                     updateBoundsTextForProperty($scope.ngModel, 'start');
+                    $scope.boundsModel.endValid = true;
                 } catch (e) {
+                    $scope.boundsModel.endValid = false;
                     return;
                 }
             }

--- a/platform/commonUI/general/src/controllers/TimeRangeController.js
+++ b/platform/commonUI/general/src/controllers/TimeRangeController.js
@@ -186,6 +186,8 @@ define(
             function updateOuterStart(t) {
                 var ngModel = $scope.ngModel;
 
+                ngModel.outer.start = t;
+
                 ngModel.outer.end = Math.max(
                     ngModel.outer.start + outerMinimumSpan,
                     ngModel.outer.end
@@ -198,13 +200,13 @@ define(
                     ngModel.inner.end
                 );
 
-                $scope.startOuterText = formatTimestamp(t);
-
                 updateViewForInnerSpanFromModel(ngModel);
             }
 
             function updateOuterEnd(t) {
                 var ngModel = $scope.ngModel;
+
+                ngModel.outer.end = t;
 
                 ngModel.outer.start = Math.min(
                     ngModel.outer.end - outerMinimumSpan,
@@ -217,8 +219,6 @@ define(
                     ngModel.inner.end - innerMinimumSpan,
                     ngModel.inner.start
                 );
-
-                $scope.endOuterText = formatTimestamp(t);
 
                 updateViewForInnerSpanFromModel(ngModel);
             }

--- a/platform/commonUI/general/test/controllers/TimeRangeControllerSpec.js
+++ b/platform/commonUI/general/test/controllers/TimeRangeControllerSpec.js
@@ -22,8 +22,8 @@
 /*global define,Promise,describe,it,expect,beforeEach,waitsFor,jasmine*/
 
 define(
-    ["../../src/controllers/TimeRangeController"],
-    function (TimeRangeController) {
+    ["../../src/controllers/TimeRangeController", "moment"],
+    function (TimeRangeController, moment) {
         "use strict";
 
         var SEC = 1000,
@@ -166,7 +166,71 @@ define(
                     expect(mockScope.ngModel.inner.end)
                         .toBeGreaterThan(mockScope.ngModel.inner.start);
                 });
+
+                describe("by typing", function () {
+                    it("updates models", function () {
+                        var newStart = "1977-05-25 17:30:00",
+                            newEnd = "2015-12-18 03:30:00";
+
+                        mockScope.boundsModel.start = newStart;
+                        fireWatch("boundsModel.start", newStart);
+                        expect(mockScope.ngModel.outer.start)
+                            .toEqual(moment.utc(newStart).valueOf());
+                        expect(mockScope.boundsModel.startValid)
+                            .toBeTruthy();
+
+                        mockScope.boundsModel.end = newEnd;
+                        fireWatch("boundsModel.end", newEnd);
+                        expect(mockScope.ngModel.outer.end)
+                            .toEqual(moment.utc(newEnd).valueOf());
+                        expect(mockScope.boundsModel.endValid)
+                            .toBeTruthy();
+                    });
+
+                    it("displays error state", function () {
+                        var newStart = "Not a date",
+                            newEnd = "Definitely not a date",
+                            oldStart = mockScope.ngModel.outer.start,
+                            oldEnd = mockScope.ngModel.outer.end;
+
+                        mockScope.boundsModel.start = newStart;
+                        fireWatch("boundsModel.start", newStart);
+                        expect(mockScope.ngModel.outer.start)
+                            .toEqual(oldStart);
+                        expect(mockScope.boundsModel.startValid)
+                            .toBeFalsy();
+
+                        mockScope.boundsModel.end = newEnd;
+                        fireWatch("boundsModel.end", newEnd);
+                        expect(mockScope.ngModel.outer.end)
+                            .toEqual(oldEnd);
+                        expect(mockScope.boundsModel.endValid)
+                            .toBeFalsy();
+                    });
+
+                    it("does not modify user input", function () {
+                        // Don't want the controller "fixing" bad or
+                        // irregularly-formatted input out from under
+                        // the user's fingertips.
+                        var newStart = "Not a date",
+                            newEnd = "2015-3-3 01:02:04",
+                            oldStart = mockScope.ngModel.outer.start,
+                            oldEnd = mockScope.ngModel.outer.end;
+
+                        mockScope.boundsModel.start = newStart;
+                        fireWatch("boundsModel.start", newStart);
+                        expect(mockScope.boundsModel.start)
+                            .toEqual(newStart);
+
+                        mockScope.boundsModel.end = newEnd;
+                        fireWatch("boundsModel.end", newEnd);
+                        expect(mockScope.boundsModel.end)
+                            .toEqual(newEnd);
+                    });
+                });
             });
+
+
 
         });
     }


### PR DESCRIPTION
Allow dates to be entered as text in the start/end bounds of the time controller.

Summary of changes:

* Replace text spans with input fields in template.
* Move clickable region which exposes the date picker, such that it does _not_ get fired by clicking the input field
* Update model as text changes in response to user input
* Misc. reordering/refactoring of operations to ensure that changes to user input do not get overwritten while the user is typing