### PR TITLE
Review and integrate open-vista54a into master

### DIFF
--- a/example/generator/src/SinewaveLimitCapability.js
+++ b/example/generator/src/SinewaveLimitCapability.js
@@ -30,25 +30,25 @@ define(
             YELLOW = 0.5,
             LIMITS = {
                 rh: {
-                    cssClass: "s-limit-upr-red",
+                    cssClass: "s-limit-upr s-limit-red",
                     low: RED,
                     high: Number.POSITIVE_INFINITY,
                     name: "Red High"
                 },
                 rl: {
-                    cssClass: "s-limit-lwr-red",
+                    cssClass: "s-limit-lwr s-limit-red",
                     high: -RED,
                     low: Number.NEGATIVE_INFINITY,
                     name: "Red Low"
                 },
                 yh: {
-                    cssClass: "s-limit-upr-yellow",
+                    cssClass: "s-limit-upr s-limit-yellow",
                     low: YELLOW,
                     high: RED,
                     name: "Yellow High"
                 },
                 yl: {
-                    cssClass: "s-limit-lwr-yellow",
+                    cssClass: "s-limit-lwr s-limit-yellow",
                     low: -RED,
                     high: -YELLOW,
                     name: "Yellow Low"

--- a/platform/commonUI/general/res/sass/_constants.scss
+++ b/platform/commonUI/general/res/sass/_constants.scss
@@ -106,3 +106,8 @@ $dirImgs: $dirCommonRes + 'images/';
 
 /************************** TIMINGS */
 $controlFadeMs: 100ms;
+
+/************************** LIMITS */
+$glyphLimit: '\e603';
+$glyphLimitUpr: '\0000eb';
+$glyphLimitLwr: '\0000ee';

--- a/platform/commonUI/general/res/sass/_limits.scss
+++ b/platform/commonUI/general/res/sass/_limits.scss
@@ -3,23 +3,12 @@
         color: $iconColor;
         content: $glyph;
         font-family: symbolsfont;
+        font-size: 0.8em;
         display: inline;
         margin-right: $interiorMarginSm;
     }
 
 }
-
-/*[class*="s-limit"] {
-	//white-space: nowrap;
-	&:before {
-		display: inline-block;
-		font-family: symbolsfont;
-		font-size: 0.75em;
-		font-style: normal !important;
-		margin-right: $interiorMarginSm;
-		vertical-align: middle;
-	}
-}*/
 
 .s-limit-red { background: $colorLimitRedBg !important; }
 .s-limit-yellow { background: $colorLimitYellowBg !important; }
@@ -37,6 +26,7 @@ tr[class*="s-limit"] {
 }
 
 // Handle limit when applied directly to a non-tr element
+// Assume this is applied to the element that displays the limit value
 :not(tr)[class*="s-limit"] {
     &.s-limit-red {
         @include limitGlyph($colorLimitRedIc);

--- a/platform/commonUI/general/res/sass/_limits.scss
+++ b/platform/commonUI/general/res/sass/_limits.scss
@@ -1,14 +1,15 @@
-@mixin limit($bg, $ic, $glyph) {
-	background: $bg !important;
-	//color: $fg !important;
-	&:before {
-		//@include pulse(1000ms);
-		color: $ic;
-		content: $glyph;
-	}
+@mixin limitGlyph($iconColor, $glyph: $glyphLimit) {
+    &:before {
+        color: $iconColor;
+        content: $glyph;
+        font-family: symbolsfont;
+        display: inline;
+        margin-right: $interiorMarginSm;
+    }
+
 }
 
-[class*="s-limit"] {
+/*[class*="s-limit"] {
 	//white-space: nowrap;
 	&:before {
 		display: inline-block;
@@ -18,9 +19,31 @@
 		margin-right: $interiorMarginSm;
 		vertical-align: middle;
 	}
+}*/
+
+.s-limit-red { background: $colorLimitRedBg !important; }
+.s-limit-yellow { background: $colorLimitYellowBg !important; }
+
+// Handle limit when applied to a tr
+tr[class*="s-limit"] {
+    &.s-limit-red td:first-child {
+        @include limitGlyph($colorLimitRedIc);
+    }
+    &.s-limit-yellow td:first-child {
+        @include limitGlyph($colorLimitYellowIc);
+    }
+    &.s-limit-upr td:first-child:before { content:$glyphLimitUpr; }
+    &.s-limit-lwr td:first-child:before { content:$glyphLimitLwr; }
 }
 
-.s-limit-upr-red { @include limit($colorLimitRedBg, $colorLimitRedIc, "\0000eb"); };
-.s-limit-upr-yellow { @include limit($colorLimitYellowBg, $colorLimitYellowIc, "\0000ed"); };
-.s-limit-lwr-yellow { @include limit($colorLimitYellowBg, $colorLimitYellowIc, "\0000ec"); };
-.s-limit-lwr-red { @include limit($colorLimitRedBg, $colorLimitRedIc, "\0000ee"); };
+// Handle limit when applied directly to a non-tr element
+:not(tr)[class*="s-limit"] {
+    &.s-limit-red {
+        @include limitGlyph($colorLimitRedIc);
+    }
+    &.s-limit-yellow {
+        @include limitGlyph($colorLimitYellowIc);
+    }
+    &.s-limit-upr:before { content:$glyphLimitUpr; }
+    &.s-limit-lwr:before { content:$glyphLimitLwr; }
+}

--- a/platform/commonUI/themes/espresso/res/css/theme-espresso.css
+++ b/platform/commonUI/themes/espresso/res/css/theme-espresso.css
@@ -20,7 +20,7 @@
  * this source code distribution or the Licensing information page available
  * at runtime from the About dialog for additional information.
  *****************************************************************************/
-/* line 5, ../../../../../../../../../../Library/Ruby/Gems/2.0.0/gems/compass-core-1.0.3/stylesheets/compass/reset/_utilities.scss */
+/* line 5, ../../../../../../../../../../../Library/Ruby/Gems/2.0.0/gems/compass-core-1.0.3/stylesheets/compass/reset/_utilities.scss */
 html, body, div, span, applet, object, iframe,
 h1, h2, h3, h4, h5, h6, p, blockquote, pre,
 a, abbr, acronym, address, big, cite, code,
@@ -41,38 +41,38 @@ time, mark, audio, video {
   font-size: 100%;
   vertical-align: baseline; }
 
-/* line 22, ../../../../../../../../../../Library/Ruby/Gems/2.0.0/gems/compass-core-1.0.3/stylesheets/compass/reset/_utilities.scss */
+/* line 22, ../../../../../../../../../../../Library/Ruby/Gems/2.0.0/gems/compass-core-1.0.3/stylesheets/compass/reset/_utilities.scss */
 html {
   line-height: 1; }
 
-/* line 24, ../../../../../../../../../../Library/Ruby/Gems/2.0.0/gems/compass-core-1.0.3/stylesheets/compass/reset/_utilities.scss */
+/* line 24, ../../../../../../../../../../../Library/Ruby/Gems/2.0.0/gems/compass-core-1.0.3/stylesheets/compass/reset/_utilities.scss */
 ol, ul {
   list-style: none; }
 
-/* line 26, ../../../../../../../../../../Library/Ruby/Gems/2.0.0/gems/compass-core-1.0.3/stylesheets/compass/reset/_utilities.scss */
+/* line 26, ../../../../../../../../../../../Library/Ruby/Gems/2.0.0/gems/compass-core-1.0.3/stylesheets/compass/reset/_utilities.scss */
 table {
   border-collapse: collapse;
   border-spacing: 0; }
 
-/* line 28, ../../../../../../../../../../Library/Ruby/Gems/2.0.0/gems/compass-core-1.0.3/stylesheets/compass/reset/_utilities.scss */
+/* line 28, ../../../../../../../../../../../Library/Ruby/Gems/2.0.0/gems/compass-core-1.0.3/stylesheets/compass/reset/_utilities.scss */
 caption, th, td {
   text-align: left;
   font-weight: normal;
   vertical-align: middle; }
 
-/* line 30, ../../../../../../../../../../Library/Ruby/Gems/2.0.0/gems/compass-core-1.0.3/stylesheets/compass/reset/_utilities.scss */
+/* line 30, ../../../../../../../../../../../Library/Ruby/Gems/2.0.0/gems/compass-core-1.0.3/stylesheets/compass/reset/_utilities.scss */
 q, blockquote {
   quotes: none; }
-  /* line 103, ../../../../../../../../../../Library/Ruby/Gems/2.0.0/gems/compass-core-1.0.3/stylesheets/compass/reset/_utilities.scss */
+  /* line 103, ../../../../../../../../../../../Library/Ruby/Gems/2.0.0/gems/compass-core-1.0.3/stylesheets/compass/reset/_utilities.scss */
   q:before, q:after, blockquote:before, blockquote:after {
     content: "";
     content: none; }
 
-/* line 32, ../../../../../../../../../../Library/Ruby/Gems/2.0.0/gems/compass-core-1.0.3/stylesheets/compass/reset/_utilities.scss */
+/* line 32, ../../../../../../../../../../../Library/Ruby/Gems/2.0.0/gems/compass-core-1.0.3/stylesheets/compass/reset/_utilities.scss */
 a img {
   border: none; }
 
-/* line 116, ../../../../../../../../../../Library/Ruby/Gems/2.0.0/gems/compass-core-1.0.3/stylesheets/compass/reset/_utilities.scss */
+/* line 116, ../../../../../../../../../../../Library/Ruby/Gems/2.0.0/gems/compass-core-1.0.3/stylesheets/compass/reset/_utilities.scss */
 article, aside, details, figcaption, figure, footer, header, hgroup, main, menu, nav, section, summary {
   display: block; }
 
@@ -147,6 +147,7 @@ article, aside, details, figcaption, figure, footer, header, hgroup, main, menu,
 /************************** CONTROLS */
 /************************** PATHS */
 /************************** TIMINGS */
+/************************** LIMITS */
 /*****************************************************************************
  * Open MCT Web, Copyright (c) 2014-2015, United States Government
  * as represented by the Administrator of the National Aeronautics and Space
@@ -657,46 +658,70 @@ mct-container {
     color: #ff3c00;
     content: "!"; }
 
-/* line 13, ../../../../general/res/sass/_limits.scss */
-[class*="s-limit"]:before {
-  display: inline-block;
-  font-family: symbolsfont;
-  font-size: 0.75em;
-  font-style: normal !important;
-  margin-right: 3px;
-  vertical-align: middle; }
-
-/* line 23, ../../../../general/res/sass/_limits.scss */
-.s-limit-upr-red {
-  background: rgba(255, 0, 0, 0.3) !important; }
-  /* line 4, ../../../../general/res/sass/_limits.scss */
-  .s-limit-upr-red:before {
-    color: red;
-    content: "ë"; }
-
-/* line 24, ../../../../general/res/sass/_limits.scss */
-.s-limit-upr-yellow {
-  background: rgba(255, 170, 0, 0.3) !important; }
-  /* line 4, ../../../../general/res/sass/_limits.scss */
-  .s-limit-upr-yellow:before {
-    color: #ffaa00;
-    content: "í"; }
-
+/*[class*="s-limit"] {
+	//white-space: nowrap;
+	&:before {
+		display: inline-block;
+		font-family: symbolsfont;
+		font-size: 0.75em;
+		font-style: normal !important;
+		margin-right: $interiorMarginSm;
+		vertical-align: middle;
+	}
+}*/
 /* line 25, ../../../../general/res/sass/_limits.scss */
-.s-limit-lwr-yellow {
-  background: rgba(255, 170, 0, 0.3) !important; }
-  /* line 4, ../../../../general/res/sass/_limits.scss */
-  .s-limit-lwr-yellow:before {
-    color: #ffaa00;
-    content: "ì"; }
+.s-limit-red {
+  background: rgba(255, 0, 0, 0.3) !important; }
 
 /* line 26, ../../../../general/res/sass/_limits.scss */
-.s-limit-lwr-red {
-  background: rgba(255, 0, 0, 0.3) !important; }
-  /* line 4, ../../../../general/res/sass/_limits.scss */
-  .s-limit-lwr-red:before {
-    color: red;
-    content: "î"; }
+.s-limit-yellow {
+  background: rgba(255, 170, 0, 0.3) !important; }
+
+/* line 2, ../../../../general/res/sass/_limits.scss */
+tr[class*="s-limit"].s-limit-red td:first-child:before {
+  color: red;
+  content: "";
+  font-family: symbolsfont;
+  font-size: 0.8em;
+  display: inline;
+  margin-right: 3px; }
+/* line 2, ../../../../general/res/sass/_limits.scss */
+tr[class*="s-limit"].s-limit-yellow td:first-child:before {
+  color: #ffaa00;
+  content: "";
+  font-family: symbolsfont;
+  font-size: 0.8em;
+  display: inline;
+  margin-right: 3px; }
+/* line 36, ../../../../general/res/sass/_limits.scss */
+tr[class*="s-limit"].s-limit-upr td:first-child:before {
+  content: "ë"; }
+/* line 37, ../../../../general/res/sass/_limits.scss */
+tr[class*="s-limit"].s-limit-lwr td:first-child:before {
+  content: "î"; }
+
+/* line 2, ../../../../general/res/sass/_limits.scss */
+:not(tr)[class*="s-limit"].s-limit-red:before {
+  color: red;
+  content: "";
+  font-family: symbolsfont;
+  font-size: 0.8em;
+  display: inline;
+  margin-right: 3px; }
+/* line 2, ../../../../general/res/sass/_limits.scss */
+:not(tr)[class*="s-limit"].s-limit-yellow:before {
+  color: #ffaa00;
+  content: "";
+  font-family: symbolsfont;
+  font-size: 0.8em;
+  display: inline;
+  margin-right: 3px; }
+/* line 48, ../../../../general/res/sass/_limits.scss */
+:not(tr)[class*="s-limit"].s-limit-upr:before {
+  content: "ë"; }
+/* line 49, ../../../../general/res/sass/_limits.scss */
+:not(tr)[class*="s-limit"].s-limit-lwr:before {
+  content: "î"; }
 
 /* line 1, ../../../../general/res/sass/_data-status.scss */
 .s-stale {
@@ -4142,32 +4167,10 @@ span.req {
     height: auto;
     max-height: 100%;
     position: relative; }
-    /* line 228, ../../../../general/res/sass/search/_search.scss */
+    /* line 226, ../../../../general/res/sass/search/_search.scss */
     .search .search-scroll .load-icon {
-      position: relative;
-      /*			&.loading {
-      				pointer-events: none;
-      				margin-left: $leftMargin;
-      
-      				.title-label {
-      					// Text styling
-      					font-style: italic;
-      					font-size: .9em;
-      					opacity: 0.5;
-      
-      					// Text positioning
-      					margin-left: $iconWidth + $leftMargin;
-      					line-height: 24px;
-      				}
-      				.wait-spinner {
-      					margin-left: $leftMargin;
-      				}
-      			}
-      
-      			&:not(.loading) {
-      				cursor: pointer;
-      			}*/ }
-    /* line 255, ../../../../general/res/sass/search/_search.scss */
+      position: relative; }
+    /* line 230, ../../../../general/res/sass/search/_search.scss */
     .search .search-scroll .load-more-button {
       margin-top: 5px 0;
       font-size: 0.8em;
@@ -4438,21 +4441,7 @@ ul.tree {
   height: 1.5rem;
   line-height: 1.5rem;
   margin-bottom: 3px;
-  position: relative;
-    /*
-	&.loading {
-		pointer-events: none;
-		.label {
-			opacity: 0.5;
-			.title-label {
-				font-style: italic;
-			}
-		}
-		.wait-spinner {
-			margin-left: 14px;
-		}
-	}
-    */ }
+  position: relative; }
   /* line 48, ../../../../general/res/sass/tree/_tree.scss */
   .tree-item .view-control,
   .search-result-item .view-control {
@@ -4499,7 +4488,7 @@ ul.tree {
       .search-result-item .label .type-icon .icon.l-icon-alert {
         position: absolute;
         z-index: 2; }
-      /* line 90, ../../../../general/res/sass/tree/_tree.scss */
+      /* line 89, ../../../../general/res/sass/tree/_tree.scss */
       .tree-item .label .type-icon .icon.l-icon-alert,
       .search-result-item .label .type-icon .icon.l-icon-alert {
         color: #ff3c00;
@@ -4509,7 +4498,7 @@ ul.tree {
         width: 8px;
         top: 1px;
         right: -2px; }
-      /* line 96, ../../../../general/res/sass/tree/_tree.scss */
+      /* line 95, ../../../../general/res/sass/tree/_tree.scss */
       .tree-item .label .type-icon .icon.l-icon-link,
       .search-result-item .label .type-icon .icon.l-icon-link {
         color: #49dedb;
@@ -4519,7 +4508,7 @@ ul.tree {
         width: 8px;
         left: -3px;
         bottom: 0px; }
-    /* line 104, ../../../../general/res/sass/tree/_tree.scss */
+    /* line 103, ../../../../general/res/sass/tree/_tree.scss */
     .tree-item .label .title-label,
     .search-result-item .label .title-label {
       overflow: hidden;
@@ -4535,47 +4524,47 @@ ul.tree {
       overflow: hidden;
       text-overflow: ellipsis;
       white-space: nowrap; }
-  /* line 130, ../../../../general/res/sass/tree/_tree.scss */
+  /* line 113, ../../../../general/res/sass/tree/_tree.scss */
   .tree-item.selected,
   .search-result-item.selected {
     background: #006080;
     color: #cccccc; }
-    /* line 133, ../../../../general/res/sass/tree/_tree.scss */
+    /* line 116, ../../../../general/res/sass/tree/_tree.scss */
     .tree-item.selected .view-control,
     .search-result-item.selected .view-control {
       color: rgba(255, 255, 255, 0.3); }
-    /* line 136, ../../../../general/res/sass/tree/_tree.scss */
+    /* line 119, ../../../../general/res/sass/tree/_tree.scss */
     .tree-item.selected .label .type-icon,
     .search-result-item.selected .label .type-icon {
       color: #cccccc; }
   @media screen and (min-device-width: 800px) and (min-device-height: 1025px), screen and (min-device-width: 1025px) and (min-device-height: 800px) {
-    /* line 144, ../../../../general/res/sass/tree/_tree.scss */
+    /* line 127, ../../../../general/res/sass/tree/_tree.scss */
     .tree-item:not(.selected):hover,
     .search-result-item:not(.selected):hover {
       background: rgba(153, 153, 153, 0.1);
       color: #cccccc; }
-      /* line 150, ../../../../general/res/sass/tree/_tree.scss */
+      /* line 130, ../../../../general/res/sass/tree/_tree.scss */
       .tree-item:not(.selected):hover .icon,
       .search-result-item:not(.selected):hover .icon {
         color: #33ccff; } }
-  /* line 157, ../../../../general/res/sass/tree/_tree.scss */
+  /* line 137, ../../../../general/res/sass/tree/_tree.scss */
   .tree-item:not(.loading),
   .search-result-item:not(.loading) {
     cursor: pointer; }
-  /* line 161, ../../../../general/res/sass/tree/_tree.scss */
+  /* line 141, ../../../../general/res/sass/tree/_tree.scss */
   .tree-item .context-trigger,
   .search-result-item .context-trigger {
     top: -1px;
     position: absolute;
     right: 3px; }
-    /* line 167, ../../../../general/res/sass/tree/_tree.scss */
+    /* line 146, ../../../../general/res/sass/tree/_tree.scss */
     .tree-item .context-trigger .invoke-menu,
     .search-result-item .context-trigger .invoke-menu {
       font-size: 0.75em;
       height: 0.9rem;
       line-height: 0.9rem; }
 
-/* line 176, ../../../../general/res/sass/tree/_tree.scss */
+/* line 155, ../../../../general/res/sass/tree/_tree.scss */
 .tree-item .label {
   left: 15px; }
 

--- a/platform/commonUI/themes/snow/res/css/theme-snow.css
+++ b/platform/commonUI/themes/snow/res/css/theme-snow.css
@@ -20,7 +20,7 @@
  * this source code distribution or the Licensing information page available
  * at runtime from the About dialog for additional information.
  *****************************************************************************/
-/* line 5, ../../../../../../../../../../Library/Ruby/Gems/2.0.0/gems/compass-core-1.0.3/stylesheets/compass/reset/_utilities.scss */
+/* line 5, ../../../../../../../../../../../Library/Ruby/Gems/2.0.0/gems/compass-core-1.0.3/stylesheets/compass/reset/_utilities.scss */
 html, body, div, span, applet, object, iframe,
 h1, h2, h3, h4, h5, h6, p, blockquote, pre,
 a, abbr, acronym, address, big, cite, code,
@@ -41,38 +41,38 @@ time, mark, audio, video {
   font-size: 100%;
   vertical-align: baseline; }
 
-/* line 22, ../../../../../../../../../../Library/Ruby/Gems/2.0.0/gems/compass-core-1.0.3/stylesheets/compass/reset/_utilities.scss */
+/* line 22, ../../../../../../../../../../../Library/Ruby/Gems/2.0.0/gems/compass-core-1.0.3/stylesheets/compass/reset/_utilities.scss */
 html {
   line-height: 1; }
 
-/* line 24, ../../../../../../../../../../Library/Ruby/Gems/2.0.0/gems/compass-core-1.0.3/stylesheets/compass/reset/_utilities.scss */
+/* line 24, ../../../../../../../../../../../Library/Ruby/Gems/2.0.0/gems/compass-core-1.0.3/stylesheets/compass/reset/_utilities.scss */
 ol, ul {
   list-style: none; }
 
-/* line 26, ../../../../../../../../../../Library/Ruby/Gems/2.0.0/gems/compass-core-1.0.3/stylesheets/compass/reset/_utilities.scss */
+/* line 26, ../../../../../../../../../../../Library/Ruby/Gems/2.0.0/gems/compass-core-1.0.3/stylesheets/compass/reset/_utilities.scss */
 table {
   border-collapse: collapse;
   border-spacing: 0; }
 
-/* line 28, ../../../../../../../../../../Library/Ruby/Gems/2.0.0/gems/compass-core-1.0.3/stylesheets/compass/reset/_utilities.scss */
+/* line 28, ../../../../../../../../../../../Library/Ruby/Gems/2.0.0/gems/compass-core-1.0.3/stylesheets/compass/reset/_utilities.scss */
 caption, th, td {
   text-align: left;
   font-weight: normal;
   vertical-align: middle; }
 
-/* line 30, ../../../../../../../../../../Library/Ruby/Gems/2.0.0/gems/compass-core-1.0.3/stylesheets/compass/reset/_utilities.scss */
+/* line 30, ../../../../../../../../../../../Library/Ruby/Gems/2.0.0/gems/compass-core-1.0.3/stylesheets/compass/reset/_utilities.scss */
 q, blockquote {
   quotes: none; }
-  /* line 103, ../../../../../../../../../../Library/Ruby/Gems/2.0.0/gems/compass-core-1.0.3/stylesheets/compass/reset/_utilities.scss */
+  /* line 103, ../../../../../../../../../../../Library/Ruby/Gems/2.0.0/gems/compass-core-1.0.3/stylesheets/compass/reset/_utilities.scss */
   q:before, q:after, blockquote:before, blockquote:after {
     content: "";
     content: none; }
 
-/* line 32, ../../../../../../../../../../Library/Ruby/Gems/2.0.0/gems/compass-core-1.0.3/stylesheets/compass/reset/_utilities.scss */
+/* line 32, ../../../../../../../../../../../Library/Ruby/Gems/2.0.0/gems/compass-core-1.0.3/stylesheets/compass/reset/_utilities.scss */
 a img {
   border: none; }
 
-/* line 116, ../../../../../../../../../../Library/Ruby/Gems/2.0.0/gems/compass-core-1.0.3/stylesheets/compass/reset/_utilities.scss */
+/* line 116, ../../../../../../../../../../../Library/Ruby/Gems/2.0.0/gems/compass-core-1.0.3/stylesheets/compass/reset/_utilities.scss */
 article, aside, details, figcaption, figure, footer, header, hgroup, main, menu, nav, section, summary {
   display: block; }
 
@@ -147,6 +147,7 @@ article, aside, details, figcaption, figure, footer, header, hgroup, main, menu,
 /************************** CONTROLS */
 /************************** PATHS */
 /************************** TIMINGS */
+/************************** LIMITS */
 /*****************************************************************************
  * Open MCT Web, Copyright (c) 2014-2015, United States Government
  * as represented by the Administrator of the National Aeronautics and Space
@@ -657,46 +658,70 @@ mct-container {
     color: #ff3c00;
     content: "!"; }
 
-/* line 13, ../../../../general/res/sass/_limits.scss */
-[class*="s-limit"]:before {
-  display: inline-block;
-  font-family: symbolsfont;
-  font-size: 0.75em;
-  font-style: normal !important;
-  margin-right: 3px;
-  vertical-align: middle; }
-
-/* line 23, ../../../../general/res/sass/_limits.scss */
-.s-limit-upr-red {
-  background: rgba(255, 0, 0, 0.3) !important; }
-  /* line 4, ../../../../general/res/sass/_limits.scss */
-  .s-limit-upr-red:before {
-    color: red;
-    content: "ë"; }
-
-/* line 24, ../../../../general/res/sass/_limits.scss */
-.s-limit-upr-yellow {
-  background: rgba(255, 170, 0, 0.3) !important; }
-  /* line 4, ../../../../general/res/sass/_limits.scss */
-  .s-limit-upr-yellow:before {
-    color: #ffaa00;
-    content: "í"; }
-
+/*[class*="s-limit"] {
+	//white-space: nowrap;
+	&:before {
+		display: inline-block;
+		font-family: symbolsfont;
+		font-size: 0.75em;
+		font-style: normal !important;
+		margin-right: $interiorMarginSm;
+		vertical-align: middle;
+	}
+}*/
 /* line 25, ../../../../general/res/sass/_limits.scss */
-.s-limit-lwr-yellow {
-  background: rgba(255, 170, 0, 0.3) !important; }
-  /* line 4, ../../../../general/res/sass/_limits.scss */
-  .s-limit-lwr-yellow:before {
-    color: #ffaa00;
-    content: "ì"; }
+.s-limit-red {
+  background: rgba(255, 0, 0, 0.3) !important; }
 
 /* line 26, ../../../../general/res/sass/_limits.scss */
-.s-limit-lwr-red {
-  background: rgba(255, 0, 0, 0.3) !important; }
-  /* line 4, ../../../../general/res/sass/_limits.scss */
-  .s-limit-lwr-red:before {
-    color: red;
-    content: "î"; }
+.s-limit-yellow {
+  background: rgba(255, 170, 0, 0.3) !important; }
+
+/* line 2, ../../../../general/res/sass/_limits.scss */
+tr[class*="s-limit"].s-limit-red td:first-child:before {
+  color: red;
+  content: "";
+  font-family: symbolsfont;
+  font-size: 0.8em;
+  display: inline;
+  margin-right: 3px; }
+/* line 2, ../../../../general/res/sass/_limits.scss */
+tr[class*="s-limit"].s-limit-yellow td:first-child:before {
+  color: #ffaa00;
+  content: "";
+  font-family: symbolsfont;
+  font-size: 0.8em;
+  display: inline;
+  margin-right: 3px; }
+/* line 36, ../../../../general/res/sass/_limits.scss */
+tr[class*="s-limit"].s-limit-upr td:first-child:before {
+  content: "ë"; }
+/* line 37, ../../../../general/res/sass/_limits.scss */
+tr[class*="s-limit"].s-limit-lwr td:first-child:before {
+  content: "î"; }
+
+/* line 2, ../../../../general/res/sass/_limits.scss */
+:not(tr)[class*="s-limit"].s-limit-red:before {
+  color: red;
+  content: "";
+  font-family: symbolsfont;
+  font-size: 0.8em;
+  display: inline;
+  margin-right: 3px; }
+/* line 2, ../../../../general/res/sass/_limits.scss */
+:not(tr)[class*="s-limit"].s-limit-yellow:before {
+  color: #ffaa00;
+  content: "";
+  font-family: symbolsfont;
+  font-size: 0.8em;
+  display: inline;
+  margin-right: 3px; }
+/* line 48, ../../../../general/res/sass/_limits.scss */
+:not(tr)[class*="s-limit"].s-limit-upr:before {
+  content: "ë"; }
+/* line 49, ../../../../general/res/sass/_limits.scss */
+:not(tr)[class*="s-limit"].s-limit-lwr:before {
+  content: "î"; }
 
 /* line 1, ../../../../general/res/sass/_data-status.scss */
 .s-stale {
@@ -4089,32 +4114,10 @@ span.req {
     height: auto;
     max-height: 100%;
     position: relative; }
-    /* line 228, ../../../../general/res/sass/search/_search.scss */
+    /* line 226, ../../../../general/res/sass/search/_search.scss */
     .search .search-scroll .load-icon {
-      position: relative;
-      /*			&.loading {
-      				pointer-events: none;
-      				margin-left: $leftMargin;
-      
-      				.title-label {
-      					// Text styling
-      					font-style: italic;
-      					font-size: .9em;
-      					opacity: 0.5;
-      
-      					// Text positioning
-      					margin-left: $iconWidth + $leftMargin;
-      					line-height: 24px;
-      				}
-      				.wait-spinner {
-      					margin-left: $leftMargin;
-      				}
-      			}
-      
-      			&:not(.loading) {
-      				cursor: pointer;
-      			}*/ }
-    /* line 255, ../../../../general/res/sass/search/_search.scss */
+      position: relative; }
+    /* line 230, ../../../../general/res/sass/search/_search.scss */
     .search .search-scroll .load-more-button {
       margin-top: 5px 0;
       font-size: 0.8em;
@@ -4367,21 +4370,7 @@ ul.tree {
   height: 1.5rem;
   line-height: 1.5rem;
   margin-bottom: 3px;
-  position: relative;
-    /*
-	&.loading {
-		pointer-events: none;
-		.label {
-			opacity: 0.5;
-			.title-label {
-				font-style: italic;
-			}
-		}
-		.wait-spinner {
-			margin-left: 14px;
-		}
-	}
-    */ }
+  position: relative; }
   /* line 48, ../../../../general/res/sass/tree/_tree.scss */
   .tree-item .view-control,
   .search-result-item .view-control {
@@ -4427,7 +4416,7 @@ ul.tree {
       .search-result-item .label .type-icon .icon.l-icon-alert {
         position: absolute;
         z-index: 2; }
-      /* line 90, ../../../../general/res/sass/tree/_tree.scss */
+      /* line 89, ../../../../general/res/sass/tree/_tree.scss */
       .tree-item .label .type-icon .icon.l-icon-alert,
       .search-result-item .label .type-icon .icon.l-icon-alert {
         color: #ff3c00;
@@ -4437,7 +4426,7 @@ ul.tree {
         width: 8px;
         top: 1px;
         right: -2px; }
-      /* line 96, ../../../../general/res/sass/tree/_tree.scss */
+      /* line 95, ../../../../general/res/sass/tree/_tree.scss */
       .tree-item .label .type-icon .icon.l-icon-link,
       .search-result-item .label .type-icon .icon.l-icon-link {
         color: #49dedb;
@@ -4447,7 +4436,7 @@ ul.tree {
         width: 8px;
         left: -3px;
         bottom: 0px; }
-    /* line 104, ../../../../general/res/sass/tree/_tree.scss */
+    /* line 103, ../../../../general/res/sass/tree/_tree.scss */
     .tree-item .label .title-label,
     .search-result-item .label .title-label {
       overflow: hidden;
@@ -4463,47 +4452,47 @@ ul.tree {
       overflow: hidden;
       text-overflow: ellipsis;
       white-space: nowrap; }
-  /* line 130, ../../../../general/res/sass/tree/_tree.scss */
+  /* line 113, ../../../../general/res/sass/tree/_tree.scss */
   .tree-item.selected,
   .search-result-item.selected {
     background: #1ac6ff;
     color: #fcfcfc; }
-    /* line 133, ../../../../general/res/sass/tree/_tree.scss */
+    /* line 116, ../../../../general/res/sass/tree/_tree.scss */
     .tree-item.selected .view-control,
     .search-result-item.selected .view-control {
       color: #fcfcfc; }
-    /* line 136, ../../../../general/res/sass/tree/_tree.scss */
+    /* line 119, ../../../../general/res/sass/tree/_tree.scss */
     .tree-item.selected .label .type-icon,
     .search-result-item.selected .label .type-icon {
       color: #fcfcfc; }
   @media screen and (min-device-width: 800px) and (min-device-height: 1025px), screen and (min-device-width: 1025px) and (min-device-height: 800px) {
-    /* line 144, ../../../../general/res/sass/tree/_tree.scss */
+    /* line 127, ../../../../general/res/sass/tree/_tree.scss */
     .tree-item:not(.selected):hover,
     .search-result-item:not(.selected):hover {
       background: rgba(102, 102, 102, 0.1);
       color: #333333; }
-      /* line 150, ../../../../general/res/sass/tree/_tree.scss */
+      /* line 130, ../../../../general/res/sass/tree/_tree.scss */
       .tree-item:not(.selected):hover .icon,
       .search-result-item:not(.selected):hover .icon {
         color: #0099cc; } }
-  /* line 157, ../../../../general/res/sass/tree/_tree.scss */
+  /* line 137, ../../../../general/res/sass/tree/_tree.scss */
   .tree-item:not(.loading),
   .search-result-item:not(.loading) {
     cursor: pointer; }
-  /* line 161, ../../../../general/res/sass/tree/_tree.scss */
+  /* line 141, ../../../../general/res/sass/tree/_tree.scss */
   .tree-item .context-trigger,
   .search-result-item .context-trigger {
     top: -1px;
     position: absolute;
     right: 3px; }
-    /* line 167, ../../../../general/res/sass/tree/_tree.scss */
+    /* line 146, ../../../../general/res/sass/tree/_tree.scss */
     .tree-item .context-trigger .invoke-menu,
     .search-result-item .context-trigger .invoke-menu {
       font-size: 0.75em;
       height: 0.9rem;
       line-height: 0.9rem; }
 
-/* line 176, ../../../../general/res/sass/tree/_tree.scss */
+/* line 155, ../../../../general/res/sass/tree/_tree.scss */
 .tree-item .label {
   left: 15px; }
 


### PR DESCRIPTION
Based on jpl github pull https://github.jpl.nasa.gov/MissionControl/vista/pull/116.
Changes the way limit CSS classes are applied: now uses 2 classes instead of one: Apply "s-limit-red" or "s-limit-yellow" to a tr element, or directly to any block element. When applied to a tr, the whole row will be colored, and a glyph icon will be added to the first cell of the row. For upper and lower limits, apply "s-limit-upr" and "s-limit-lwr" as a separate class.

Still to-do: make any mods needed in warp in order to apply classes properly.

**Author checklist:**
- Changes address original issue? Y
- Unit tests included and/or updated with changes? N/A
- Command line build passes? N/A
- Expect to pass code review? Y