### PR TITLE
[Status] Add status tracking

### DIFF
--- a/bundles.json
+++ b/bundles.json
@@ -29,6 +29,7 @@
     "platform/policy",
     "platform/entanglement",
     "platform/search",
+    "platform/status",
 
     "example/imagery",
     "example/eventGenerator",

--- a/docs/src/guide/index.md
+++ b/docs/src/guide/index.md
@@ -2056,6 +2056,31 @@ objects which has a `relationships` property in their model, whose value is an
 object containing key-value pairs, where keys are strings identifying 
 relationship types, and values are arrays of domain object identifiers.
 
+## Status Capability
+
+The `status` capability provides a way to flag domain objects as possessing
+certain states, represented as simple strings. These states, in turn, are
+reflected on `mct-representation` elements as classes (prefixed with
+`s-status-`.) The `status` capability has the following interface:
+
+* `get()`: Returns an array of all status strings that currently apply
+  to this object.
+* `set(status, state)`: Adds or removes a status flag to this domain object.
+  The `status` argument is the string to set; `state` is a boolean
+  indicating whether this status should be included (true) or removed (false).
+* `listen(callback)`: Listen for changes in status. The provided `callback`
+  will be invoked with an array of all current status strings whenever status
+  changes.
+
+Plug-ins may add and/or recognize arbitrary status flags. Flags defined
+and/or supported by the platform are:
+
+ Status    | CSS Class          | Meaning
+-----------|--------------------|-----------------------------------
+`editing`  | `s-status-editing` | Domain object is being edited.
+`pending`  | `s-status-pending` | Domain object is partially loaded.
+
+
 ## Telemetry Capability
 
 The telemetry capability provides a means for accessing telemetry data 

--- a/platform/status/README.md
+++ b/platform/status/README.md
@@ -1,0 +1,2 @@
+Facilitates tracking states associated with specific domain
+objects.

--- a/platform/status/bundle.json
+++ b/platform/status/bundle.json
@@ -1,0 +1,23 @@
+{
+    "extensions": {
+        "representers": [
+            {
+                "implementation": "StatusRepresenter.js"
+            }
+        ],
+        "capabilities": [
+            {
+                "key": "status",
+                "implementation": "StatusCapability.js",
+                "depends": [ "statusService" ]
+            }
+        ],
+        "services": [
+            {
+                "key": "statusService",
+                "implementation": "StatusService.js",
+                "depends": [ "topic" ]
+            }
+        ]
+    }
+}

--- a/platform/status/src/StatusCapability.js
+++ b/platform/status/src/StatusCapability.js
@@ -49,11 +49,20 @@ define(
         }
 
         /**
-         * Get all status flags currently set for this domain object.
+         * List all status flags currently set for this domain object.
          * @returns {string[]} all current status flags.
          */
