### PR TITLE
[Representation] Avoid scope reuse

### DIFF
--- a/platform/representation/src/MCTRepresentation.js
+++ b/platform/representation/src/MCTRepresentation.js
@@ -31,7 +31,6 @@ define(
     function () {
         "use strict";
 
-
         /**
          * Defines the mct-representation directive. This may be used to
          * present domain objects as HTML (with event wiring), with the
@@ -96,6 +95,9 @@ define(
                     }),
                     toClear = [], // Properties to clear out of scope on change
                     counter = 0,
+                    couldRepresent = false,
+                    lastId,
+                    lastKey,
                     changeTemplate = templateLinker.link($scope, element);
 
                 // Populate scope with any capabilities indicated by the
@@ -141,6 +143,13 @@ define(
                     });
                 }
 
+                function unchanged(canRepresent, id, key) {
+                    return canRepresent &&
+                        couldRepresent &&
+                        id === lastId &&
+                        key === lastKey;
+                }
+
                 // General-purpose refresh mechanism; should set up the scope
                 // as appropriate for current representation key and
                 // domain object.
@@ -149,7 +158,13 @@ define(
                         representation = lookup($scope.key, domainObject),
                         path = representation && getPath(representation),
                         uses = ((representation || {}).uses || []),
-                        canRepresent = !!(path && domainObject);
+                        canRepresent = !!(path && domainObject),
+                        id = domainObject && domainObject.getId(),
+                        key = $scope.key;
+
+                    if (unchanged(canRepresent, id, key)) {
+                        return;
+                    }
 
                     // Create an empty object named "representation", for this
                     // representation to store local variables into.
@@ -172,6 +187,11 @@ define(
                     toClear.forEach(function (property) {
                         delete $scope[property];
                     });
+
+                    // To allow simplified change detection next time around
+                    couldRepresent = canRepresent;
+                    lastId = id;
+                    lastKey = key;
 
                     // Populate scope with fields associated with the current
                     // domain object (if one has been passed in)

--- a/platform/representation/src/TemplateLinker.js
+++ b/platform/representation/src/TemplateLinker.js
@@ -132,6 +132,7 @@ define(
 
             function changeTemplate(templateUrl) {
                 if (templateUrl) {
+                    destroyScope();
                     addElement();
                     self.load(templateUrl).then(function (template) {
                         // Avoid race conditions

--- a/platform/representation/src/TemplateLinker.js
+++ b/platform/representation/src/TemplateLinker.js
@@ -121,8 +121,8 @@ define(
             function populateElement(template) {
                 destroyScope();
                 activeScope = scope.$new(false);
-                element.empty();
-                element.append(self.$compile(template)(activeScope));
+                element.html(template);
+                self.$compile(element.contents())(activeScope);
             }
 
             function badTemplate(templateUrl) {

--- a/platform/representation/src/TemplateLinker.js
+++ b/platform/representation/src/TemplateLinker.js
@@ -131,22 +131,20 @@ define(
             }
 
             function changeTemplate(templateUrl) {
-                if (templateUrl !== activeTemplateUrl) {
-                    if (templateUrl) {
-                        addElement();
-                        self.load(templateUrl).then(function (template) {
-                            // Avoid race conditions
-                            if (templateUrl === activeTemplateUrl) {
-                                populateElement(template);
-                            }
-                        }, function () {
-                            badTemplate(templateUrl);
-                        });
-                    } else {
-                        removeElement();
-                    }
-                    activeTemplateUrl = templateUrl;
+                if (templateUrl) {
+                    addElement();
+                    self.load(templateUrl).then(function (template) {
+                        // Avoid race conditions
+                        if (templateUrl === activeTemplateUrl) {
+                            populateElement(template);
+                        }
+                    }, function () {
+                        badTemplate(templateUrl);
+                    });
+                } else {
+                    removeElement();
                 }
+                activeTemplateUrl = templateUrl;
             }
 
             if (templateUrl) {

--- a/platform/representation/src/TemplateLinker.js
+++ b/platform/representation/src/TemplateLinker.js
@@ -92,10 +92,19 @@ define(
             var activeElement = element,
                 activeTemplateUrl,
                 comment = this.$compile('<!-- hidden mct element -->')(scope),
+                activeScope,
                 self = this;
+
+            function destroyScope() {
+                if (activeScope) {
+                    activeScope.$destroy();
+                    activeScope = undefined;
+                }
+            }
 
             function removeElement() {
                 if (activeElement !== comment) {
+                    destroyScope();
                     activeElement.replaceWith(comment);
                     activeElement = comment;
                 }
@@ -110,8 +119,10 @@ define(
             }
 
             function populateElement(template) {
+                destroyScope();
+                activeScope = scope.$new(false);
                 element.empty();
-                element.append(self.$compile(template)(scope));
+                element.append(self.$compile(template)(activeScope));
             }
 
             function badTemplate(templateUrl) {

--- a/platform/representation/test/TemplateLinkerSpec.js
+++ b/platform/representation/test/TemplateLinkerSpec.js
@@ -27,7 +27,8 @@ define(
     function (TemplateLinker) {
         'use strict';
 
-        var JQLITE_METHODS = [ 'replaceWith', 'empty', 'append' ];
+        var JQLITE_METHODS = [ 'replaceWith', 'empty', 'append' ],
+            SCOPE_METHODS = [ '$on', '$new', '$destroy' ];
 
         describe("TemplateLinker", function () {
             var mockTemplateRequest,
@@ -38,6 +39,7 @@ define(
                 mockElement,
                 mockTemplates,
                 mockElements,
+                mockNewScope,
                 mockPromise,
                 linker;
 
@@ -46,7 +48,8 @@ define(
                 mockSce = jasmine.createSpyObj('$sce', ['trustAsResourceUrl']);
                 mockCompile = jasmine.createSpy('$compile');
                 mockLog = jasmine.createSpyObj('$log', ['error', 'warn']);
-                mockScope = jasmine.createSpyObj('$scope', ['$on']);
+                mockScope = jasmine.createSpyObj('$scope', SCOPE_METHODS);
+                mockNewScope = jasmine.createSpyObj('$scope', SCOPE_METHODS);
                 mockElement = jasmine.createSpyObj('element', JQLITE_METHODS);
                 mockPromise = jasmine.createSpyObj('promise', ['then']);
                 mockTemplates = {};
@@ -63,6 +66,7 @@ define(
                 mockSce.trustAsResourceUrl.andCallFake(function (url) {
                     return { trusted: url };
                 });
+                mockScope.$new.andReturn(mockNewScope);
 
                 linker = new TemplateLinker(
                     mockTemplateRequest,
@@ -131,10 +135,10 @@ define(
                         }, false);
                     });
 
-                    it("compiles loaded templates with linked scope", function () {
+                    it("compiles loaded templates with a new scope", function () {
                         expect(mockCompile).toHaveBeenCalledWith(testTemplate);
                         expect(mockTemplates[testTemplate])
-                            .toHaveBeenCalledWith(mockScope);
+                            .toHaveBeenCalledWith(mockNewScope);
                     });
 
                     it("replaces comments with specified element", function () {


### PR DESCRIPTION
Addresses #227 (and decreases severity of #229)

Summary of changes:

* Create new child scopes in `templateLinker` whenever a call is made to change a template.
  * This includes calls that have the same `templateUrl`, to handle cases such as switching from one plot to another plot.
* Tweak ordering such that scope is destroyed as soon as a call to change templates is made. This avoids cases where an existing scope (e.g. in nested `mct-representation`s) gets updated to reflect new content, only to be replaced and recreated when its parent representation gets recreated.
* Change compilation process for loaded templates to more closely resemble the way `ng-include` does it. HTML is inserted into the relevant containing element _before_ compilation; as a consequence, loaded styles are applied at compilation time, resulting in more consistent behavior.
  * This fixes a fresh bug wherein the right hand pane in Edit mode is collapsed when entering Edit mode.
* When refreshing an mct-representation, add some checks to determine if anything really needs to be refreshed. A refresh is triggered by changes to both key and domain object, often in the same digest cycle; in these cases, the representation is fully handled after the first watch is triggered, so any work done for the second watch is redundant.


### Author Checklist

1. Changes address original issue? Y
2. Unit tests included and/or updated with changes? Y
3. Command line build passes? Y
4. Expect to pass code review? Y

