### PR TITLE
[Edit] Return a promise from editable persistence capability

### DIFF
--- a/platform/commonUI/edit/src/capabilities/EditablePersistenceCapability.js
+++ b/platform/commonUI/edit/src/capabilities/EditablePersistenceCapability.js
@@ -50,7 +50,7 @@ define(
             // Simply trigger refresh of in-view objects; do not
             // write anything to database.
             persistence.persist = function () {
-                cache.markDirty(editableObject);
+                return cache.markDirty(editableObject);
             };
 
             // Delegate refresh to the original object; this avoids refreshing

--- a/platform/commonUI/edit/src/objects/EditableDomainObjectCache.js
+++ b/platform/commonUI/edit/src/objects/EditableDomainObjectCache.js
@@ -111,6 +111,7 @@ define(
          */
         EditableDomainObjectCache.prototype.markDirty = function (domainObject) {
             this.dirtyObjects[domainObject.getId()] = domainObject;
+            return this.$q.when(true);
         };
 
         /**

--- a/platform/commonUI/edit/test/capabilities/EditablePersistenceCapabilitySpec.js
+++ b/platform/commonUI/edit/test/capabilities/EditablePersistenceCapabilitySpec.js
@@ -31,6 +31,7 @@ define(
                 mockEditableObject,
                 mockDomainObject,
                 mockCache,
+                mockPromise,
                 capability;
 
             beforeEach(function () {
@@ -50,7 +51,9 @@ define(
                     "cache",
                     [ "markDirty" ]
                 );
+                mockPromise = jasmine.createSpyObj("promise", ["then"]);
 
+                mockCache.markDirty.andReturn(mockPromise);
                 mockDomainObject.getCapability.andReturn(mockPersistence);
 
                 capability = new EditablePersistenceCapability(
@@ -82,6 +85,10 @@ define(
                 capability.refresh();
                 expect(mockDomainObject.getCapability).toHaveBeenCalledWith('persistence');
                 expect(mockPersistence.refresh).toHaveBeenCalled();
+            });
+
+            it("returns a promise from persist", function () {
+                expect(capability.persist().then).toEqual(jasmine.any(Function));
             });
 
         });


### PR DESCRIPTION
Addresses immediate cause of #305 (returning correct type from the edit-mode-wrapped persistence capability.)

Note that a [benign warning](https://github.com/nasa/openmctweb/issues/305#issuecomment-161146898). Plan to address this in the context of #368 


### Author Checklist

1. Changes address original issue? Y
2. Unit tests included and/or updated with changes? Y
3. Command line build passes? Y
4. Expect to pass code review? Y