-        StatusCapability.prototype.get = function () {
-            return this.statusService.getStatus(this.domainObject.getId());
+        StatusCapability.prototype.list = function () {
+            return this.statusService.listStatuses(this.domainObject.getId());
+        };
+
+        /**
+         * Check if a status flag is currently set for this domain object.
+         * @param {string} status the status to get
+         * @returns {boolean} true if the flag is present, otherwise false
+         */
+        StatusCapability.prototype.get = function (status) {
+            return this.list().indexOf(status) !== -1;
         };
 
         /**

--- a/platform/status/src/StatusCapability.js
+++ b/platform/status/src/StatusCapability.js
@@ -26,15 +26,42 @@ define(
     function () {
         'use strict';
 
+        /**
+         * The `status` capability can be used to attach information
+         * about the state of a domain object, expressed as simple
+         * string flags.
+         *
+         * Representations of domain objects will also receive CSS
+         * classes which reflect their current status.
+         * (@see platform/status.StatusRepresenter)
+         *
+         * @param {platform/status.StatusService} statusService
+         *        the service which will track domain object status
+         *        within the application.
+         * @param {DomainObject} the domain object whose status will
+         *        be tracked.
+         * @constructor
+         * @memberof platform/status
+         */
         function StatusCapability(statusService, domainObject) {
             this.statusService = statusService;
             this.domainObject = domainObject;
         }
 
+        /**
+         * Get all status flags currently set for this domain object.
+         * @returns {string[]} all current status flags.
+         */
         StatusCapability.prototype.get = function () {
             return this.statusService.getStatus(this.domainObject.getId());
         };
 
+        /**
+         * Set a status flag on this domain object.
+         * @param {string} status the status to set
+         * @param {boolean} state true if the domain object should
+         *        possess this status, false if it should not
+         */
         StatusCapability.prototype.set = function (status, state) {
             return this.statusService.setStatus(
                 this.domainObject.getId(),
@@ -43,6 +70,14 @@ define(
             );
         };
 
+        /**
+         * Listen for changes in this domain object's status.
+         * @param {Function} callback function to invoke on changes;
+         *        called with the new status of the domain object, as an
+         *        array of strings
+         * @returns {Function} a function which can be used to stop
+         *          listening to status changes for this domain object.
+         */
         StatusCapability.prototype.listen = function (callback) {
             return this.statusService.listen(
                 this.domainObject.getId(),

--- a/platform/status/src/StatusCapability.js
+++ b/platform/status/src/StatusCapability.js
@@ -1,0 +1,56 @@
+/*****************************************************************************
+ * Open MCT Web, Copyright (c) 2014-2015, United States Government
+ * as represented by the Administrator of the National Aeronautics and Space
+ * Administration. All rights reserved.
+ *
+ * Open MCT Web is licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * Open MCT Web includes source code licensed under additional open source
+ * licenses. See the Open Source Licenses file (LICENSES.md) included with
+ * this source code distribution or the Licensing information page available
+ * at runtime from the About dialog for additional information.
+ *****************************************************************************/
+/*global define*/
+
+define(
+    [],
+    function () {
+        'use strict';
+
+        function StatusCapability(statusService, domainObject) {
+            this.statusService = statusService;
+            this.domainObject = domainObject;
+        }
+
+        StatusCapability.prototype.get = function () {
+            return this.statusService.getStatus(this.domainObject.getId());
+        };
+
+        StatusCapability.prototype.set = function (status, state) {
+            return this.statusService.setStatus(
+                this.domainObject.getId(),
+                status,
+                state
+            );
+        };
+
+        StatusCapability.prototype.listen = function (callback) {
+            return this.statusService.listen(
+                this.domainObject.getId(),
+                callback
+            );
+        };
+
+        return StatusCapability;
+
+    }
+);

--- a/platform/status/src/StatusConstants.js
+++ b/platform/status/src/StatusConstants.js
@@ -1,0 +1,26 @@
+/*****************************************************************************
+ * Open MCT Web, Copyright (c) 2014-2015, United States Government
+ * as represented by the Administrator of the National Aeronautics and Space
+ * Administration. All rights reserved.
+ *
+ * Open MCT Web is licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * Open MCT Web includes source code licensed under additional open source
+ * licenses. See the Open Source Licenses file (LICENSES.md) included with
+ * this source code distribution or the Licensing information page available
+ * at runtime from the About dialog for additional information.
+ *****************************************************************************/
+/*global define*/
+define({
+    CSS_CLASS_PREFIX: 's-status-',
+    TOPIC_PREFIX: 'status:'
+});

--- a/platform/status/src/StatusRepresenter.js
+++ b/platform/status/src/StatusRepresenter.js
@@ -77,7 +77,7 @@ define(
                 self.lastClasses = newClasses;
             }
 
-            updateStatus(statusCapability.get());
+            updateStatus(statusCapability.list());
             this.unlisten = statusCapability.listen(updateStatus);
         };
 

--- a/platform/status/src/StatusRepresenter.js
+++ b/platform/status/src/StatusRepresenter.js
@@ -48,6 +48,17 @@ define(
             this.lastClasses = [];
         }
 
+        /**
+         * Remove any status-related classes from this representation.
+         * @private
+         */
+        StatusRepresenter.prototype.clearClasses = function () {
+            var element = this.element;
+            this.lastClasses.forEach(function (c) {
+                element.removeClass(c);
+            });
+        };
+
         StatusRepresenter.prototype.represent = function (representation, domainObject) {
             var self = this,
                 statusCapability = domainObject.getCapability('status');
@@ -57,9 +68,7 @@ define(
                     return STATUS_CLASS_PREFIX + flag;
                 });
 
-                self.lastClasses.forEach(function (c) {
-                    self.element.removeClass(c);
-                });
+                self.clearClasses();
 
                 newClasses.forEach(function (c) {
                     self.element.addClass(c);
@@ -73,6 +82,7 @@ define(
         };
 
         StatusRepresenter.prototype.destroy = function () {
+            this.clearClasses();
             if (this.unlisten) {
                 this.unlisten();
                 this.unlisten = undefined;

--- a/platform/status/src/StatusRepresenter.js
+++ b/platform/status/src/StatusRepresenter.js
@@ -26,8 +26,23 @@ define(
     function () {
         'use strict';
 
-        var STATUS_CLASS_PREFIX = "l-status-";
+        var STATUS_CLASS_PREFIX = "s-status-";
 
+        /**
+         * Adds/removes CSS classes to `mct-representation`s to reflect the
+         * current status of represented domain objects, as reported by
+         * their `status` capability.
+         *
+         * Statuses are prefixed with `s-status-` to build CSS class names.
+         * As such, when a domain object has the status "pending", its
+         * representations will have the CSS class `s-status-pending`.
+         *
+         * @param {angular.Scope} scope the representation's scope object
+         * @param element the representation's jqLite-wrapped DOM element
+         * @implements {Representer}
+         * @constructor
+         * @memberof platform/status
+         */
         function StatusRepresenter(scope, element) {
             this.element = element;
             this.lastClasses = [];

--- a/platform/status/src/StatusRepresenter.js
+++ b/platform/status/src/StatusRepresenter.js
@@ -22,11 +22,11 @@
 /*global define*/
 
 define(
-    [],
-    function () {
+    ['./StatusConstants'],
+    function (StatusConstants) {
         'use strict';
 
-        var STATUS_CLASS_PREFIX = "s-status-";
+        var STATUS_CLASS_PREFIX = StatusConstants.CSS_CLASS_PREFIX;
 
         /**
          * Adds/removes CSS classes to `mct-representation`s to reflect the

--- a/platform/status/src/StatusRepresenter.js
+++ b/platform/status/src/StatusRepresenter.js
@@ -1,0 +1,71 @@
+/*****************************************************************************
+ * Open MCT Web, Copyright (c) 2014-2015, United States Government
+ * as represented by the Administrator of the National Aeronautics and Space
+ * Administration. All rights reserved.
+ *
+ * Open MCT Web is licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * Open MCT Web includes source code licensed under additional open source
+ * licenses. See the Open Source Licenses file (LICENSES.md) included with
+ * this source code distribution or the Licensing information page available
+ * at runtime from the About dialog for additional information.
+ *****************************************************************************/
+/*global define*/
+
+define(
+    [],
+    function () {
+        'use strict';
+
+        var STATUS_CLASS_PREFIX = "l-status-";
+
+        function StatusRepresenter(scope, element) {
+            this.element = element;
+            this.lastClasses = [];
+        }
+
+        StatusRepresenter.prototype.represent = function (representation, domainObject) {
+            var self = this,
+                statusCapability = domainObject.getCapability('status');
+
+            function updateStatus(flags) {
+                var newClasses = flags.map(function (flag) {
+                    return STATUS_CLASS_PREFIX + flag;
+                });
+
+                self.lastClasses.forEach(function (c) {
+                    self.element.removeClass(c);
+                });
+
+                newClasses.forEach(function (c) {
+                    self.element.addClass(c);
+                });
+
+                self.lastClasses = newClasses;
+            }
+
+            updateStatus(statusCapability.get());
+            this.unlisten = statusCapability.listen(updateStatus);
+        };
+
+        StatusRepresenter.prototype.destroy = function () {
+            if (this.unlisten) {
+                this.unlisten();
+                this.unlisten = undefined;
+            }
+        };
+
+
+        return StatusRepresenter;
+
+    }
+);

--- a/platform/status/src/StatusService.js
+++ b/platform/status/src/StatusService.js
@@ -51,7 +51,7 @@ define(
          * @returns {string[]} an array containing all status flags currently
          *          applicable to the object with this identifier
          */
-        StatusService.prototype.getStatus = function (id) {
+        StatusService.prototype.listStatuses = function (id) {
             return this.statusTable[id] || [];
         };
 

--- a/platform/status/src/StatusService.js
+++ b/platform/status/src/StatusService.js
@@ -22,11 +22,11 @@
 /*global define*/
 
 define(
-    [],
-    function () {
+    ['./StatusConstants'],
+    function (StatusConstants) {
         'use strict';
 
-        var STATUS_PREFIX = "status:";
+        var STATUS_PREFIX = StatusConstants.TOPIC_PREFIX;
 
         /**
          * The `statusService` maintains information about the current

--- a/platform/status/src/StatusService.js
+++ b/platform/status/src/StatusService.js
@@ -1,0 +1,62 @@
+/*****************************************************************************
+ * Open MCT Web, Copyright (c) 2014-2015, United States Government
+ * as represented by the Administrator of the National Aeronautics and Space
+ * Administration. All rights reserved.
+ *
+ * Open MCT Web is licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * Open MCT Web includes source code licensed under additional open source
+ * licenses. See the Open Source Licenses file (LICENSES.md) included with
+ * this source code distribution or the Licensing information page available
+ * at runtime from the About dialog for additional information.
+ *****************************************************************************/
+/*global define*/
+
+define(
+    [],
+    function () {
+        'use strict';
+
+        var STATUS_PREFIX = "status:";
+
+        function StatusService(topic) {
+            this.statusTable = {};
+            this.topic = topic;
+        }
+
+        /**
+         * @returns {string[]} an array containing all status flags currently
+         *          applicable to the object with this identifier
+         */
+        StatusService.prototype.getStatus = function (id) {
+            return this.statusTable[id] || [];
+        };
+
+        StatusService.prototype.setStatus = function (id, status, state) {
+            this.statusTable[id] = this.statusTable[id] || [];
+            this.statusTable[id] = this.statusTable[id].filter(function (s) {
+                return s !== status;
+            });
+            if (state) {
+                this.statusTable[id].push(status);
+            }
+            this.topic(STATUS_PREFIX + id).notify(this.statusTable[id]);
+        };
+
+        StatusService.prototype.listen = function (id, callback) {
+            return this.topic(STATUS_PREFIX + id).listen(callback);
+        };
+
+        return StatusService;
+
+    }
+);

--- a/platform/status/src/StatusService.js
+++ b/platform/status/src/StatusService.js
@@ -28,12 +28,26 @@ define(
 
         var STATUS_PREFIX = "status:";
 
+        /**
+         * The `statusService` maintains information about the current
+         * status of specific domain objects within the system. Status
+         * is represented as string flags which are present when a
+         * domain object possesses that status, and false when it does
+         * not.
+         *
+         * @param {platform/core.Topic} topic the `topic` service, used
+         *        to create/use named listeners.
+         * @constructor
+         * @memberof platform/status
+         */
         function StatusService(topic) {
             this.statusTable = {};
             this.topic = topic;
         }
 
         /**
+         * Get all status flags currently set for a domain object.
+         * @param {string} id the identifier of the domain object
          * @returns {string[]} an array containing all status flags currently
          *          applicable to the object with this identifier
          */
@@ -41,6 +55,13 @@ define(
             return this.statusTable[id] || [];
         };
 
+        /**
+         * Set a status flag for a domain object.
+         * @param {string} id the identifier of the domain object
+         * @param {string} status the status to set
+         * @param {boolean} state true if the domain object should
+         *        possess this status, false if it should not
+         */
         StatusService.prototype.setStatus = function (id, status, state) {
             this.statusTable[id] = this.statusTable[id] || [];
             this.statusTable[id] = this.statusTable[id].filter(function (s) {
@@ -52,6 +73,15 @@ define(
             this.topic(STATUS_PREFIX + id).notify(this.statusTable[id]);
         };
 
+        /**
+         * Listen for changes in a domain object's status.
+         * @param {string} id the identifier of the domain object
+         * @param {Function} callback function to invoke on changes;
+         *        called with the new status of the domain object, as an
+         *        array of strings
+         * @returns {Function} a function which can be used to stop
+         *          listening to status changes for this domain object.
+         */
         StatusService.prototype.listen = function (id, callback) {
             return this.topic(STATUS_PREFIX + id).listen(callback);
         };

--- a/platform/status/test/StatusCapabilitySpec.js
+++ b/platform/status/test/StatusCapabilitySpec.js
@@ -27,6 +27,58 @@ define(
         "use strict";
 
         describe("The status capability", function () {
+            var mockStatusService,
+                mockDomainObject,
+                mockUnlisten,
+                testId,
+                testStatusFlags,
+                capability;
+
+            beforeEach(function () {
+                testId = "some-id";
+                testStatusFlags = [ 'a', 'b', 'c' ];
+
+                mockStatusService = jasmine.createSpyObj(
+                    'statusService',
+                    [ 'listen', 'setStatus', 'getStatus' ]
+                );
+                mockDomainObject = jasmine.createSpyObj(
+                    'domainObject',
+                    [ 'getId', 'getCapability', 'getModel' ]
+                );
+                mockUnlisten = jasmine.createSpy('unlisten');
+
+                mockStatusService.listen.andReturn(mockUnlisten);
+                mockStatusService.getStatus.andReturn(testStatusFlags);
+                mockDomainObject.getId.andReturn(testId);
+
+                capability = new StatusCapability(
+                    mockStatusService,
+                    mockDomainObject
+                );
+            });
+
+            it("sets status with the statusService", function () {
+                var testStatus = "some-test-status";
+                capability.set(testStatus, true);
+                expect(mockStatusService.setStatus)
+                    .toHaveBeenCalledWith(testId, testStatus, true);
+                capability.set(testStatus, false);
+                expect(mockStatusService.setStatus)
+                    .toHaveBeenCalledWith(testId, testStatus, false);
+            });
+
+            it("gets status from the statusService", function () {
+                expect(capability.get()).toBe(testStatusFlags);
+            });
+
+            it("listens to changes from the statusService", function () {
+                var mockCallback = jasmine.createSpy();
+                expect(capability.listen(mockCallback))
+                    .toBe(mockUnlisten);
+                expect(mockStatusService.listen)
+                    .toHaveBeenCalledWith(testId, mockCallback);
+            });
         });
     }
 );

--- a/platform/status/test/StatusCapabilitySpec.js
+++ b/platform/status/test/StatusCapabilitySpec.js
@@ -1,0 +1,32 @@
+/*****************************************************************************
+ * Open MCT Web, Copyright (c) 2014-2015, United States Government
+ * as represented by the Administrator of the National Aeronautics and Space
+ * Administration. All rights reserved.
+ *
+ * Open MCT Web is licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * Open MCT Web includes source code licensed under additional open source
+ * licenses. See the Open Source Licenses file (LICENSES.md) included with
+ * this source code distribution or the Licensing information page available
+ * at runtime from the About dialog for additional information.
+ *****************************************************************************/
+/*global define,Promise,describe,it,expect,beforeEach,waitsFor,jasmine*/
+
+define(
+    ["../src/StatusCapability"],
+    function (StatusCapability) {
+        "use strict";
+
+        describe("The status capability", function () {
+        });
+    }
+);

--- a/platform/status/test/StatusCapabilitySpec.js
+++ b/platform/status/test/StatusCapabilitySpec.js
@@ -40,7 +40,7 @@ define(
 
                 mockStatusService = jasmine.createSpyObj(
                     'statusService',
-                    [ 'listen', 'setStatus', 'getStatus' ]
+                    [ 'listen', 'setStatus', 'listStatuses' ]
                 );
                 mockDomainObject = jasmine.createSpyObj(
                     'domainObject',
@@ -49,7 +49,7 @@ define(
                 mockUnlisten = jasmine.createSpy('unlisten');
 
                 mockStatusService.listen.andReturn(mockUnlisten);
-                mockStatusService.getStatus.andReturn(testStatusFlags);
+                mockStatusService.listStatuses.andReturn(testStatusFlags);
                 mockDomainObject.getId.andReturn(testId);
 
                 capability = new StatusCapability(
@@ -69,7 +69,7 @@ define(
             });
 
             it("gets status from the statusService", function () {
-                expect(capability.get()).toBe(testStatusFlags);
+                expect(capability.list()).toBe(testStatusFlags);
             });
 
             it("listens to changes from the statusService", function () {
@@ -78,6 +78,11 @@ define(
                     .toBe(mockUnlisten);
                 expect(mockStatusService.listen)
                     .toHaveBeenCalledWith(testId, mockCallback);
+            });
+
+            it("allows statuses to be checked individually", function () {
+                expect(capability.get('some-unset-status')).toBe(false);
+                expect(capability.get(testStatusFlags[0])).toBe(true);
             });
         });
     }

--- a/platform/status/test/StatusRepresenterSpec.js
+++ b/platform/status/test/StatusRepresenterSpec.js
@@ -1,0 +1,32 @@
+/*****************************************************************************
+ * Open MCT Web, Copyright (c) 2014-2015, United States Government
+ * as represented by the Administrator of the National Aeronautics and Space
+ * Administration. All rights reserved.
+ *
+ * Open MCT Web is licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * Open MCT Web includes source code licensed under additional open source
+ * licenses. See the Open Source Licenses file (LICENSES.md) included with
+ * this source code distribution or the Licensing information page available
+ * at runtime from the About dialog for additional information.
+ *****************************************************************************/
+/*global define,Promise,describe,it,expect,beforeEach,waitsFor,jasmine*/
+
+define(
+    ["../src/StatusRepresenter"],
+    function (StatusRepresenter) {
+        "use strict";
+
+        describe("The status representer", function () {
+        });
+    }
+);

--- a/platform/status/test/StatusRepresenterSpec.js
+++ b/platform/status/test/StatusRepresenterSpec.js
@@ -66,7 +66,7 @@ define(
                 );
                 mockStatusCapability = jasmine.createSpyObj(
                     'status',
-                    [ 'get', 'set', 'listen' ]
+                    [ 'list', 'get', 'set', 'listen' ]
                 );
                 mockUnlisten = jasmine.createSpy();
 
@@ -79,7 +79,7 @@ define(
                     delete elementClasses[c];
                 });
 
-                mockStatusCapability.get.andReturn(testStatusFlags);
+                mockStatusCapability.list.andReturn(testStatusFlags);
                 mockStatusCapability.listen.andReturn(mockUnlisten);
 
                 mockDomainObject.getCapability.andCallFake(function (c) {

--- a/platform/status/test/StatusServiceSpec.js
+++ b/platform/status/test/StatusServiceSpec.js
@@ -1,0 +1,32 @@
+/*****************************************************************************
+ * Open MCT Web, Copyright (c) 2014-2015, United States Government
+ * as represented by the Administrator of the National Aeronautics and Space
+ * Administration. All rights reserved.
+ *
+ * Open MCT Web is licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * Open MCT Web includes source code licensed under additional open source
+ * licenses. See the Open Source Licenses file (LICENSES.md) included with
+ * this source code distribution or the Licensing information page available
+ * at runtime from the About dialog for additional information.
+ *****************************************************************************/
+/*global define,Promise,describe,it,expect,beforeEach,waitsFor,jasmine*/
+
+define(
+    ["../src/StatusService"],
+    function (StatusService) {
+        "use strict";
+
+        describe("The status service", function () {
+        });
+    }
+);

--- a/platform/status/test/StatusServiceSpec.js
+++ b/platform/status/test/StatusServiceSpec.js
@@ -54,14 +54,14 @@ define(
             });
 
             it("initially contains no flags for an object", function () {
-                expect(statusService.getStatus(testId)).toEqual([]);
+                expect(statusService.listStatuses(testId)).toEqual([]);
             });
 
             it("stores and clears status flags", function () {
                 statusService.setStatus(testId, testStatus, true);
-                expect(statusService.getStatus(testId)).toEqual([testStatus]);
+                expect(statusService.listStatuses(testId)).toEqual([testStatus]);
                 statusService.setStatus(testId, testStatus, false);
-                expect(statusService.getStatus(testId)).toEqual([]);
+                expect(statusService.listStatuses(testId)).toEqual([]);
             });
 
             it("uses topic to listen for changes", function () {

--- a/platform/status/test/suite.json
+++ b/platform/status/test/suite.json
@@ -1,0 +1,5 @@
+[
+    "StatusCapability",
+    "StatusRepresenter",
+    "StatusService"
+]


### PR DESCRIPTION
Add status tracking for domain objects, and decoration of
representations with status-related classes. Supports WTD-1575
by allowing pending state of taxonomy to be handled by
status tracking and custom CSS, instead of by overriding platform
templates.

Opening for early review; still need:

- [x] ~~Reduce number of listeners~~ No observable performance/memory issues here, leaving as-is
- [x] Add tests
- [x] JSDoc