### PR TITLE
[Time Conductor] Fix date picker toggles

### DIFF
--- a/platform/commonUI/general/res/templates/controls/datetime-field.html
+++ b/platform/commonUI/general/res/templates/controls/datetime-field.html
@@ -6,10 +6,10 @@
     </input>
     <a class="ui-symbol icon icon-calendar"
        ng-if="structure.format === 'utc' || !structure.format"
-       ng-click="pickerActive = !pickerActive">
+       ng-click="picker.active = !picker.active">
     </a>
-    <mct-popup ng-if="pickerActive">
-        <div mct-click-elsewhere="pickerActive = false">
+    <mct-popup ng-if="picker.active">
+        <div mct-click-elsewhere="picker.active = false">
             <mct-control key="'datetime-picker'"
                          ng-model="ngModel"
                          field="field"

--- a/platform/commonUI/general/src/controllers/DateTimeFieldController.js
+++ b/platform/commonUI/general/src/controllers/DateTimeFieldController.js
@@ -69,9 +69,12 @@ define(
                 updateFromModel($scope.ngModel[$scope.field]);
             }
 
+            $scope.picker = { active: false };
+
             $scope.$watch('structure.format', setFormat);
             $scope.$watch('ngModel[field]', updateFromModel);
             $scope.$watch('textValue', updateFromView);
+
         }
 
         return DateTimeFieldController;

--- a/platform/commonUI/general/src/directives/MCTPopup.js
+++ b/platform/commonUI/general/src/directives/MCTPopup.js
@@ -51,6 +51,8 @@ define(
                     position = [ rect.left, rect.top ],
                     popup = popupService.display(div, position);
 
+                // TODO: Handle in CSS;
+                //       https://github.com/nasa/openmctweb/issues/298
                 div.css('z-index', 75);
 
                 transclude(function (clone) {

--- a/platform/commonUI/general/src/directives/MCTPopup.js
+++ b/platform/commonUI/general/src/directives/MCTPopup.js
@@ -51,6 +51,8 @@ define(
                     position = [ rect.left, rect.top ],
                     popup = popupService.display(div, position);
 
+                div.css('z-index', 75);
+
                 transclude(function (clone) {
                     div.append(clone);
                 });

--- a/platform/commonUI/general/test/controllers/DateTimeFieldControllerSpec.js
+++ b/platform/commonUI/general/test/controllers/DateTimeFieldControllerSpec.js
@@ -91,6 +91,10 @@ define(
                 expect(mockScope.textValue).toEqual("1977-05-25 17:30:00");
             });
 
+            it("exposes toggle state for date-time picker", function () {
+                expect(mockScope.picker.active).toBe(false);
+            });
+
             describe("when user input is invalid", function () {
                 var newText, oldValue;
 


### PR DESCRIPTION
Addresses #297, wherein a flag which toggles visibility of the date-time picker gets lost in a child scope. Moving flag into a nested object resolves the issue.

Also includes a workaround for #298 which should be removed when that issue is properly resolved



### Author Checklist

1. Changes address original issue? Y
2. Unit tests included and/or updated with changes? Y
3. Command line build passes? Y
4. Expect to pass code review? Y