### PR TITLE
[Representation] Prototype for watch count reduction

### DIFF
--- a/bundles.json
+++ b/bundles.json
@@ -24,6 +24,7 @@
     "platform/features/events",
     "platform/forms",
     "platform/identity",
+    "platform/observables",
     "platform/persistence/local",
     "platform/persistence/queue",
     "platform/policy",

--- a/platform/commonUI/browse/src/BrowseController.js
+++ b/platform/commonUI/browse/src/BrowseController.js
@@ -45,8 +45,9 @@ define(
          */
         function BrowseController($scope, $route, $location, objectService, navigationService, urlService) {
             var path = [ROOT_ID].concat(
-                ($route.current.params.ids || DEFAULT_PATH).split("/")
-            );
+                    ($route.current.params.ids || DEFAULT_PATH).split("/")
+                ),
+                unobserve;
 
             function updateRoute(domainObject) {
                 var priorRoute = $route.current,
@@ -148,10 +149,16 @@ define(
 
             // Also listen for changes which come from the tree
             $scope.$watch("treeModel.selectedObject", setNavigation);
+            $scope.$watch("treeModel.observableSelectedObject", function (obs) {
+                if (obs) {
+                    unobserve = obs.observe(setNavigation);
+                }
+            });
 
             // Clean up when the scope is destroyed
             $scope.$on("$destroy", function () {
                 navigationService.removeListener(setNavigation);
+                unobserve();
             });
         }
 

--- a/platform/commonUI/browse/src/MenuArrowController.js
+++ b/platform/commonUI/browse/src/MenuArrowController.js
@@ -28,11 +28,11 @@ define(
     [],
     function () {
         "use strict";
-        
+
         /**
-         * A left-click on the menu arrow should display a 
-         * context menu. This controller launches the context 
-         * menu. 
+         * A left-click on the menu arrow should display a
+         * context menu. This controller launches the context
+         * menu.
          * @memberof platform/commonUI/browse
          * @constructor
          */

--- a/platform/commonUI/browse/src/windowing/WindowTitler.js
+++ b/platform/commonUI/browse/src/windowing/WindowTitler.js
@@ -40,12 +40,11 @@ define(
             }
 
             // Set the window title...
-            function setTitle(name) {
-                $document[0].title = name;
+            function updateTitle() {
+                $document[0].title = getNavigatedObjectName();
             }
 
-            // Watch the former, and invoke the latter
-            $rootScope.$watch(getNavigatedObjectName, setTitle);
+            navigationService.addListener(updateTitle);
         }
 
         return WindowTitler;

--- a/platform/commonUI/dialog/src/OverlayService.js
+++ b/platform/commonUI/dialog/src/OverlayService.js
@@ -28,7 +28,7 @@ define(
 
         // Template to inject into the DOM to show the dialog; really just points to
         // the a specific template that can be included via mct-include
-        var TEMPLATE = '<mct-include ng-model="overlay" key="key" ng-class="typeClass"></mct-include>';
+        var TEMPLATE = '<span><mct-include ng-model="overlay" key="key" ng-class="typeClass"></mct-include></span>';
 
 
         /**

--- a/platform/commonUI/general/bundle.json
+++ b/platform/commonUI/general/bundle.json
@@ -85,7 +85,8 @@
             },
             {
                 "key": "ToggleController",
-                "implementation": "controllers/ToggleController.js"
+                "implementation": "controllers/ToggleController.js",
+                "depends": [ "Observable" ]
             },
             {
                 "key": "ContextMenuController",

--- a/platform/commonUI/general/bundle.json
+++ b/platform/commonUI/general/bundle.json
@@ -76,7 +76,7 @@
             {
                 "key": "TreeNodeController",
                 "implementation": "controllers/TreeNodeController.js",
-                "depends": [ "$scope", "$timeout" ]
+                "depends": [ "$scope", "$timeout", "Observable" ]
             },
             {
                 "key": "ActionGroupController",

--- a/platform/commonUI/general/res/templates/label.html
+++ b/platform/commonUI/general/res/templates/label.html
@@ -19,7 +19,9 @@
  this source code distribution or the Licensing information page available
  at runtime from the About dialog for additional information.
 -->
-<span class="t-object-label">
-<span class="t-item-icon" ng-class="{ 'l-icon-link':location.isLink() }">{{type.getGlyph()}}</span>
-<span class='t-title-label'>{{model.name}}</span>
+<span class="t-object-label"
+      mct-refresh="domainObject">
+    <span class="t-item-icon"
+          ng-class="::{ 'l-icon-link':location.isLink() }">{{::type.getGlyph()}}</span>
+    <span class='t-title-label'>{{::model.name}}</span>
 </span>

--- a/platform/commonUI/general/res/templates/subtree.html
+++ b/platform/commonUI/general/res/templates/subtree.html
@@ -31,7 +31,7 @@
         <mct-representation key="::'tree-node'"
                             mct-object="::child"
                             parameters="::parameters"
-                            ng-model="::ngModel">
+                            mct-model="::ngModel">
         </mct-representation>
     </li>
 </ul>

--- a/platform/commonUI/general/res/templates/subtree.html
+++ b/platform/commonUI/general/res/templates/subtree.html
@@ -19,7 +19,8 @@
  this source code distribution or the Licensing information page available
  at runtime from the About dialog for additional information.
 -->
-<ul class="tree">
+<ul class="tree"
+    ng-if="::(model.composition !== undefined)">
     <!-- li ng-if="!composition">
         <span class="tree-item">
             <span class="icon wait-spinner"></span>
@@ -27,7 +28,7 @@
         </span>
     </li -->
     <li ng-repeat="child in ::composition">
-        <mct-representation key="'tree-node'"
+        <mct-representation key="::'tree-node'"
                             mct-object="::child"
                             parameters="::parameters"
                             ng-model="::ngModel">

--- a/platform/commonUI/general/res/templates/subtree.html
+++ b/platform/commonUI/general/res/templates/subtree.html
@@ -20,17 +20,17 @@
  at runtime from the About dialog for additional information.
 -->
 <ul class="tree">
-    <li ng-if="!composition">
+    <!-- li ng-if="!composition">
         <span class="tree-item">
             <span class="icon wait-spinner"></span>
             <span class="title-label">Loading...</span>
         </span>
-    </li>
-    <li ng-repeat="child in composition">
+    </li -->
+    <li ng-repeat="child in ::composition">
         <mct-representation key="'tree-node'"
-                            mct-object="child"
-                            parameters="parameters"
-                            ng-model="ngModel">
+                            mct-object="::child"
+                            parameters="::parameters"
+                            ng-model="::ngModel">
         </mct-representation>
     </li>
 </ul>

--- a/platform/commonUI/general/res/templates/subtree.html
+++ b/platform/commonUI/general/res/templates/subtree.html
@@ -19,14 +19,13 @@
  this source code distribution or the Licensing information page available
  at runtime from the About dialog for additional information.
 -->
-<ul class="tree"
-    ng-if="::(model.composition !== undefined)">
-    <!-- li ng-if="!composition">
+<ul class="tree" mct-refresh="domainObject">
+    <li ng-hide="::composition">
         <span class="tree-item">
             <span class="icon wait-spinner"></span>
             <span class="title-label">Loading...</span>
         </span>
-    </li -->
+    </li>
     <li ng-repeat="child in ::composition">
         <mct-representation key="::'tree-node'"
                             mct-object="::child"

--- a/platform/commonUI/general/res/templates/tree-node.html
+++ b/platform/commonUI/general/res/templates/tree-node.html
@@ -57,7 +57,6 @@
             <span
                 mct-device="mobile"
                 class='ui-symbol view-control'
-                ng-model="::ngModel"
                 ng-click="treeNode.select()"
                 >
                 }
@@ -70,7 +69,7 @@
                 >
 
                 <mct-representation key="::'subtree'"
-                                    ng-model="::ngModel"
+                                    mct-model="::ngModel"
                                     parameters="::parameters"
                                     mct-object="::(treeNode.hasBeenExpanded() ? domainObject : undefined)">
                 </mct-representation>

--- a/platform/commonUI/general/res/templates/tree-node.html
+++ b/platform/commonUI/general/res/templates/tree-node.html
@@ -38,7 +38,7 @@
             <mct-representation
                 mct-device="desktop"
                 class="mobile-hide"
-                key="'label'"
+                key="::'label'"
                 mct-object="::domainObject"
                 ng-click="treeNode.select()"
                 >
@@ -46,7 +46,7 @@
             <mct-representation
                 mct-device="mobile"
                 class="desktop-hide"
-                key="'label'"
+                key="::'label'"
                 mct-object="::domainObject"
                 ng-click="(model.composition === undefined) && treeNode.select();
                           toggle.toggle();
@@ -69,7 +69,7 @@
                 ng-if="::(toggle.isActive())"
                 >
 
-                <mct-representation key="'subtree'"
+                <mct-representation key="::'subtree'"
                                     ng-model="::ngModel"
                                     parameters="::parameters"
                                     mct-object="::(treeNode.hasBeenExpanded() ? domainObject : undefined)">

--- a/platform/commonUI/general/res/templates/tree-node.html
+++ b/platform/commonUI/general/res/templates/tree-node.html
@@ -29,7 +29,7 @@
                 mct-device="desktop"
                 class='ui-symbol view-control'
                 ng-click="toggle.toggle(); treeNode.trackExpansion()"
-                ng-if="model.composition !== undefined"
+                ng-if="::(model.composition !== undefined)"
                 >
                 {{toggle.isActive() ? "v" : ">"}}
             </span>
@@ -38,7 +38,7 @@
                 mct-device="desktop"
                 class="mobile-hide"
                 key="'label'"
-                mct-object="domainObject"
+                mct-object="::domainObject"
                 ng-click="treeNode.select()"
                 >
             </mct-representation>
@@ -46,7 +46,7 @@
                 mct-device="mobile"
                 class="desktop-hide"
                 key="'label'"
-                mct-object="domainObject"
+                mct-object="::domainObject"
                 ng-click="(model.composition === undefined) && treeNode.select();
                           toggle.toggle();
                           treeNode.trackExpansion();"
@@ -56,7 +56,7 @@
             <span
                 mct-device="mobile"
                 class='ui-symbol view-control'
-                ng-model="ngModel"
+                ng-model="::ngModel"
                 ng-click="treeNode.select()"
                 >
                 }
@@ -65,13 +65,13 @@
         <span
             class="tree-item-subtree"
             ng-show="toggle.isActive()"
-            ng-if="model.composition !== undefined"
+            ng-if="::(model.composition !== undefined)"
             >
 
             <mct-representation key="'subtree'"
-                                ng-model="ngModel"
-                                parameters="parameters"
-                                mct-object="treeNode.hasBeenExpanded() && domainObject">
+                                ng-model="::ngModel"
+                                parameters="::parameters"
+                                mct-object="::(treeNode.hasBeenExpanded() ? domainObject : undefined)">
             </mct-representation>
 
         </span>

--- a/platform/commonUI/general/res/templates/tree-node.html
+++ b/platform/commonUI/general/res/templates/tree-node.html
@@ -22,6 +22,8 @@
 <span ng-controller="ToggleController as toggle">
     <span ng-controller="TreeNodeController as treeNode">
         <span
+            mct-observe="ngModel.observableSelectedObject"
+            ng-class="{selected: treeNode.isSelected()}"
             class="tree-item menus-to-left"
             >
             <span

--- a/platform/commonUI/general/res/templates/tree-node.html
+++ b/platform/commonUI/general/res/templates/tree-node.html
@@ -23,7 +23,6 @@
     <span ng-controller="TreeNodeController as treeNode">
         <span
             class="tree-item menus-to-left"
-            ng-class="{selected: treeNode.isSelected()}"
             >
             <span
                 mct-device="desktop"
@@ -31,7 +30,9 @@
                 ng-click="toggle.toggle(); treeNode.trackExpansion()"
                 ng-if="::(model.composition !== undefined)"
                 >
-                {{toggle.isActive() ? "v" : ">"}}
+                <span mct-observe="::toggle.state">
+                    {{::(toggle.isActive() ? "v" : ">")}}
+                </span>
             </span>
 
             <mct-representation
@@ -62,18 +63,19 @@
                 }
             </span>
         </span>
-        <span
-            class="tree-item-subtree"
-            ng-show="toggle.isActive()"
-            ng-if="::(model.composition !== undefined)"
-            >
+        <span mct-observe="::toggle.state">
+            <span
+                class="tree-item-subtree"
+                ng-if="::(toggle.isActive())"
+                >
 
-            <mct-representation key="'subtree'"
-                                ng-model="::ngModel"
-                                parameters="::parameters"
-                                mct-object="::(treeNode.hasBeenExpanded() ? domainObject : undefined)">
-            </mct-representation>
+                <mct-representation key="'subtree'"
+                                    ng-model="::ngModel"
+                                    parameters="::parameters"
+                                    mct-object="::(treeNode.hasBeenExpanded() ? domainObject : undefined)">
+                </mct-representation>
 
+            </span>
         </span>
     </span>
 </span>

--- a/platform/commonUI/general/res/templates/tree.html
+++ b/platform/commonUI/general/res/templates/tree.html
@@ -21,7 +21,7 @@
 -->
 <ul class="tree">
     <li>
-        <mct-representation key="'tree-node'"
+        <mct-representation key="::'tree-node'"
                             mct-object="::domainObject"
                             ng-model="::ngModel"
                             parameters="::parameters">

--- a/platform/commonUI/general/res/templates/tree.html
+++ b/platform/commonUI/general/res/templates/tree.html
@@ -23,7 +23,7 @@
     <li>
         <mct-representation key="::'tree-node'"
                             mct-object="::domainObject"
-                            ng-model="::ngModel"
+                            mct-model="::ngModel"
                             parameters="::parameters">
         </mct-representation>
     </li>

--- a/platform/commonUI/general/res/templates/tree.html
+++ b/platform/commonUI/general/res/templates/tree.html
@@ -22,9 +22,9 @@
 <ul class="tree">
     <li>
         <mct-representation key="'tree-node'"
-                            mct-object="domainObject"
-                            ng-model="ngModel"
-                            parameters="parameters">
+                            mct-object="::domainObject"
+                            ng-model="::ngModel"
+                            parameters="::parameters">
         </mct-representation>
     </li>
 </ul>

--- a/platform/commonUI/general/src/controllers/ToggleController.js
+++ b/platform/commonUI/general/src/controllers/ToggleController.js
@@ -33,8 +33,8 @@ define(
          * @memberof platform/commonUI/general
          * @constructor
          */
-        function ToggleController() {
-            this.state = false;
+        function ToggleController(Observable) {
+            this.state = new Observable(false);
         }
 
         /**
@@ -42,7 +42,7 @@ define(
          * @return {boolean} true if active
          */
         ToggleController.prototype.isActive = function () {
-            return this.state;
+            return this.state.get();
         };
 
         /**
@@ -50,7 +50,7 @@ define(
          * @return {boolean} true to activate
          */
         ToggleController.prototype.setState = function (newState) {
-            this.state = newState;
+            this.state.set(newState);
         };
 
         /**
@@ -58,7 +58,7 @@ define(
          * deactivate if it is active.
          */
         ToggleController.prototype.toggle = function () {
-            this.state = !this.state;
+            this.state.set(!this.state.get());
         };
 
         return ToggleController;

--- a/platform/commonUI/general/src/controllers/TreeNodeController.js
+++ b/platform/commonUI/general/src/controllers/TreeNodeController.js
@@ -145,8 +145,8 @@ define(
             this.$scope = $scope;
 
             // Listen for changes which will effect display parameters
-            $scope.$watch("ngModel.selectedObject", setSelection);
-            $scope.$watch("domainObject", checkSelection);
+            //$scope.$watch("ngModel.selectedObject", setSelection);
+            //$scope.$watch("domainObject", checkSelection);
         }
 
         /**

--- a/platform/commonUI/general/src/controllers/TreeNodeController.js
+++ b/platform/commonUI/general/src/controllers/TreeNodeController.js
@@ -60,9 +60,10 @@ define(
          * @memberof platform/commonUI/general
          * @constructor
          */
-        function TreeNodeController($scope, $timeout) {
+        function TreeNodeController($scope, $timeout, Observable) {
             var self = this,
                 selectedObject = ($scope.ngModel || {}).selectedObject,
+                unobserve,
                 isSelected = false,
                 hasBeenExpanded = false;
 
@@ -144,6 +145,17 @@ define(
             this.$timeout = $timeout;
             this.$scope = $scope;
 
+            $scope.ngModel.observableSelectedObject =
+                $scope.ngModel.observableSelectedObject ||
+                    new Observable($scope.ngModel.selectedObject);
+
+            unobserve = $scope.ngModel.observableSelectedObject
+                .observe(setSelection);
+            $scope.$on("$destroy", function () {
+                unobserve();
+            });
+
+
             // Listen for changes which will effect display parameters
             //$scope.$watch("ngModel.selectedObject", setSelection);
             //$scope.$watch("domainObject", checkSelection);
@@ -159,6 +171,8 @@ define(
             if (this.$scope.ngModel) {
                 this.$scope.ngModel.selectedObject =
                     this.$scope.domainObject;
+                this.$scope.ngModel.observableSelectedObject
+                    .set(this.$scope.domainObject);
             }
             if ((this.$scope.parameters || {}).callback) {
                 this.$scope.parameters.callback(this.$scope.domainObject);

--- a/platform/observables/bundle.json
+++ b/platform/observables/bundle.json
@@ -1,0 +1,7 @@
+{
+    "extensions": {
+        "directives": [
+
+        ]
+    }
+}

--- a/platform/observables/bundle.json
+++ b/platform/observables/bundle.json
@@ -1,7 +1,17 @@
 {
     "extensions": {
         "directives": [
-
+            {
+                "key": "mctObserve",
+                "implementation": "MCTObserve.js",
+                "depends": [ "throttle" ]
+            }
+        ],
+        "services": [
+            {
+                "key": "Observable",
+                "implementation": "ObservableExposer.js"
+            }
         ]
     }
 }

--- a/platform/observables/src/MCTObserve.js
+++ b/platform/observables/src/MCTObserve.js
@@ -1,0 +1,57 @@
+/*global define*/
+define(
+    [],
+    function () {
+        'use strict';
+
+        function MCTObserve(throttle) {
+
+            function link(scope, elem, attrs, ctrl, transclude) {
+                var unobserveFns = [],
+                    unwatch,
+                    scheduleRecreate;
+
+                function stopObserving() {
+                    unobserveFns.forEach(function (unobserve) {
+                        unobserve();
+                    });
+                    unobserveFns = [];
+                }
+
+                function recreateContents() {
+                    transclude(function (clone) {
+                        elem.empty();
+                        elem.append(clone);
+                    });
+                }
+
+                recreateContents();
+                scheduleRecreate = throttle(recreateContents);
+
+                unwatch = scope.$parent.$watch(attrs.mctObserve, function (observables) {
+                    stopObserving();
+                    unobserveFns = Object.keys(observables).map(function (key) {
+                        return observables[key].observe(function (newValue) {
+                            scope[key] = newValue;
+                            scheduleRecreate();
+                        });
+                    });
+                });
+
+                scope.$on('$destroy', function () {
+                    stopObserving();
+                    unwatch();
+                });
+            }
+
+            return {
+                restrict: 'A',
+                transclude: true,
+                link: link,
+                scope: true
+            };
+        }
+
+        return MCTObserve;
+    }
+);

--- a/platform/observables/src/MCTObserve.js
+++ b/platform/observables/src/MCTObserve.js
@@ -25,17 +25,12 @@ define(
                     });
                 }
 
-                recreateContents();
-                scheduleRecreate = throttle(recreateContents);
+                //recreateContents();
+                scheduleRecreate = throttle(recreateContents, 0);
 
-                unwatch = scope.$parent.$watch(attrs.mctObserve, function (observables) {
+                unwatch = scope.$parent.$watch(attrs.mctObserve, function (observable) {
                     stopObserving();
-                    unobserveFns = Object.keys(observables).map(function (key) {
-                        return observables[key].observe(function (newValue) {
-                            scope[key] = newValue;
-                            scheduleRecreate();
-                        });
-                    });
+                    unobserveFns = [observable.observe(scheduleRecreate)];
                 });
 
                 scope.$on('$destroy', function () {

--- a/platform/observables/src/Observable.js
+++ b/platform/observables/src/Observable.js
@@ -24,6 +24,7 @@ define(
         Observable.prototype.observe = function (listener) {
             var self = this;
             this.listeners.push(listener);
+            listener(this.get());
             return function () {
                 self.listeners = self.listeners.filter(function (fn) {
                     return fn !== listener;

--- a/platform/observables/src/Observable.js
+++ b/platform/observables/src/Observable.js
@@ -1,0 +1,36 @@
+/*global define*/
+
+define(
+    [],
+    function () {
+        'use strict';
+
+        function Observable(initialValue) {
+            this.value = initialValue;
+            this.listeners = [];
+        }
+
+        Observable.prototype.get = function () {
+            return this.value;
+        };
+
+        Observable.prototype.set = function (newValue) {
+            this.value = newValue;
+            this.listeners.forEach(function (listener) {
+                listener(newValue);
+            });
+        };
+
+        Observable.prototype.observe = function (listener) {
+            var self = this;
+            this.listeners.push(listener);
+            return function () {
+                self.listeners = self.listeners.filter(function (fn) {
+                    return fn !== listener;
+                });
+            };
+        };
+
+        return Observable;
+    }
+);

--- a/platform/observables/src/ObservableExposer.js
+++ b/platform/observables/src/ObservableExposer.js
@@ -1,0 +1,10 @@
+/*global define*/
+define(
+    ['./Observable'],
+    function (Observable) {
+        'use strict';
+        return function () {
+            return Observable;
+        };
+    }
+);

--- a/platform/representation/bundle.json
+++ b/platform/representation/bundle.json
@@ -10,6 +10,10 @@
                 "key": "mctRepresentation",
                 "implementation": "MCTRepresentation.js",
                 "depends": [ "representations[]", "views[]", "representers[]", "$q", "templateLinker", "$log" ]
+            },
+            {
+                "key": "mctRefresh",
+                "implementation": "MCTRefresh.js"
             }
         ],
         "gestures": [

--- a/platform/representation/src/MCTInclude.js
+++ b/platform/representation/src/MCTInclude.js
@@ -57,16 +57,19 @@ define(
         function MCTInclude(templates, templateLinker) {
             var templateMap = {};
 
-            function link(scope, element) {
+            function link(scope, element, attrs) {
                 var changeTemplate = templateLinker.link(
-                    scope,
-                    element,
-                    scope.key && templateMap[scope.key]
-                );
+                        scope,
+                        element,
+                        scope.key && templateMap[scope.key]
+                    ),
+                    unwatch;
 
-                scope.$watch('key', function (key) {
+                unwatch = scope.$parent.$watch(attrs.key, function (key) {
                     changeTemplate(key && templateMap[key]);
                 });
+
+                scope.$on("$destroy", unwatch);
             }
 
             // Prepopulate templateMap for easy look up by key
@@ -87,8 +90,8 @@ define(
                 // May hide the element, so let other directives act first
                 priority: -1000,
 
-                // Two-way bind key, ngModel, and parameters
-                scope: { key: "=", ngModel: "=", parameters: "=" }
+                // Two-way bind ngModel, and parameters
+                scope: { ngModel: "=", parameters: "=" }
             };
         }
 

--- a/platform/representation/src/MCTInclude.js
+++ b/platform/representation/src/MCTInclude.js
@@ -70,6 +70,9 @@ define(
                 });
 
                 scope.$on("$destroy", unwatch);
+
+                scope.ngModel = scope.$parent.$eval(attrs.ngModel);
+                scope.parameters = scope.$parent.$eval(attrs.parameters);
             }
 
             // Prepopulate templateMap for easy look up by key
@@ -91,7 +94,10 @@ define(
                 priority: -1000,
 
                 // Two-way bind ngModel, and parameters
-                scope: { ngModel: "=", parameters: "=" }
+                scope: {
+//                    ngModel: "=",
+//                    parameters: "="
+                }
             };
         }
 

--- a/platform/representation/src/MCTRefresh.js
+++ b/platform/representation/src/MCTRefresh.js
@@ -1,0 +1,33 @@
+/*global define*/
+define(
+    [],
+    function () {
+        'use strict';
+
+        function MCTRefresh() {
+
+            function link(scope, elem, attrs, ctrl, transclude) {
+                var domainObject = scope.$eval(attrs.mctRefresh),
+                    mutation = domainObject.getCapability('mutation'),
+                    unlisten;
+
+                function recreateContents() {
+                    transclude(function (clone) {
+                        elem.empty();
+                        elem.append(clone);
+                    });
+                }
+
+                unlisten = mutation.listen(recreateContents);
+                scope.$on("$destroy", unlisten);
+            }
+
+            return {
+                transclude: true,
+                link: link
+            };
+        }
+
+        return MCTRefresh;
+    }
+);

--- a/platform/representation/src/MCTRefresh.js
+++ b/platform/representation/src/MCTRefresh.js
@@ -18,6 +18,7 @@ define(
                     });
                 }
 
+                recreateContents();
                 unlisten = mutation.listen(recreateContents);
                 scope.$on("$destroy", unlisten);
             }

--- a/platform/representation/src/MCTRepresentation.js
+++ b/platform/representation/src/MCTRepresentation.js
@@ -93,7 +93,9 @@ define(
                 var activeRepresenters = representers.map(function (Representer) {
                         return new Representer($scope, element, attrs);
                     }),
+                    toUnwatch = [],
                     toClear = [], // Properties to clear out of scope on change
+                    unlisten,
                     counter = 0,
                     couldRepresent = false,
                     lastId,
@@ -137,10 +139,13 @@ define(
 
                 // Destroy (deallocate any resources associated with) any
                 // active representers.
-                function destroyRepresenters() {
+                function cleanup() {
                     activeRepresenters.forEach(function (activeRepresenter) {
                         activeRepresenter.destroy();
                     });
+                    if (unlisten) {
+                        unlisten();
+                    }
                 }
 
                 function unchanged(canRepresent, id, key) {
@@ -175,7 +180,7 @@ define(
                     changeTemplate(canRepresent ? path : undefined);
 
                     // Any existing representers are no longer valid; release them.
-                    destroyRepresenters();
+                    cleanup();
 
                     // Log if a key was given, but no matching representation
                     // was found.
@@ -196,6 +201,9 @@ define(
                     // Populate scope with fields associated with the current
                     // domain object (if one has been passed in)
                     if (canRepresent) {
+                        unlisten = domainObject.getCapability('mutation')
+                            .listen(refreshCapabilities);
+
                         // Track how many representations we've made in this scope,
                         // to ensure that the correct representations are matched to
                         // the correct object/key pairs.
@@ -223,20 +231,24 @@ define(
 
                 // Update the representation when the key changes (e.g. if a
                 // different representation has been selected)
-                $scope.$watch("key", refresh);
+                toUnwatch.push($scope.$parent.$watch(attrs.key, function (key) {
+                    $scope.key = key;
+                    refresh();
+                }));
 
                 // Also update when the represented domain object changes
                 // (to a different object)
-                $scope.$watch("domainObject", refresh);
-
-                // Finally, also update when there is a new version of that
-                // same domain object; these changes should be tracked in the
-                // model's "modified" field, by the mutation capability.
-                $scope.$watch("domainObject.getModel().modified", refreshCapabilities);
+                toUnwatch.push($scope.$parent.$watch(attrs.mctObject, function (domainObject) {
+                    $scope.domainObject = domainObject;
+                    refresh();
+                }));
 
                 // Make sure any resources allocated by representers also get
                 // released.
-                $scope.$on("$destroy", destroyRepresenters);
+                $scope.$on("$destroy", function () {
+                    cleanup();
+                    toUnwatch.forEach(function (unwatch) { unwatch(); });
+                });
 
                 // Do one initial refresh, so that we don't need another
                 // digest iteration just to populate the scope. Failure to
@@ -255,11 +267,8 @@ define(
                 // May hide the element, so let other directives act first
                 priority: -1000,
 
-                // Two-way bind key and parameters, get the represented domain
-                // object as "mct-object"
+                // Two-way bind ng-model and parameters
                 scope: {
-                    key: "=",
-                    domainObject: "=mctObject",
                     ngModel: "=",
                     parameters: "="
                 }

--- a/platform/representation/src/MCTRepresentation.js
+++ b/platform/representation/src/MCTRepresentation.js
@@ -255,6 +255,9 @@ define(
                 // do this can result in unstable digest cycles, which
                 // Angular will detect, and throw an Error about.
                 refresh();
+
+                $scope.ngModel = $scope.$parent.$eval(attrs.mctModel || attrs.ngModel);
+                $scope.parameters = $scope.$parent.$eval(attrs.parameters);
             }
 
             return {
@@ -269,8 +272,8 @@ define(
 
                 // Two-way bind ng-model and parameters
                 scope: {
-                    ngModel: "=",
-                    parameters: "="
+//                    ngModel: "=",
+//                    parameters: "="
                 }
             };
         }

--- a/platform/representation/src/actions/ContextMenuAction.js
+++ b/platform/representation/src/actions/ContextMenuAction.js
@@ -29,11 +29,11 @@ define(
     function (GestureConstants) {
         "use strict";
 
-        var MENU_TEMPLATE = "<mct-representation key=\"'context-menu'\" " +
+        var MENU_TEMPLATE = "<span><mct-representation key=\"'context-menu'\" " +
                 "mct-object=\"domainObject\" " +
                 "ng-class=\"menuClass\" " +
                 "ng-style=\"menuStyle\">" +
-                "</mct-representation>",
+                "</mct-representation></span>",
             dismissExistingMenu;
 
         /**


### PR DESCRIPTION
Following @akhenry's lead and opening for purposes of review/discussion. Prototype work for #300, not intended for integration; want to come out of this with concrete implementation tasks.

Summary of changes:
- Use one-time binding (::-prefixed expressions liberally)
- Add an `mct-refresh` directive which listens for mutation and re-renders its content
  - Used in conjunction with one-time binding, this allows things like labels to be watchless, but still stay up to date.
- Add an `mct-observe` directive which listens to observables (literally to some "observe" method) and re-renders its content when a callback is fired
  - Same rationale as above
  - Would like suggestions on how to clean this up and make its usage more obvious

Which would support a development pattern of:
- Implement first using plain-old-watches, with one-time binding where appropriate
- For templates which are part of performance bottlenecks, use some combination of `mct-observe` and `mct-refresh` to convert from a watch-driven to an event-driven paradigm
  - Notably, this isn't necessarily more efficient than using watches. Which approach is best depends on the frequency of changes. Things like the tree (which changes state almost exclusively due to user actions) are a good candidate

Still to-do:
- [x] Restore loading indicator in the tree
- [x] Re-enable highlighting & object selection in tree using observables
- [x] Track down the remaining watches in the tree (these still add up for large trees)
  - These were from:
    - Two-way binding for `mct-representation` and/or `mct-include`'s `ng-model` and `parameters` objects
    - `ng-model`-installed watches 
- [x] Change attribute name from `ng-model` to something else for templates/representations (`ng-model` adds watches, which is not what we want here)