### PR TITLE
[Core] Catch errors from listeners in topic

### DIFF
--- a/platform/core/bundle.json
+++ b/platform/core/bundle.json
@@ -207,7 +207,8 @@
             },
             {
                 "key": "topic",
-                "implementation": "services/Topic.js"
+                "implementation": "services/Topic.js",
+                "depends": [ "$log" ]
             },
             {
                 "key": "contextualize",

--- a/platform/core/src/services/Topic.js
+++ b/platform/core/src/services/Topic.js
@@ -26,6 +26,8 @@ define(
     function () {
         "use strict";
 
+        var ERROR_PREFIX = "Error when notifying listener: ";
+
         /**
          * The `topic` service provides a way to create both named,
          * shared listeners and anonymous, private listeners.
@@ -46,7 +48,7 @@ define(
          * @returns {Function}
          * @memberof platform/core
          */
-        function Topic() {
+        function Topic($log) {
             var topics = {};
 
             function createTopic() {
@@ -63,7 +65,11 @@ define(
                     },
                     notify: function (message) {
                         listeners.forEach(function (listener) {
-                            listener(message);
+                            try {
+                                listener(message);
+                            } catch (e) {
+                                $log.error(ERROR_PREFIX + e.message);
+                            }
                         });
                     }
                 };

--- a/platform/core/test/services/TopicSpec.js
+++ b/platform/core/test/services/TopicSpec.js
@@ -65,6 +65,21 @@ define(
                 expect(mockCallback).toHaveBeenCalledWith(testMessage);
             });
 
+            it("is robust against errors thrown by listeners", function () {
+                var mockBadCallback = jasmine.createSpy("bad-callback"),
+                    t = topic();
+
+                mockBadCallback.andCallFake(function () {
+                    throw new Error("I'm afraid I can't do that.");
+                });
+
+                t.listen(mockBadCallback);
+                t.listen(mockCallback);
+
+                t.notify(testMessage);
+                expect(mockCallback).toHaveBeenCalledWith(testMessage);
+            });
+
         });
     }
 );

--- a/platform/core/test/services/TopicSpec.js
+++ b/platform/core/test/services/TopicSpec.js
@@ -28,13 +28,18 @@ define(
 
         describe("The 'topic' service", function () {
             var topic,
+                mockLog,
                 testMessage,
                 mockCallback;
 
             beforeEach(function () {
                 testMessage = { someKey: "some value"};
+                mockLog = jasmine.createSpyObj(
+                    '$log',
+                    [ 'error', 'warn', 'info', 'debug' ]
+                );
                 mockCallback = jasmine.createSpy('callback');
-                topic = new Topic();
+                topic = new Topic(mockLog);
             });
 
             it("notifies listeners on a topic", function () {


### PR DESCRIPTION
In `topic`, when a listener throws an error, catch it and log the message.

Addresses #231. Previously, such an error would be uncaught, and topic would not notify any remaining listeners. This could result in objects [failing to persist](https://github.com/nasa/openmctweb/pull/207#issuecomment-151219179) correctly after mutation.

### Author Checklist

1. Changes address original issue? Y
2. Unit tests included and/or updated with changes? Y
3. Command line build passes? Y
4. Expect to pass code review? Y