### PR TITLE
[Time Conductor] Don't update model while typing

### DIFF
--- a/platform/commonUI/general/res/templates/controls/datetime-field.html
+++ b/platform/commonUI/general/res/templates/controls/datetime-field.html
@@ -1,6 +1,7 @@
 <span class="s-btn"
       ng-controller="DateTimeFieldController">
     <input type="text"
+           ng-blur="updateFromView(textValue)"
            ng-model="textValue"
            ng-class="{ error: textInvalid }">
     </input>

--- a/platform/commonUI/general/res/templates/controls/datetime-field.html
+++ b/platform/commonUI/general/res/templates/controls/datetime-field.html
@@ -1,14 +1,17 @@
 <span class="s-btn"
       ng-controller="DateTimeFieldController">
-    <input type="text"
-           ng-blur="updateFromView(textValue)"
-           ng-model="textValue"
-           ng-class="{ error: textInvalid }">
-    </input>
-    <a class="ui-symbol icon icon-calendar"
-       ng-if="structure.format === 'utc' || !structure.format"
-       ng-click="picker.active = !picker.active">
-    </a>
+    <form ng-submit="updateFromView(textValue)">
+        <input type="text"
+               ng-blur="updateFromView(textValue)"
+               ng-model="textValue"
+               ng-class="{ error: textInvalid }">
+        </input>
+
+        <a class="ui-symbol icon icon-calendar"
+           ng-if="structure.format === 'utc' || !structure.format"
+           ng-click="picker.active = !picker.active">
+        </a>
+    </form>
     <mct-popup ng-if="picker.active">
         <div mct-click-elsewhere="picker.active = false">
             <mct-control key="'datetime-picker'"

--- a/platform/commonUI/general/src/controllers/DateTimeFieldController.js
+++ b/platform/commonUI/general/src/controllers/DateTimeFieldController.js
@@ -57,11 +57,14 @@ define(
             }
 
             function updateFromView(textValue) {
-                $scope.textInvalid = !formatter.validate(textValue);
                 if (!$scope.textInvalid) {
                     $scope.ngModel[$scope.field] =
                         formatter.parse(textValue);
                 }
+            }
+
+            function checkValidity(textValue) {
+                $scope.textInvalid = !formatter.validate(textValue);
             }
 
             function setFormat(format) {
@@ -70,11 +73,11 @@ define(
             }
 
             $scope.picker = { active: false };
+            $scope.updateFromView = updateFromView;
 
             $scope.$watch('structure.format', setFormat);
             $scope.$watch('ngModel[field]', updateFromModel);
-            $scope.$watch('textValue', updateFromView);
-
+            $scope.$watch('textValue', checkValidity);
         }
 
         return DateTimeFieldController;

--- a/platform/commonUI/general/src/controllers/DateTimeFieldController.js
+++ b/platform/commonUI/general/src/controllers/DateTimeFieldController.js
@@ -60,6 +60,8 @@ define(
                 if (!$scope.textInvalid) {
                     $scope.ngModel[$scope.field] =
                         formatter.parse(textValue);
+                } else {
+                    updateFromModel($scope.ngModel[$scope.field]);
                 }
             }
 

--- a/platform/commonUI/general/test/controllers/DateTimeFieldControllerSpec.js
+++ b/platform/commonUI/general/test/controllers/DateTimeFieldControllerSpec.js
@@ -104,7 +104,9 @@ define(
                 var newText, oldText, oldValue;
 
                 beforeEach(function () {
+                    fireWatch("ngModel[field]", mockScope.ngModel.testField);
                     newText = "Not a date";
+                    oldText = mockScope.textValue;
                     oldValue = mockScope.ngModel.testField;
                     mockScope.textValue = newText;
                     fireWatch("textValue", newText);
@@ -125,6 +127,10 @@ define(
 
                     it("does not modify model state", function () {
                         expect(mockScope.ngModel.testField).toEqual(oldValue);
+                    });
+
+                    it("restores original text", function () {
+                        expect(mockScope.textValue).toEqual(oldText);
                     });
                 });
             });

