### PR TITLE
[Representation] Check full path when comparing domain objects

### DIFF
--- a/platform/representation/src/MCTRepresentation.js
+++ b/platform/representation/src/MCTRepresentation.js
@@ -157,6 +157,9 @@ define(
                     if (!domainObject) {
                         return [];
                     }
+                    if (!domainObject.hasCapability('context')) {
+                        return [domainObject.getId()];
+                    }
                     return domainObject.getCapability('context')
                         .getPath().map(function (pathObject) {
                             return pathObject.getId();

--- a/platform/representation/src/MCTRepresentation.js
+++ b/platform/representation/src/MCTRepresentation.js
@@ -96,7 +96,7 @@ define(
                     toClear = [], // Properties to clear out of scope on change
                     counter = 0,
                     couldRepresent = false,
-                    lastId,
+                    lastIdPath = [],
                     lastKey,
                     changeTemplate = templateLinker.link($scope, element);
 
@@ -143,11 +143,24 @@ define(
                     });
                 }
 
-                function unchanged(canRepresent, id, key) {
+                function unchanged(canRepresent, idPath, key) {
                     return canRepresent &&
                         couldRepresent &&
-                        id === lastId &&
-                        key === lastKey;
+                        key === lastKey &&
+                        idPath.length === lastIdPath.length &&
+                        idPath.every(function (id, i) {
+                            return id === lastIdPath[i];
+                        });
+                }
+
+                function getIdPath(domainObject) {
+                    if (!domainObject) {
+                        return [];
+                    }
+                    return domainObject.getCapability('context')
+                        .getPath().map(function (pathObject) {
+                            return pathObject.getId();
+                        });
                 }
 
                 // General-purpose refresh mechanism; should set up the scope
@@ -159,10 +172,10 @@ define(
                         path = representation && getPath(representation),
                         uses = ((representation || {}).uses || []),
                         canRepresent = !!(path && domainObject),
-                        id = domainObject && domainObject.getId(),
+                        idPath = getIdPath(domainObject),
                         key = $scope.key;
 
-                    if (unchanged(canRepresent, id, key)) {
+                    if (unchanged(canRepresent, idPath, key)) {
                         return;
                     }
 
@@ -190,7 +203,7 @@ define(
 
                     // To allow simplified change detection next time around
                     couldRepresent = canRepresent;
-                    lastId = id;
+                    lastIdPath = idPath;
                     lastKey = key;
 
                     // Populate scope with fields associated with the current

--- a/platform/representation/test/MCTRepresentationSpec.js
+++ b/platform/representation/test/MCTRepresentationSpec.js
@@ -247,6 +247,54 @@ define(
                 mockScope.$watch.calls[0].args[1]();
                 expect(mockScope.testCapability).toBeUndefined();
             });
+
+            it("detects changes among linked instances", function () {
+                var mockContext = jasmine.createSpyObj('context', ['getPath']),
+                    mockContext2 = jasmine.createSpyObj('context', ['getPath']),
+                    mockLink = jasmine.createSpyObj(
+                        'linkedObject',
+                        DOMAIN_OBJECT_METHODS
+                    ),
+                    mockParent = jasmine.createSpyObj(
+                        'parentObject',
+                        DOMAIN_OBJECT_METHODS
+                    ),
+                    callCount;
+
+                mockDomainObject.getCapability.andCallFake(function (c) {
+                    return c === 'context' && mockContext;
+                });
+                mockLink.getCapability.andCallFake(function (c) {
+                    return c === 'context' && mockContext2;
+                });
+                mockDomainObject.hasCapability.andCallFake(function (c) {
+                    return c === 'context';
+                });
+                mockLink.hasCapability.andCallFake(function (c) {
+                    return c === 'context';
+                });
+                mockLink.getModel.andReturn({});
+
+                mockContext.getPath.andReturn([mockDomainObject]);
+                mockContext2.getPath.andReturn([mockParent, mockLink]);
+
+                mockLink.getId.andReturn('test-id');
+                mockDomainObject.getId.andReturn('test-id');
+
+                mockParent.getId.andReturn('parent-id');
+
+                mockScope.key = "abc";
+                mockScope.domainObject = mockDomainObject;
+
+                mockScope.$watch.calls[0].args[1]();
+                callCount = mockChangeTemplate.calls.length;
+
+                mockScope.domainObject = mockLink;
+                mockScope.$watch.calls[0].args[1]();
+
+                expect(mockChangeTemplate.calls.length)
+                    .toEqual(callCount + 1);
+            });
         });
     }
 );


### PR DESCRIPTION
Addresses #302 by differentiating between two linked instances of the same domain object from `mct-representation` when determining if a watch-invoked `refresh` can be ignored. (Previously, refresh _was_ ignored in this case, allowing for incorrect contextual behavior when this occurred.)

### Author Checklist

1. Changes address original issue? Y
2. Unit tests included and/or updated with changes? Y
3. Command line build passes? Y
4. Expect to pass code review? Y