### PR TITLE
[bug] TypeImpl.getInitialmodel should always return a fresh (ie. cloned) model.

### DIFF
--- a/platform/core/src/types/TypeImpl.js
+++ b/platform/core/src/types/TypeImpl.js
@@ -157,7 +157,7 @@ define(
         };
 
         TypeImpl.prototype.getInitialModel = function () {
-            return this.typeDef.model || {};
+            return JSON.parse(JSON.stringify(this.typeDef.model || {}));
         };
 
         TypeImpl.prototype.getDefinition = function () {

--- a/platform/core/src/types/TypeImpl.js
+++ b/platform/core/src/types/TypeImpl.js
@@ -156,6 +156,13 @@ define(
             });
         };
 
+        /**
+         * Returns the default model for an object of this type. Note that
+         * this method returns a clone of the original model, so if using this
+         * method heavily, consider caching the result to optimize performance.
+         *
+         * @return {object} The default model for an object of this type.
+         */
         TypeImpl.prototype.getInitialModel = function () {
             return JSON.parse(JSON.stringify(this.typeDef.model || {}));
         };

--- a/platform/core/test/types/TypeImplSpec.js
+++ b/platform/core/test/types/TypeImplSpec.js
@@ -102,6 +102,8 @@ define(
             });
 
             it("provides a fresh initial model each time", function () {
+                var model = type.getInitialModel();
+                model.someKey = "some other value"
                 expect(type.getInitialModel().someKey).toEqual("some value");
             });
 

--- a/platform/core/test/types/TypeImplSpec.js
+++ b/platform/core/test/types/TypeImplSpec.js
@@ -103,7 +103,7 @@ define(
 
             it("provides a fresh initial model each time", function () {
                 var model = type.getInitialModel();
-                model.someKey = "some other value"
+                model.someKey = "some other value";
                 expect(type.getInitialModel().someKey).toEqual("some value");
             });
 

--- a/platform/core/test/types/TypeImplSpec.js
+++ b/platform/core/test/types/TypeImplSpec.js
@@ -101,6 +101,10 @@ define(
                 expect(type.getInitialModel().someKey).toEqual("some value");
             });
 
+            it("provides a fresh initial model each time", function () {
+                expect(type.getInitialModel().someKey).toEqual("some value");
+            });
+
             it("provides type properties", function () {
                 expect(type.getProperties().length).toEqual(1);
             });


### PR DESCRIPTION
See #316