### PR TITLE
#338 [Copy] Copying an object with telemetry from the data dictionary results in a number of unknown objects in copied tree

### DIFF
--- a/platform/commonUI/browse/bundle.json
+++ b/platform/commonUI/browse/bundle.json
@@ -104,7 +104,7 @@
         ],
         "policies": [
             {
-                "implementation": "CreationPolicy.js",
+                "implementation": "creation/CreationPolicy.js",
                 "category": "creation"
             }
         ],

--- a/platform/commonUI/browse/bundle.json
+++ b/platform/commonUI/browse/bundle.json
@@ -102,6 +102,12 @@
                 "implementation": "navigation/NavigationService.js"
             }
         ],
+        "policies": [
+            {
+                "implementation": "CreationPolicy.js",
+                "category": "creation"
+            }
+        ],
         "actions": [
             {
                 "key": "navigate",

--- a/platform/commonUI/browse/src/creation/CreateActionProvider.js
+++ b/platform/commonUI/browse/src/creation/CreateActionProvider.js
@@ -69,7 +69,7 @@ define(
 
             // Introduce one create action per type
             return this.typeService.listTypes().filter(function (type) {
-                return type.hasFeature("creation");
+                return self.policyService.allow("creation", type);
             }).map(function (type) {
                 return new CreateAction(
                     type,

--- a/platform/commonUI/browse/src/creation/CreationPolicy.js
+++ b/platform/commonUI/browse/src/creation/CreationPolicy.js
@@ -1,0 +1,49 @@
+/*****************************************************************************
+ * Open MCT Web, Copyright (c) 2014-2015, United States Government
+ * as represented by the Administrator of the National Aeronautics and Space
+ * Administration. All rights reserved.
+ *
+ * Open MCT Web is licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * Open MCT Web includes source code licensed under additional open source
+ * licenses. See the Open Source Licenses file (LICENSES.md) included with
+ * this source code distribution or the Licensing information page available
+ * at runtime from the About dialog for additional information.
+ *****************************************************************************/
+/*global define*/
+
+define(
+    [],
+    function () {
+        "use strict";
+
+        /**
+         * A policy for determining whether objects of a certain type can be
+         * created.
+         * @returns {{allow: Function}}
+         * @constructor
+         */
+        function CreationPolicy() {
+            return {
+                /**
+                 * Only allow creation of object types that have the
+                 * Creation capability
+                 */
+                allow: function (action, type) {
+                    return type.hasFeature("creation");
+                }
+            };
+        }
+
+        return CreationPolicy;
+    }
+);

--- a/platform/commonUI/browse/src/creation/CreationPolicy.js
+++ b/platform/commonUI/browse/src/creation/CreationPolicy.js
@@ -27,22 +27,18 @@ define(
         "use strict";
 
         /**
-         * A policy for determining whether objects of a certain type can be
+         * A policy for determining whether objects of a given type can be
          * created.
-         * @returns {{allow: Function}}
          * @constructor
+         * @implements {Policy}
+         * @memberof platform/commonUI/browse
          */
         function CreationPolicy() {
-            return {
-                /**
-                 * Only allow creation of object types that have the
-                 * Creation capability
-                 */
-                allow: function (type) {
-                    return type.hasFeature("creation");
-                }
-            };
         }
+
+        CreationPolicy.prototype.allow = function (type) {
+            return type.hasFeature("creation");
+        };
 
         return CreationPolicy;
     }

--- a/platform/commonUI/browse/src/creation/CreationPolicy.js
+++ b/platform/commonUI/browse/src/creation/CreationPolicy.js
@@ -38,7 +38,7 @@ define(
                  * Only allow creation of object types that have the
                  * Creation capability
                  */
-                allow: function (action, type) {
+                allow: function (type) {
                     return type.hasFeature("creation");
                 }
             };

--- a/platform/commonUI/browse/test/creation/CreationPolicySpec.js
+++ b/platform/commonUI/browse/test/creation/CreationPolicySpec.js
@@ -1,0 +1,54 @@
+/*****************************************************************************
+ * Open MCT Web, Copyright (c) 2014-2015, United States Government
+ * as represented by the Administrator of the National Aeronautics and Space
+ * Administration. All rights reserved.
+ *
+ * Open MCT Web is licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * Open MCT Web includes source code licensed under additional open source
+ * licenses. See the Open Source Licenses file (LICENSES.md) included with
+ * this source code distribution or the Licensing information page available
+ * at runtime from the About dialog for additional information.
+ *****************************************************************************/
+/*global define,describe,it,expect,beforeEach,jasmine*/
+
+define(
+    ["../../src/creation/CreationPolicy"],
+    function (CreationPolicy) {
+        "use strict";
+
+        describe("The creation policy", function () {
+            var mockDomainObject,
+                mockType,
+                policy;
+
+            beforeEach(function () {
+                mockType = jasmine.createSpyObj(
+                    'type',
+                    ['hasFeature']
+                );
+
+                policy = new CreationPolicy();
+            });
+
+            it("allows creation of types with the creation feature", function () {
+                mockType.hasFeature.andReturn(true);
+                expect(policy.allow({}, mockType)).toBeTruthy();
+            });
+
+            it("disallows creation of types without the creation feature", function () {
+                mockType.hasFeature.andReturn(false);
+                expect(policy.allow({}, mockType)).toBeFalsy();
+            });
+        });
+    }
+);

--- a/platform/commonUI/browse/test/creation/CreationPolicySpec.js
+++ b/platform/commonUI/browse/test/creation/CreationPolicySpec.js
@@ -27,8 +27,7 @@ define(
         "use strict";
 
         describe("The creation policy", function () {
-            var mockDomainObject,
-                mockType,
+            var mockType,
                 policy;
 
             beforeEach(function () {
@@ -42,12 +41,12 @@ define(
 
             it("allows creation of types with the creation feature", function () {
                 mockType.hasFeature.andReturn(true);
-                expect(policy.allow({}, mockType)).toBeTruthy();
+                expect(policy.allow(mockType)).toBeTruthy();
             });
 
             it("disallows creation of types without the creation feature", function () {
                 mockType.hasFeature.andReturn(false);
-                expect(policy.allow({}, mockType)).toBeFalsy();
+                expect(policy.allow(mockType)).toBeFalsy();
             });
         });
     }

--- a/platform/commonUI/browse/test/suite.json
+++ b/platform/commonUI/browse/test/suite.json
@@ -8,6 +8,7 @@
     "creation/CreateMenuController",
     "creation/CreateWizard",
     "creation/CreationService",
+    "creation/CreationPolicy",
     "creation/LocatorController",
     "navigation/NavigateAction",
     "navigation/NavigationService",

--- a/platform/entanglement/bundle.json
+++ b/platform/entanglement/bundle.json
@@ -89,8 +89,7 @@
                 "name": "Copy Service",
                 "description": "Provides a service for copying objects",
                 "implementation": "services/CopyService.js",
-                "depends": ["$q", "creationService", "policyService",
-                    "persistenceService", "now"]
+                "depends": ["$q", "policyService", "now"]
             },
             {
                 "key": "locationService",

--- a/platform/entanglement/src/services/CopyService.js
+++ b/platform/entanglement/src/services/CopyService.js
@@ -71,7 +71,7 @@ define(
          */
         CopyService.prototype.perform = function (domainObject, parent) {
             var $q = this.$q,
-                copyTask = new CopyTask(domainObject, parent, this.persistenceService, this.$q, this.now);
+                copyTask = new CopyTask(domainObject, parent, this.persistenceService, this.policyService, this.$q, this.now);
             if (this.validate(domainObject, parent)) {
                 return copyTask.perform();
             } else {

--- a/platform/entanglement/src/services/CopyService.js
+++ b/platform/entanglement/src/services/CopyService.js
@@ -38,12 +38,9 @@ define(
          * @memberof platform/entanglement
          * @implements {platform/entanglement.AbstractComposeService}
          */
-        function CopyService($q, creationService, policyService, persistenceService, now) {
+        function CopyService($q, policyService) {
             this.$q = $q;
-            this.creationService = creationService;
             this.policyService = policyService;
-            this.persistenceService = persistenceService;
-            this.now = now;
         }
 
         CopyService.prototype.validate = function (object, parentCandidate) {
@@ -71,7 +68,7 @@ define(
          */
         CopyService.prototype.perform = function (domainObject, parent) {
             var $q = this.$q,
-                copyTask = new CopyTask(domainObject, parent, this.persistenceService, this.policyService, this.$q, this.now);
+                copyTask = new CopyTask(domainObject, parent, this.policyService, this.$q);
             if (this.validate(domainObject, parent)) {
                 return copyTask.perform();
             } else {

--- a/platform/entanglement/src/services/CopyTask.js
+++ b/platform/entanglement/src/services/CopyTask.js
@@ -203,10 +203,6 @@ define(
         CopyTask.prototype.perform = function(){
             this.deferred = this.$q.defer();
 
-            if (!this.parent.hasCapability('composition')){
-                return this.$q.reject();
-            }
-
             this.buildCopyPlan()
                 .then(persistObjects)
                 .then(addClonesToParent)

--- a/platform/entanglement/src/services/CopyTask.js
+++ b/platform/entanglement/src/services/CopyTask.js
@@ -39,6 +39,7 @@ define(
         function CopyTask (domainObject, parent, policyService, $q){
             this.domainObject = domainObject;
             this.parent = parent;
+            this.firstClone = undefined;
             this.$q = $q;
             this.deferred = undefined;
             this.policyService = policyService;
@@ -97,12 +98,10 @@ define(
          * Will add a list of clones to the specified parent's composition
          */
         function addClonesToParent(self) {
-            var parentClone = self.clones[self.clones.length-1];
-
-            return parentClone.getCapability("persistence").persist()
-                .then(function(){self.parent.getCapability("composition").add(parentClone.getId())})
+            return self.firstClone.getCapability("persistence").persist()
+                .then(function(){self.parent.getCapability("composition").add(self.firstClone.getId())})
                 .then(function(){return self.parent.getCapability("persistence").persist();})
-                .then(function(){return parentClone;});
+                .then(function(){return self.firstClone;});
         }
 
         /**
@@ -188,7 +187,10 @@ define(
             var self = this;
 
             return this.copy(self.domainObject, self.parent).then(function(domainObjectClone){
-                domainObjectClone.getModel().location = self.parent.getId();
+                if (domainObjectClone !== self.domainObject) {
+                    domainObjectClone.getModel().location = self.parent.getId();
+                }
+                self.firstClone = domainObjectClone;
                 return self;
             });
         };

--- a/platform/entanglement/src/services/CopyTask.js
+++ b/platform/entanglement/src/services/CopyTask.js
@@ -104,14 +104,10 @@ define(
         function addClonesToParent(self) {
             var parentClone = self.clones[self.clones.length-1];
 
-            //self.persistenceService
-            //    .updateObject(self.persistenceSpace,
-            // parentClone.id, parentClone.model)
-                return parentClone.getCapability("persistence").persist()
-                    .then(function(){self.parent.getCapability("composition").add(parentClone.getId())})
-                    .then(function(){return self.parent.getCapability("persistence").persist();})
-                    .then(function(){return parentClone;});
-            // Ensure the clone of the original domainObject is returned
+            return parentClone.getCapability("persistence").persist()
+                .then(function(){self.parent.getCapability("composition").add(parentClone.getId())})
+                .then(function(){return self.parent.getCapability("persistence").persist();})
+                .then(function(){return parentClone;});
         }
 
         /**
@@ -175,7 +171,7 @@ define(
                 });
             } else {
                 //Creating a link, no need to iterate children
-                return $q.when(originalObject);
+                return self.$q.when(originalObject);
             }
 
 

--- a/platform/entanglement/src/services/CopyTask.js
+++ b/platform/entanglement/src/services/CopyTask.js
@@ -99,7 +99,7 @@ define(
          */
         function addClonesToParent(self) {
             return self.firstClone.getCapability("persistence").persist()
-                .then(function(){self.parent.getCapability("composition").add(self.firstClone.getId())})
+                .then(function(){self.parent.getCapability("composition").add(self.firstClone.getId());})
                 .then(function(){return self.parent.getCapability("persistence").persist();})
                 .then(function(){return self.firstClone;});
         }

--- a/platform/entanglement/src/services/CopyTask.js
+++ b/platform/entanglement/src/services/CopyTask.js
@@ -47,14 +47,14 @@ define(
             this.clones = [];
         }
 
-        function composeChild(child, parent) {
+        function composeChild(child, parent, setLocation) {
             //Once copied, associate each cloned
             // composee with its parent clone
 
             parent.getModel().composition.push(child.getId());
 
-            //Check if the object being composed is a link
-            if (!child.getCapability("location").isLink()) {
+            //If a location is not specified, set it.
+            if (setLocation && child.getModel().location === undefined) {
                 child.getModel().location = parent.getId();
             }
         }
@@ -113,13 +113,16 @@ define(
         CopyTask.prototype.copyComposees = function(composees, clonedParent, originalParent){
             var self = this;
 
-            return (composees || []).reduce(function(promise, composee){
+            return (composees || []).reduce(function(promise, originalComposee){
                 //If the composee is composed of other
                 // objects, chain a promise..
                 return promise.then(function(){
                     // ...to recursively copy it (and its children)
-                    return self.copy(composee, originalParent).then(function(composee){
-                        return composeChild(composee, clonedParent);
+                    return self.copy(originalComposee, originalParent).then(function(clonedComposee){
+                        //Compose the child within its parent. Cloned
+                        // objects will need to also have their location
+                        // set, however linked objects will not.
+                        return composeChild(clonedComposee, clonedParent, clonedComposee !== originalComposee);
                     });
                 });}, self.$q.when(undefined)
             );
@@ -132,11 +135,11 @@ define(
          * cloning objects, and composing them with their child clones
          * as it goes
          * @private
-         * @param originalObject
-         * @param originalParent
-         * @returns {*}
+         * @returns {DomainObject} If the type of the original object allows for
+         * duplication, then a duplicate of the object, otherwise the object
+         * itself (to allow linking to non duplicatable objects).
          */
-        CopyTask.prototype.copy = function(originalObject, originalParent) {
+        CopyTask.prototype.copy = function(originalObject) {
             var self = this,
                 clone;
 

--- a/platform/entanglement/src/services/CopyTask.js
+++ b/platform/entanglement/src/services/CopyTask.js
@@ -33,21 +33,16 @@ define(
          *
          * @param domainObject The object to copy
          * @param parent The new location of the cloned object tree
-         * @param persistenceService
          * @param $q
-         * @param now
          * @constructor
          */
-        function CopyTask (domainObject, parent, persistenceService, policyService, $q, now){
+        function CopyTask (domainObject, parent, policyService, $q){
             this.domainObject = domainObject;
             this.parent = parent;
             this.$q = $q;
             this.deferred = undefined;
-            this.persistenceService = persistenceService;
             this.policyService = policyService;
-            this.persistenceSpace = parent.getCapability("persistence") && parent.getCapability("persistence").getSpace();
             this.persisted = 0;
-            this.now = now;
             this.clones = [];
         }
 
@@ -154,7 +149,7 @@ define(
                 // creation capability of the targetParent to create the
                 // new clone. This will ensure that the correct persistence
                 // space is used.
-                clone = this.parent.hasCapability("instantiation") && originalParent.useCapability("instantiation", cloneObjectModel(originalObject.getModel()));
+                clone = this.parent.hasCapability("instantiation") && this.parent.useCapability("instantiation", cloneObjectModel(originalObject.getModel()));
 
                 //Iterate through child tree
                 return this.$q.when(originalObject.useCapability('composition')).then(function(composees){
@@ -193,7 +188,7 @@ define(
             var self = this;
 
             return this.copy(self.domainObject, self.parent).then(function(domainObjectClone){
-                domainObjectClone.model.location = self.parent.getId();
+                domainObjectClone.getModel().location = self.parent.getId();
                 return self;
             });
         };
@@ -207,7 +202,7 @@ define(
             this.deferred = this.$q.defer();
 
             if (!this.parent.hasCapability('composition')){
-                return self.$q.reject();
+                return this.$q.reject();
             }
 
             this.buildCopyPlan()

--- a/platform/entanglement/src/services/CopyTask.js
+++ b/platform/entanglement/src/services/CopyTask.js
@@ -38,12 +38,13 @@ define(
          * @param now
          * @constructor
          */
-        function CopyTask (domainObject, parent, persistenceService, $q, now){
+        function CopyTask (domainObject, parent, persistenceService, policyService, $q, now){
             this.domainObject = domainObject;
             this.parent = parent;
             this.$q = $q;
             this.deferred = undefined;
             this.persistenceService = persistenceService;
+            this.policyService = policyService;
             this.persistenceSpace = parent.getCapability("persistence") && parent.getCapability("persistence").getSpace();
             this.persisted = 0;
             this.now = now;
@@ -54,20 +55,30 @@ define(
             //Once copied, associate each cloned
             // composee with its parent clone
 
-            //Could check islink here, and not set the location if it is a
-            // link? Object should have been contextualized during
-            // composition, so isLink should work.
-            child.model.location = parent.id;
-            parent.model.composition = parent.model.composition || [];
-            return parent.model.composition.push(child.id);
+            parent.getModel().composition.push(child.getId());
+
+            //Check if the object being composed is a link
+            if (!child.getCapability("location").isLink()) {
+                child.getModel().location = parent.getId();
+            }
         }
 
         function cloneObjectModel(objectModel) {
             var clone = JSON.parse(JSON.stringify(objectModel));
 
-            delete clone.composition;
+            /**
+             * Reset certain fields.
+             */
+            //If has a composition, set it to an empty array. Will be
+            // recomposed later with the ids of its cloned children.
+            if (clone.composition) {
+                //Important to set it to an empty array here, otherwise
+                // hasCapability("composition") returns false;
+                clone.composition = [];
+            }
             delete clone.persisted;
             delete clone.modified;
+            delete clone.location;
 
             return clone;
         }
@@ -78,13 +89,10 @@ define(
          * result in automatic request batching by the browser.
          */
         function persistObjects(self) {
-
             return self.$q.all(self.clones.map(function(clone){
-                clone.model.persisted = self.now();
-                return self.persistenceService.createObject(self.persistenceSpace, clone.id, clone.model)
-                    .then(function(){
-                        self.deferred.notify({phase: "copying", totalObjects: self.clones.length, processed: ++self.persisted});
-                    });
+                return clone.getCapability("persistence").persist().then(function(){
+                    self.deferred.notify({phase: "copying", totalObjects: self.clones.length, processed: ++self.persisted});
+                });
             })).then(function(){
                 return self;
             });
@@ -96,15 +104,13 @@ define(
         function addClonesToParent(self) {
             var parentClone = self.clones[self.clones.length-1];
 
-            if (!self.parent.hasCapability('composition')){
-                return self.$q.reject();
-            }
-
-            return self.persistenceService
-                .updateObject(self.persistenceSpace, parentClone.id, parentClone.model)
-                .then(function(){return self.parent.getCapability("composition").add(parentClone.id);})
-                .then(function(){return self.parent.getCapability("persistence").persist();})
-                .then(function(){return parentClone;});
+            //self.persistenceService
+            //    .updateObject(self.persistenceSpace,
+            // parentClone.id, parentClone.model)
+                return parentClone.getCapability("persistence").persist()
+                    .then(function(){self.parent.getCapability("composition").add(parentClone.getId())})
+                    .then(function(){return self.parent.getCapability("persistence").persist();})
+                    .then(function(){return parentClone;});
             // Ensure the clone of the original domainObject is returned
         }
 
@@ -123,7 +129,7 @@ define(
                 return promise.then(function(){
                     // ...to recursively copy it (and its children)
                     return self.copy(composee, originalParent).then(function(composee){
-                        composeChild(composee, clonedParent);
+                        return composeChild(composee, clonedParent);
                     });
                 });}, self.$q.when(undefined)
             );
@@ -142,24 +148,37 @@ define(
          */
         CopyTask.prototype.copy = function(originalObject, originalParent) {
             var self = this,
-                modelClone = {
-                    id: uuid(),
-                    model: cloneObjectModel(originalObject.getModel())
-                },
                 clone;
 
-            return this.$q.when(originalObject.useCapability('composition')).then(function(composees){
-                self.deferred.notify({phase: "preparing"});
-                //Duplicate the object's children, and their children, and
-                // so on down to the leaf nodes of the tree.
-                //If it is a link, don't both with children
-                return self.copyComposees(composees, modelClone, originalObject).then(function (){
-                    //Add the clone to the list of clones that will
-                    //be returned by this function
-                    self.clones.push(modelClone);
-                    return modelClone;
+            //Check if the type of the object being copied allows for
+            // creation of new instances. If it does not, then a link to the
+            // original will be created instead.
+            if (this.policyService.allow("creation", originalObject.getCapability("type"))){
+                //create a new clone of the original object. Use the
+                // creation capability of the targetParent to create the
+                // new clone. This will ensure that the correct persistence
+                // space is used.
+                clone = this.parent.hasCapability("instantiation") && originalParent.useCapability("instantiation", cloneObjectModel(originalObject.getModel()));
+
+                //Iterate through child tree
+                return this.$q.when(originalObject.useCapability('composition')).then(function(composees){
+                    self.deferred.notify({phase: "preparing"});
+                    //Duplicate the object's children, and their children, and
+                    // so on down to the leaf nodes of the tree.
+                    //If it is a link, don't both with children
+                    return self.copyComposees(composees, clone, originalObject).then(function (){
+                        //Add the clone to the list of clones that will
+                        //be returned by this function
+                        self.clones.push(clone);
+                        return clone;
+                    });
                 });
-            });
+            } else {
+                //Creating a link, no need to iterate children
+                return $q.when(originalObject);
+            }
+
+
         };
 
         /**
@@ -190,6 +209,10 @@ define(
          */
         CopyTask.prototype.perform = function(){
             this.deferred = this.$q.defer();
+
+            if (!this.parent.hasCapability('composition')){
+                return self.$q.reject();
+            }
 
             this.buildCopyPlan()
                 .then(persistObjects)

--- a/platform/entanglement/src/services/CopyTask.js
+++ b/platform/entanglement/src/services/CopyTask.js
@@ -23,8 +23,8 @@
 /*global define */
 
 define(
-    ["uuid"],
-    function (uuid) {
+    [],
+    function () {
         "use strict";
 
         /**
@@ -148,7 +148,7 @@ define(
                 // creation capability of the targetParent to create the
                 // new clone. This will ensure that the correct persistence
                 // space is used.
-                clone = this.parent.hasCapability("instantiation") && this.parent.useCapability("instantiation", cloneObjectModel(originalObject.getModel()));
+                clone = this.parent.useCapability("instantiation", cloneObjectModel(originalObject.getModel()));
 
                 //Iterate through child tree
                 return this.$q.when(originalObject.useCapability('composition')).then(function(composees){

--- a/platform/entanglement/test/services/CopyServiceSpec.js
+++ b/platform/entanglement/test/services/CopyServiceSpec.js
@@ -379,10 +379,28 @@ define(
                             expect(copyFinished).toHaveBeenCalled();
                         });
 
+                        it("returns a promise", function () {
+                            expect(copyResult.then).toBeDefined();
+                            expect(copyFinished).toHaveBeenCalled();
+                        });
+
                         it ("correctly locates cloned objects", function() {
                             expect(childObjectClone.getModel().location).toEqual(objectClone.getId());
                         });
+                    });
+                    describe("when cloning non-creatable objects", function() {
+                        beforeEach(function () {
+                            policyService.allow.callFake(function(category, object){
+                               return category === 'creation';
+                            });
 
+                            copyResult = copyService.perform(object, newParent);
+                            copyFinished = jasmine.createSpy('copyFinished');
+                            copyResult.then(copyFinished);
+                        });
+                        it ("creates links", function() {
+                            expect(childObjectClone.getModel().location).toEqual(objectClone.getId());
+                        });
                     });
                 });
 

--- a/platform/entanglement/test/services/CopyServiceSpec.js
+++ b/platform/entanglement/test/services/CopyServiceSpec.js
@@ -412,15 +412,23 @@ define(
                         object = domainObjectFactory({
                             name: 'object',
                             capabilities: {
-                                type: { type: 'object' }
+                                type: { type: 'object' },
+                                location: locationCapability,
+                                persistence: persistenceCapability
                             }
                         });
+
                         newParent = domainObjectFactory({
                             name: 'parentCandidate',
                             capabilities: {
-                                type: { type: 'parentCandidate' }
+                                type: { type: 'parentCandidate' },
+                                instantiation: instantiationCapability,
+                                composition: compositionCapability,
+                                persistence: persistenceCapability
                             }
                         });
+
+                        instantiationCapability.invoke.andReturn(object);
                     });
 
                     it("throws an error", function () {

--- a/platform/entanglement/test/services/CopyServiceSpec.js
+++ b/platform/entanglement/test/services/CopyServiceSpec.js
@@ -174,7 +174,6 @@ define(
                         ['notify', 'resolve', 'reject']
                     );
                     mockDeferred.notify.andCallFake(function(notification){});
-                    mockDeferred.reject.andCallFake(function(){});
                     mockDeferred.resolve.andCallFake(function(value){resolvedValue = value;});
                     mockDeferred.promise = {
                         then: function(callback){

--- a/platform/entanglement/test/services/CopyServiceSpec.js
+++ b/platform/entanglement/test/services/CopyServiceSpec.js
@@ -390,16 +390,20 @@ define(
                     });
                     describe("when cloning non-creatable objects", function() {
                         beforeEach(function () {
-                            policyService.allow.callFake(function(category, object){
-                               return category === 'creation';
+                            policyService.allow.andCallFake(function(category){
+                                //Return false for 'creation' policy
+                               return category !== 'creation';
                             });
 
                             copyResult = copyService.perform(object, newParent);
                             copyFinished = jasmine.createSpy('copyFinished');
                             copyResult.then(copyFinished);
                         });
-                        it ("creates links", function() {
-                            expect(childObjectClone.getModel().location).toEqual(objectClone.getId());
+                        it ("creates link instead of clone", function() {
+                            var copiedObject = copyFinished.calls[0].args[0];
+                            expect(copiedObject).toBe(object);
+                            expect(compositionCapability.add).toHaveBeenCalledWith(copiedObject.getId());
+                            //expect(newParent.getModel().composition).toContain(copiedObject.getId());
                         });
                     });
                 });


### PR DESCRIPTION
Summary of changes:
* Created a new creation policy category and instance that returns true if tested object hasFeature('creation')`
* Modified the `CopyService` to use the persistence space of the copy target, not the object being copied
* Modified the CreateActionProvider to use new CreationPolicy
* Modified the `CopyService` to use the CreationPolicy to check whether a new object or a link should be created for the type of the object being copied.
* Added tests for CreationPolicy
* Added a new test case to test that duplication of non-createable types creates links (addresses https://github.com/nasa/openmctweb/issues/338#issuecomment-159353004 )
* Some minor refactoring of CopyService and CopyTask. Would suggest that use of instantiationCapability actually allows for more fundamental re-architecture of CopyTask that could significantly reduce LOC, but I'll leave this for a future release.

### Author Checklist

1. Changes address original issue? __Y__
2. Unit tests included and/or updated with changes? __Y__
3. Command line build passes? __Y__
4. Expect to pass code review? __Y__