### PR TITLE
[Layout] Enforce minimum size on drop

### DIFF
--- a/platform/features/layout/src/LayoutController.js
+++ b/platform/features/layout/src/LayoutController.js
@@ -113,7 +113,7 @@ define(
                         Math.floor(position.x / self.gridSize[0]),
                         Math.floor(position.y / self.gridSize[1])
                     ],
-                    dimensions: DEFAULT_DIMENSIONS
+                    dimensions: self.defaultDimensions()
                 };
                 // Mark change as persistable
                 if ($scope.commit) {

--- a/platform/features/layout/test/LayoutControllerSpec.js
+++ b/platform/features/layout/test/LayoutControllerSpec.js
@@ -192,6 +192,29 @@ define(
                 expect(parseInt(styleB.width, 10)).toBeGreaterThan(63);
                 expect(parseInt(styleB.width, 10)).toBeGreaterThan(31);
             });
+
+            it("ensures a minimum frame size on drop", function () {
+                var style;
+
+                // Start with a very small frame size
+                testModel.layoutGrid = [ 1, 1 ];
+                mockScope.$watch.calls[0].args[1](testModel.layoutGrid);
+
+                // Notify that a drop occurred
+                testModel.composition.push('d');
+                mockScope.$on.mostRecentCall.args[1](
+                    mockEvent,
+                    'd',
+                    { x: 300, y: 100 }
+                );
+                mockScope.$watch.calls[0].args[1](['d']);
+
+                style = controller.getFrameStyle("d");
+
+                // Resulting size should still be reasonably large pixel-size
+                expect(parseInt(style.width, 10)).toBeGreaterThan(63);
+                expect(parseInt(style.height, 10)).toBeGreaterThan(31);
+            });
         });
     }
 );


### PR DESCRIPTION
Addresses nasa/openmctweb#271, ensuring frames in a layout
are not too tiny to use, even if the grid size is small.

### Author Checklist

1. Changes address original issue? Y
2. Unit tests included and/or updated with changes? Y
3. Command line build passes? Y
4. Expect to pass code review? Y