### PR TITLE
[Performance] Fix usages of $interval

### DIFF
--- a/example/profiling/src/DigestIndicator.js
+++ b/example/profiling/src/DigestIndicator.js
@@ -39,8 +39,11 @@ define(
                 start = Date.now();
 
             function update() {
-                var secs = (Date.now() - start) / 1000;
+                var now = Date.now(),
+                    secs = (now - start) / 1000;
                 displayed = Math.round(digests / secs);
+                start = now;
+                digests = 0;
             }
 
             function increment() {

--- a/platform/commonUI/general/src/directives/MCTSplitPane.js
+++ b/platform/commonUI/general/src/directives/MCTSplitPane.js
@@ -204,7 +204,7 @@ define(
                 // And poll for position changes enforced by styles
                 activeInterval = $interval(function () {
                     getSetPosition(getSetPosition());
-                }, POLLING_INTERVAL, false);
+                }, POLLING_INTERVAL, 0, false);
 
                 // ...and stop polling when we're destroyed.
                 $scope.$on('$destroy', function () {

--- a/platform/commonUI/general/test/directives/MCTSplitPaneSpec.js
+++ b/platform/commonUI/general/test/directives/MCTSplitPaneSpec.js
@@ -1,0 +1,95 @@
+/*****************************************************************************
+ * Open MCT Web, Copyright (c) 2014-2015, United States Government
+ * as represented by the Administrator of the National Aeronautics and Space
+ * Administration. All rights reserved.
+ *
+ * Open MCT Web is licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * Open MCT Web includes source code licensed under additional open source
+ * licenses. See the Open Source Licenses file (LICENSES.md) included with
+ * this source code distribution or the Licensing information page available
+ * at runtime from the About dialog for additional information.
+ *****************************************************************************/
+/*global define,Promise,describe,it,expect,beforeEach,waitsFor,jasmine*/
+
+define(
+    ["../../src/directives/MCTSplitPane"],
+    function (MCTSplitPane) {
+        'use strict';
+
+        var JQLITE_METHODS = [
+                'on',
+                'addClass',
+                'children',
+                'eq'
+            ];
+
+        describe("The mct-split-pane directive", function () {
+            var mockParse,
+                mockLog,
+                mockInterval,
+                mctSplitPane;
+
+            beforeEach(function () {
+                mockParse = jasmine.createSpy('$parse');
+                mockLog =
+                    jasmine.createSpyObj('$log', ['warn', 'info', 'debug']);
+                mockInterval = jasmine.createSpy('$interval');
+                mockInterval.cancel = jasmine.createSpy('mockCancel');
+                mctSplitPane = new MCTSplitPane(
+                    mockParse,
+                    mockLog,
+                    mockInterval
+                );
+            });
+
+            it("is only applicable as an element", function () {
+                expect(mctSplitPane.restrict).toEqual("E");
+            });
+
+            describe("when its controller is applied", function () {
+                var mockScope,
+                    mockElement,
+                    testAttrs,
+                    mockChildren,
+                    controller;
+
+                beforeEach(function () {
+                    mockScope =
+                        jasmine.createSpyObj('$scope', ['$apply', '$watch', '$on']);
+                    mockElement =
+                        jasmine.createSpyObj('element', JQLITE_METHODS);
+                    testAttrs = {};
+                    mockChildren =
+                        jasmine.createSpyObj('children', JQLITE_METHODS);
+
+                    mockElement.children.andReturn(mockChildren);
+                    mockChildren.eq.andReturn(mockChildren);
+                    mockChildren[0] = {};
+
+                    controller = mctSplitPane.controller[3](
+                        mockScope,
+                        mockElement,
+                        testAttrs
+                    );
+                });
+
+                it("sets an interval which does not trigger digests", function () {
+                    expect(mockInterval.mostRecentCall.args[3]).toBe(false);
+                });
+
+            });
+
+        });
+
+    }
+);

--- a/platform/commonUI/general/test/suite.json
+++ b/platform/commonUI/general/test/suite.json
@@ -19,6 +19,7 @@
     "directives/MCTPopup",
     "directives/MCTResize",
     "directives/MCTScroll",
+    "directives/MCTSplitPane",
     "services/Popup",
     "services/PopupService",
     "services/UrlService",

--- a/platform/features/plot/src/MCTChart.js
+++ b/platform/features/plot/src/MCTChart.js
@@ -146,6 +146,7 @@ define(
                     if (canvas.width !== canvas.offsetWidth ||
                             canvas.height !== canvas.offsetHeight) {
                         doDraw(scope.draw);
+                        scope.$apply();
                     }
                 }
 
@@ -181,7 +182,7 @@ define(
                 canvas.addEventListener("webglcontextlost", fallbackFromWebGL);
 
                 // Check for resize, on a timer
-                activeInterval = $interval(drawIfResized, 1000);
+                activeInterval = $interval(drawIfResized, 1000, 0, false);
 
                 // Watch "draw" for external changes to the set of
                 // things to be drawn.

--- a/platform/features/plot/test/MCTChartSpec.js
+++ b/platform/features/plot/test/MCTChartSpec.js
@@ -45,8 +45,10 @@ define(
                     jasmine.createSpy("$interval");
                 mockLog =
                     jasmine.createSpyObj("$log", ["warn", "info", "debug"]);
-                mockScope =
-                    jasmine.createSpyObj("$scope", ["$watchCollection", "$on"]);
+                mockScope = jasmine.createSpyObj(
+                    "$scope",
+                    ["$watchCollection", "$on", "$apply"]
+                );
                 mockElement =
                     jasmine.createSpyObj("element", ["find", "html"]);
                 mockInterval.cancel = jasmine.createSpy("cancelInterval");
@@ -152,7 +154,9 @@ define(
                 // Should track canvas size in an interval
                 expect(mockInterval).toHaveBeenCalledWith(
                     jasmine.any(Function),
-                    jasmine.any(Number)
+                    jasmine.any(Number),
+                    0,
+                    false
                 );
 
                 // Verify pre-condition

--- a/platform/persistence/elastic/src/ElasticIndicator.js
+++ b/platform/persistence/elastic/src/ElasticIndicator.js
@@ -80,7 +80,7 @@ define(
 
             // Update the indicator initially, and start polling.
             updateIndicator();
-            $interval(updateIndicator, interval, false);
+            $interval(updateIndicator, interval, 0, false);
         }
 
         ElasticIndicator.prototype.getGlyph = function () {

--- a/platform/persistence/elastic/test/ElasticIndicatorSpec.js
+++ b/platform/persistence/elastic/test/ElasticIndicatorSpec.js
@@ -55,6 +55,7 @@ define(
                 expect(mockInterval).toHaveBeenCalledWith(
                     jasmine.any(Function),
                     testInterval,
+                    0,
                     false
                 );
             });


### PR DESCRIPTION
This updates usages of $interval to set `invokeApply` to `false` when desired, to reduce number of digests that get triggered. Addresses #369 

This is most significant in MCTSplitPane; without this change, there are 140 digests/sec while idle. With this change, that number drops below 10 (accounted for by indicators etc which do refresh once per second.)

Summary of changes:
* Updated digest indicator (from example/profiling) to give more current results
* Fixed usage of $interval in MCTSplitPane
* Added spec for MCTSplitPane in order to verify usage of $interval
  * Spec remains mostly empty for now; WTD-1400 exists to backfill these
* Use `invokeApply=false` from `mct-chart` to reduce watch counts associated with plotting
* Fixed usage of $interval for the ElasticSearch indicator
  * This does still trigger watches as a consequence of its $http usages, but these currently occur at 15-second intervals


### Author Checklist

1. Changes address original issue? Y
2. Unit tests included and/or updated with changes? Y
3. Command line build passes? Y
4. Expect to pass code review? Y