### PR TITLE
[RequireJS] Specify path for uuid

### DIFF
--- a/platform/commonUI/browse/bundle.json
+++ b/platform/commonUI/browse/bundle.json
@@ -1,4 +1,9 @@
 {
+    "configuration": {
+        "paths": {
+            "uuid": "uuid"
+        }
+    },
     "extensions": {
         "routes": [
             {

--- a/platform/commonUI/browse/src/creation/CreationService.js
+++ b/platform/commonUI/browse/src/creation/CreationService.js
@@ -25,7 +25,7 @@
  * Module defining CreateService. Created by vwoeltje on 11/10/14.
  */
 define(
-    ["../../lib/uuid"],
+    ["uuid"],
     function (uuid) {
         "use strict";
 

--- a/test-main.js
+++ b/test-main.js
@@ -44,7 +44,8 @@ require.config({
 
     paths: {
         'es6-promise': 'platform/framework/lib/es6-promise-2.0.0.min',
-        'moment-duration-format': 'warp/clock/lib/moment-duration-format'
+        'moment-duration-format': 'warp/clock/lib/moment-duration-format',
+        'uuid': 'platform/commonUI/browse/lib/uuid'
     },
 
     // dynamically load all test files


### PR DESCRIPTION
Specify path for uuid, making it available for any code that would require it,
without that code needing to know the path to it.

Fixes https://github.com/nasa/openmctweb/issues/211.

Assigning to @VWoeltjen for review and integrate.

# Author Checklist

1. Changes address original issue? Y
2. Unit tests included and/or updated with changes? No, configuration only change
3. Command line build passes? Y
4. Expect to pass code review? Y

