### PR TITLE
[Search] Update field name

### DIFF
--- a/platform/search/src/services/GenericSearchProvider.js
+++ b/platform/search/src/services/GenericSearchProvider.js
@@ -122,7 +122,7 @@ define([
 
         mutationTopic.listen(function (mutatedObject) {
             var id = mutatedObject.getId();
-            provider.indexed[id] = false;
+            provider.indexedIds[id] = false;
             provider.scheduleForIndexing(id);
         });
     };

--- a/platform/search/test/services/GenericSearchProviderSpec.js
+++ b/platform/search/test/services/GenericSearchProviderSpec.js
@@ -99,6 +99,14 @@ define([
                 .toHaveBeenCalledWith(jasmine.any(Function));
         });
 
+        it('reschedules indexing when mutation occurs', function () {
+            var mockDomainObject =
+                jasmine.createSpyObj('domainObj', ['getId']);
+            mockDomainObject.getId.andReturn("some-id");
+            mutationTopic.listen.mostRecentCall.args[0](mockDomainObject);
+            expect(provider.scheduleForIndexing).toHaveBeenCalledWith('some-id');
+        });
+
         it('starts indexing roots', function () {
             expect(provider.scheduleForIndexing).toHaveBeenCalledWith('mine');
         });


### PR DESCRIPTION
Update field name in GenericSearchProvider to reflect changes
from nasa/openmctweb#193. Avoids exceptions on mutation.

Additionally, add test case exercising relevant code and verifying
that reindexing is scheduled upon mutation as expected.