--- a/platform/commonUI/general/test/controllers/DateTimeFieldControllerSpec.js
+++ b/platform/commonUI/general/test/controllers/DateTimeFieldControllerSpec.js
@@ -42,6 +42,12 @@ define(
                 });
             }
 
+            function updateText(newText) {
+                mockScope.textValue = newText;
+                fireWatch("textValue", newText);
+                mockScope.updateFromView(newText);
+            }
+
             beforeEach(function () {
                 mockScope = jasmine.createSpyObj('$scope', ['$watch']);
                 mockFormatService =
@@ -77,8 +83,7 @@ define(
             it("updates models from user-entered text", function () {
                 var newText = "1977-05-25 17:30:00";
 
-                mockScope.textValue = newText;
-                fireWatch("textValue", newText);
+                updateText(newText);
                 expect(mockScope.ngModel.testField)
                     .toEqual(mockFormat.parse(newText));
                 expect(mockScope.textInvalid).toBeFalsy();
@@ -101,8 +106,7 @@ define(
                 beforeEach(function () {
                     newText = "Not a date";
                     oldValue = mockScope.ngModel.testField;
-                    mockScope.textValue = newText;
-                    fireWatch("textValue", newText);
+                    updateText(newText);
                 });
 
                 it("displays error state", function () {
@@ -127,8 +131,7 @@ define(
 
                 mockFormat.validate.andReturn(true);
                 mockFormat.parse.andReturn(42);
-                mockScope.textValue = newText;
-                fireWatch("textValue", newText);
+                updateText(newText);
 
                 expect(mockScope.textValue).toEqual(newText);
                 expect(mockScope.ngModel.testField).toEqual(42);
@@ -160,16 +163,14 @@ define(
 
                 it("parses user input", function () {
                     var newText = "some other new text";
-                    mockScope.textValue = newText;
-                    fireWatch("textValue", newText);
+                    updateText(newText);
                     expect(mockFormat.parse).toHaveBeenCalledWith(newText);
                     expect(mockScope.ngModel.testField).toEqual(testValue);
                 });
 
                 it("validates user input", function () {
                     var newText = "some other new text";
-                    mockScope.textValue = newText;
-                    fireWatch("textValue", newText);
+                    updateText(newText);
                     expect(mockFormat.validate).toHaveBeenCalledWith(newText);
                 });
 

--- a/platform/commonUI/general/test/controllers/DateTimeFieldControllerSpec.js
+++ b/platform/commonUI/general/test/controllers/DateTimeFieldControllerSpec.js
@@ -101,24 +101,31 @@ define(
             });
 
             describe("when user input is invalid", function () {
-                var newText, oldValue;
+                var newText, oldText, oldValue;
 
                 beforeEach(function () {
                     newText = "Not a date";
                     oldValue = mockScope.ngModel.testField;
-                    updateText(newText);
+                    mockScope.textValue = newText;
+                    fireWatch("textValue", newText);
                 });
 
                 it("displays error state", function () {
                     expect(mockScope.textInvalid).toBeTruthy();
                 });
 
-                it("does not modify model state", function () {
-                    expect(mockScope.ngModel.testField).toEqual(oldValue);
-                });
-
                 it("does not modify user input", function () {
                     expect(mockScope.textValue).toEqual(newText);
+                });
+
+                describe("and has been submitted", function () {
+                    beforeEach(function () {
+                        mockScope.updateFromView(newText);
+                    });
+
+                    it("does not modify model state", function () {
+                        expect(mockScope.ngModel.testField).toEqual(oldValue);
+                    });
                 });
             });
 


### PR DESCRIPTION
Instead of updating the underlying model for values from a date-time fields _during_ typing, do so only when user input is complete (on a blur and/or submit.) If text is invalid when user input is complete, restore it to a valid state.

This prevents constraints in the time conductor from being enforced prematurely (while the user is typing), which can result in undesired behavior as shown in #259.

Note that this does not include any visual indication of constraint violation (e.g. start is greater than end time), as described in [this comment](https://github.com/nasa/openmctweb/issues/259#issuecomment-158253400) of the original issue. Will file a follow up issue for these cases; submitting to merge in its current state due to impending code freeze. (Changes are sufficient to make #259 irreproducible.)