### PR TITLE
[Actions] Avoid suppression of context menus

### DIFF
--- a/platform/core/bundle.json
+++ b/platform/core/bundle.json
@@ -92,7 +92,7 @@
                 "provides": "actionService",
                 "type": "provider",
                 "implementation": "actions/ActionProvider.js",
-                "depends": [ "actions[]" ]
+                "depends": [ "actions[]", "$log" ]
             },
             {
                 "provides": "actionService",

--- a/platform/entanglement/src/actions/AbstractComposeAction.js
+++ b/platform/entanglement/src/actions/AbstractComposeAction.js
@@ -122,6 +122,14 @@ define(
             });
         };
 
+        AbstractComposeAction.appliesTo = function (context) {
+            var applicableObject =
+                context.selectedObject || context.domainObject;
+
+            return !!(applicableObject &&
+                applicableObject.hasCapability('context'));
+        };
+
         return AbstractComposeAction;
     }
 );

--- a/platform/entanglement/src/actions/CopyAction.js
+++ b/platform/entanglement/src/actions/CopyAction.js
@@ -34,7 +34,7 @@ define(
          * @constructor
          * @memberof platform/entanglement
          */
-        function CopyAction($log, locationService, copyService, dialogService, 
+        function CopyAction($log, locationService, copyService, dialogService,
                             notificationService, context) {
             this.dialog = undefined;
             this.notification = undefined;
@@ -42,7 +42,7 @@ define(
             this.notificationService = notificationService;
             this.$log = $log;
             //Extend the behaviour of the Abstract Compose Action
-            AbstractComposeAction.call(this, locationService, copyService, 
+            AbstractComposeAction.call(this, locationService, copyService,
                 context, "Duplicate", "to a location");
         }
 
@@ -87,8 +87,8 @@ define(
         };
 
         /**
-         * Executes the CopyAction. The CopyAction uses the default behaviour of 
-         * the AbstractComposeAction, but extends it to support notification 
+         * Executes the CopyAction. The CopyAction uses the default behaviour of
+         * the AbstractComposeAction, but extends it to support notification
          * updates of progress on copy.
          */
         CopyAction.prototype.perform = function() {
@@ -131,6 +131,9 @@ define(
             return AbstractComposeAction.prototype.perform.call(this)
                 .then(success, error, notification);
         };
+
+        CopyAction.appliesTo = AbstractComposeAction.appliesTo;
+
         return CopyAction;
     }
 );

--- a/platform/entanglement/src/actions/LinkAction.js
+++ b/platform/entanglement/src/actions/LinkAction.js
@@ -35,13 +35,14 @@ define(
          * @memberof platform/entanglement
          */
         function LinkAction(locationService, linkService, context) {
-            return new AbstractComposeAction(
-                locationService,
-                linkService,
-                context,
-                "Link"
+            AbstractComposeAction.apply(
+                this,
+                [locationService, linkService, context, "Link"]
             );
         }
+
+        LinkAction.prototype = Object.create(AbstractComposeAction.prototype);
+        LinkAction.appliesTo = AbstractComposeAction.appliesTo;
 
         return LinkAction;
     }

--- a/platform/entanglement/src/actions/MoveAction.js
+++ b/platform/entanglement/src/actions/MoveAction.js
@@ -35,13 +35,15 @@ define(
          * @memberof platform/entanglement
          */
         function MoveAction(locationService, moveService, context) {
-            return new AbstractComposeAction(
-                locationService,
-                moveService,
-                context,
-                "Move"
+            AbstractComposeAction.apply(
+                this,
+                [locationService, moveService, context, "Move"]
             );
+
         }
+
+        MoveAction.prototype = Object.create(AbstractComposeAction.prototype);
+        MoveAction.appliesTo = AbstractComposeAction.appliesTo;
 
         return MoveAction;
     }

--- a/platform/entanglement/test/actions/AbstractComposeActionSpec.js
+++ b/platform/entanglement/test/actions/AbstractComposeActionSpec.js
@@ -94,6 +94,28 @@ define(
                 composeService = new MockCopyService();
             });
 
+            it("are only applicable to domain objects with a context", function () {
+                var noContextObject = domainObjectFactory({
+                    name: 'selectedObject',
+                    model: { name: 'selectedObject' },
+                    capabilities: {}
+                });
+
+                expect(AbstractComposeAction.appliesTo({
+                    selectedObject: selectedObject
+                })).toBe(true);
+                expect(AbstractComposeAction.appliesTo({
+                    domainObject: selectedObject
+                })).toBe(true);
+
+                expect(AbstractComposeAction.appliesTo({
+                    selectedObject: noContextObject
+                })).toBe(false);
+                expect(AbstractComposeAction.appliesTo({
+                    domainObject: noContextObject
+                })).toBe(false);
+            });
+
 
             describe("with context from context-action", function () {
                 beforeEach(function () {


### PR DESCRIPTION
Addresses nasa/openmctweb#120, wherein an exception hit while instantiating Move/Copy/Link actions causes context menu options to fail to display.

Addressing this at two levels:

* At the ActionProvider level, catch errors thrown when actions are instantiated, such that one failed instantiation will not cause the whole `getActions()` to fail (isolate errors)
* At the level of individual move/copy/link actions, add an `appliesTo` check such that the dependency on the `context` capability which causes the error is made explicit.
  * Also while in there, make these proper subclasses of AbstractComposeAction 

### Author Checklist

1. Changes address original issue? Y
2. Unit tests included and/or updated with changes? Y
3. Command line build passes? Y
4. Expect to pass code review? Y