### PR TITLE
[Search] Declare UI components as templates

### DIFF
--- a/platform/commonUI/browse/res/templates/browse.html
+++ b/platform/commonUI/browse/res/templates/browse.html
@@ -34,10 +34,9 @@
                     </mct-representation>
                     <div class='holder search-holder abs'
                          ng-class="{active: treeModel.search}">
-                        <mct-representation key="'search'"
-                                     mct-object="domainObject"
+                        <mct-include key="'search'"
                                      ng-model="treeModel">
-                        </mct-representation>
+                        </mct-include>
                     </div>
                     <div class='tree-holder abs mobile-tree-holder'
                          ng-hide="treeModel.search">

--- a/platform/search/bundle.json
+++ b/platform/search/bundle.json
@@ -28,16 +28,18 @@
         ],
         "representations": [
             {
+                "key": "search-item",
+                "templateUrl": "templates/search-item.html"
+            }
+        ],
+        "templates": [
+            {
                 "key": "search",
                 "templateUrl": "templates/search.html"
             },
             {
                 "key": "search-menu",
                 "templateUrl": "templates/search-menu.html"
-            },
-            {
-                "key": "search-item",
-                "templateUrl": "templates/search-item.html"
             }
         ],
         "components": [

--- a/platform/search/res/templates/search.html
+++ b/platform/search/res/templates/search.html
@@ -43,7 +43,7 @@
         <a class="ui-symbol clear-icon"
            ng-class="{content: !(ngModel.input === '' || ngModel.input === undefined)}"
            ng-click="ngModel.input = ''; controller.search()">
-	        &#xe607;
+            &#xe607;
         </a>
 
         <!-- Menu icon/button 'v' -->
@@ -53,12 +53,12 @@
         </a>
 
         <!-- Menu -->
-        <mct-representation key="'search-menu'"
+        <mct-include key="'search-menu'"
                      class="menu-element search-menu-holder"
                      ng-class="{off: !toggle.isActive()}"
                      ng-model="ngModel"
                      ng-click="toggle.setState(true)">
-        </mct-representation>
+        </mct-include>
     </div>
 
     <!-- Active filter display -->
@@ -71,7 +71,7 @@
             &#xe607;
         </a>
 
-	    Filtered by: {{ ngModel.filtersString }}
+        Filtered by: {{ ngModel.filtersString }}
 
     </div>
 


### PR DESCRIPTION
Declare Search UI components as templates instead of
representations so that they are not removed from the
DOM when no domain object is supplied. Fixes
nasa/openmctweb#234