### PR TITLE
Review and integrate open199e

### DIFF
--- a/platform/commonUI/edit/res/templates/elements.html
+++ b/platform/commonUI/edit/res/templates/elements.html
@@ -24,9 +24,7 @@
                  class="flex-elem holder"
                  ng-model="filterBy">
     </mct-include>
-    <div>{{searchText}}</div>
     <div class="current-elements abs" style="height: 100%;">
-        <!--p class="hint">Drop objects here to add them...</p-->
         <ul class="tree">
             <li ng-repeat="containedObject in composition | filter:searchText">
                 <span class="tree-item">

--- a/platform/commonUI/general/res/sass/tree/_tree.scss
+++ b/platform/commonUI/general/res/sass/tree/_tree.scss
@@ -143,9 +143,36 @@ ul.tree {
 		}
 	}
 
-    &.active {
-        // The item is being edited
-        background: $colorItemTreeEditingBg; //rgba($colorItemTreeSelectedBg, 0.2) !important;
+	&:not(.loading) {
+		cursor: pointer;
+	}
+
+	.context-trigger {
+		$h: 0.9rem;
+		top: -1px;
+		position: absolute;
+		right: $interiorMarginSm;
+		.invoke-menu {
+			font-size: 0.75em;
+			height: $h;
+			line-height: $h;
+		}
+	}
+}
+
+.tree .tree-item,
+.search-results .s-status-editing .search-result-item {
+    .t-object-label {
+        left: $interiorMargin + $treeVCW;
+    }
+}
+
+.tree .s-status-editing,
+.search-results .s-status-editing {
+    // Item is being edited
+    .tree-item,
+    .search-result-item {
+        background: $colorItemTreeEditingBg;
         pointer-events: none;
         &:before {
             // Pencil icon
@@ -167,27 +194,4 @@ ul.tree {
         }
         .view-control, + .tree-item-subtree { display: none; }
     }
-
-	&:not(.loading) {
-		cursor: pointer;
-	}
-
-	.context-trigger {
-		$h: 0.9rem;
-		top: -1px;
-		position: absolute;
-		right: $interiorMarginSm;
-		.invoke-menu {
-			font-size: 0.75em;
-			height: $h;
-			line-height: $h;
-		}
-	}
-}
-
-.tree-item,
-.search-result-item.active {
-	.t-object-label {
-		left: $interiorMargin + $treeVCW;
-	}
 }

--- a/platform/commonUI/general/res/sass/user-environ/_layout.scss
+++ b/platform/commonUI/general/res/sass/user-environ/_layout.scss
@@ -295,7 +295,7 @@
 
     .left {
         padding-right: $interiorMarginLg;
-        .l-back {
+        .l-back:not(.s-status-editing) {
             margin-right: $interiorMarginLg;
         }
     }

--- a/platform/commonUI/themes/espresso/res/css/theme-espresso.css
+++ b/platform/commonUI/themes/espresso/res/css/theme-espresso.css
@@ -20,7 +20,7 @@
  * this source code distribution or the Licensing information page available
  * at runtime from the About dialog for additional information.
  *****************************************************************************/
-/* line 5, ../../../../../../../../../../Library/Ruby/Gems/2.0.0/gems/compass-core-1.0.3/stylesheets/compass/reset/_utilities.scss */
+/* line 5, ../../../../../../../../../../../Library/Ruby/Gems/2.0.0/gems/compass-core-1.0.3/stylesheets/compass/reset/_utilities.scss */
 html, body, div, span, applet, object, iframe,
 h1, h2, h3, h4, h5, h6, p, blockquote, pre,
 a, abbr, acronym, address, big, cite, code,
@@ -41,38 +41,38 @@ time, mark, audio, video {
   font-size: 100%;
   vertical-align: baseline; }
 
-/* line 22, ../../../../../../../../../../Library/Ruby/Gems/2.0.0/gems/compass-core-1.0.3/stylesheets/compass/reset/_utilities.scss */
+/* line 22, ../../../../../../../../../../../Library/Ruby/Gems/2.0.0/gems/compass-core-1.0.3/stylesheets/compass/reset/_utilities.scss */
 html {
   line-height: 1; }
 
-/* line 24, ../../../../../../../../../../Library/Ruby/Gems/2.0.0/gems/compass-core-1.0.3/stylesheets/compass/reset/_utilities.scss */
+/* line 24, ../../../../../../../../../../../Library/Ruby/Gems/2.0.0/gems/compass-core-1.0.3/stylesheets/compass/reset/_utilities.scss */
 ol, ul {
   list-style: none; }
 
-/* line 26, ../../../../../../../../../../Library/Ruby/Gems/2.0.0/gems/compass-core-1.0.3/stylesheets/compass/reset/_utilities.scss */
+/* line 26, ../../../../../../../../../../../Library/Ruby/Gems/2.0.0/gems/compass-core-1.0.3/stylesheets/compass/reset/_utilities.scss */
 table {
   border-collapse: collapse;
   border-spacing: 0; }
 
-/* line 28, ../../../../../../../../../../Library/Ruby/Gems/2.0.0/gems/compass-core-1.0.3/stylesheets/compass/reset/_utilities.scss */
+/* line 28, ../../../../../../../../../../../Library/Ruby/Gems/2.0.0/gems/compass-core-1.0.3/stylesheets/compass/reset/_utilities.scss */
 caption, th, td {
   text-align: left;
   font-weight: normal;
   vertical-align: middle; }
 
-/* line 30, ../../../../../../../../../../Library/Ruby/Gems/2.0.0/gems/compass-core-1.0.3/stylesheets/compass/reset/_utilities.scss */
+/* line 30, ../../../../../../../../../../../Library/Ruby/Gems/2.0.0/gems/compass-core-1.0.3/stylesheets/compass/reset/_utilities.scss */
 q, blockquote {
   quotes: none; }
-  /* line 103, ../../../../../../../../../../Library/Ruby/Gems/2.0.0/gems/compass-core-1.0.3/stylesheets/compass/reset/_utilities.scss */
+  /* line 103, ../../../../../../../../../../../Library/Ruby/Gems/2.0.0/gems/compass-core-1.0.3/stylesheets/compass/reset/_utilities.scss */
   q:before, q:after, blockquote:before, blockquote:after {
     content: "";
     content: none; }
 
-/* line 32, ../../../../../../../../../../Library/Ruby/Gems/2.0.0/gems/compass-core-1.0.3/stylesheets/compass/reset/_utilities.scss */
+/* line 32, ../../../../../../../../../../../Library/Ruby/Gems/2.0.0/gems/compass-core-1.0.3/stylesheets/compass/reset/_utilities.scss */
 a img {
   border: none; }
 
-/* line 116, ../../../../../../../../../../Library/Ruby/Gems/2.0.0/gems/compass-core-1.0.3/stylesheets/compass/reset/_utilities.scss */
+/* line 116, ../../../../../../../../../../../Library/Ruby/Gems/2.0.0/gems/compass-core-1.0.3/stylesheets/compass/reset/_utilities.scss */
 article, aside, details, figcaption, figure, footer, header, hgroup, main, menu, nav, section, summary {
   display: block; }
 
@@ -783,41 +783,66 @@ mct-container {
     border-right: 5px solid transparent; }
 
 /* line 31, ../../../../general/res/sass/_icons.scss */
-.ui-symbol, .t-item-icon, .s-icon-btn, .l-datetime-picker .l-month-year-pager .pager, .tree-item.active:before,
-.search-result-item.active:before {
+.ui-symbol, .t-item-icon, .s-icon-btn, .l-datetime-picker .l-month-year-pager .pager, .tree .s-status-editing .tree-item:before,
+.tree .s-status-editing .search-result-item:before,
+.search-results .s-status-editing .tree-item:before,
+.search-results .s-status-editing .search-result-item:before {
   font-family: 'symbolsfont'; }
   /* line 33, ../../../../general/res/sass/_icons.scss */
-  .ui-symbol.type-icon, .type-icon.t-item-icon, .type-icon.s-icon-btn, .l-datetime-picker .l-month-year-pager .type-icon.pager, .type-icon.tree-item.active:before,
-  .type-icon.search-result-item.active:before {
+  .ui-symbol.type-icon, .type-icon.t-item-icon, .type-icon.s-icon-btn, .l-datetime-picker .l-month-year-pager .type-icon.pager, .tree .s-status-editing .type-icon.tree-item:before,
+  .tree .s-status-editing .type-icon.search-result-item:before,
+  .search-results .s-status-editing .type-icon.tree-item:before,
+  .search-results .s-status-editing .type-icon.search-result-item:before {
     color: #cccccc; }
   /* line 36, ../../../../general/res/sass/_icons.scss */
-  .ui-symbol.icon, .t-item-icon, .icon.s-icon-btn, .l-datetime-picker .l-month-year-pager .icon.pager, .l-datetime-picker .l-month-year-pager .pager.t-item-icon, .icon.tree-item.active:before, .tree-item.active.t-item-icon:before,
-  .icon.search-result-item.active:before,
-  .search-result-item.active.t-item-icon:before {
+  .ui-symbol.icon, .t-item-icon, .icon.s-icon-btn, .l-datetime-picker .l-month-year-pager .icon.pager, .l-datetime-picker .l-month-year-pager .pager.t-item-icon, .tree .s-status-editing .icon.tree-item:before, .tree .s-status-editing .tree-item.t-item-icon:before,
+  .tree .s-status-editing .icon.search-result-item:before,
+  .tree .s-status-editing .search-result-item.t-item-icon:before,
+  .search-results .s-status-editing .icon.tree-item:before,
+  .search-results .s-status-editing .tree-item.t-item-icon:before,
+  .search-results .s-status-editing .icon.search-result-item:before,
+  .search-results .s-status-editing .search-result-item.t-item-icon:before {
     color: #0099cc;
     font-size: inherit; }
     /* line 40, ../../../../general/res/sass/_icons.scss */
-    .ui-symbol.icon.alert, .alert.t-item-icon, .icon.alert.s-icon-btn, .l-datetime-picker .l-month-year-pager .icon.alert.pager, .l-datetime-picker .l-month-year-pager .alert.pager.t-item-icon, .icon.alert.tree-item.active:before, .alert.tree-item.active.t-item-icon:before,
-    .icon.alert.search-result-item.active:before,
-    .alert.search-result-item.active.t-item-icon:before {
+    .ui-symbol.icon.alert, .alert.t-item-icon, .icon.alert.s-icon-btn, .l-datetime-picker .l-month-year-pager .icon.alert.pager, .l-datetime-picker .l-month-year-pager .alert.pager.t-item-icon, .tree .s-status-editing .icon.alert.tree-item:before, .tree .s-status-editing .alert.tree-item.t-item-icon:before,
+    .tree .s-status-editing .icon.alert.search-result-item:before,
+    .tree .s-status-editing .alert.search-result-item.t-item-icon:before,
+    .search-results .s-status-editing .icon.alert.tree-item:before,
+    .search-results .s-status-editing .alert.tree-item.t-item-icon:before,
+    .search-results .s-status-editing .icon.alert.search-result-item:before,
+    .search-results .s-status-editing .alert.search-result-item.t-item-icon:before {
       color: #ff3c00; }
       /* line 42, ../../../../general/res/sass/_icons.scss */
-      .ui-symbol.icon.alert:hover, .alert.t-item-icon:hover, .icon.alert.s-icon-btn:hover, .l-datetime-picker .l-month-year-pager .icon.alert.pager:hover, .icon.alert.tree-item.active:hover:before, .alert.tree-item.active.t-item-icon:hover:before,
-      .icon.alert.search-result-item.active:hover:before,
-      .alert.search-result-item.active.t-item-icon:hover:before {
+      .ui-symbol.icon.alert:hover, .alert.t-item-icon:hover, .icon.alert.s-icon-btn:hover, .l-datetime-picker .l-month-year-pager .icon.alert.pager:hover, .tree .s-status-editing .icon.alert.tree-item:hover:before, .tree .s-status-editing .alert.tree-item.t-item-icon:hover:before,
+      .tree .s-status-editing .icon.alert.search-result-item:hover:before,
+      .tree .s-status-editing .alert.search-result-item.t-item-icon:hover:before,
+      .search-results .s-status-editing .icon.alert.tree-item:hover:before,
+      .search-results .s-status-editing .alert.tree-item.t-item-icon:hover:before,
+      .search-results .s-status-editing .icon.alert.search-result-item:hover:before,
+      .search-results .s-status-editing .alert.search-result-item.t-item-icon:hover:before {
         color: #ff8a66; }
     /* line 46, ../../../../general/res/sass/_icons.scss */
-    .ui-symbol.icon.major, .major.t-item-icon, .icon.major.s-icon-btn, .l-datetime-picker .l-month-year-pager .icon.major.pager, .l-datetime-picker .l-month-year-pager .major.pager.t-item-icon, .icon.major.tree-item.active:before, .major.tree-item.active.t-item-icon:before,
-    .icon.major.search-result-item.active:before,
-    .major.search-result-item.active.t-item-icon:before {
+    .ui-symbol.icon.major, .major.t-item-icon, .icon.major.s-icon-btn, .l-datetime-picker .l-month-year-pager .icon.major.pager, .l-datetime-picker .l-month-year-pager .major.pager.t-item-icon, .tree .s-status-editing .icon.major.tree-item:before, .tree .s-status-editing .major.tree-item.t-item-icon:before,
+    .tree .s-status-editing .icon.major.search-result-item:before,
+    .tree .s-status-editing .major.search-result-item.t-item-icon:before,
+    .search-results .s-status-editing .icon.major.tree-item:before,
+    .search-results .s-status-editing .major.tree-item.t-item-icon:before,
+    .search-results .s-status-editing .icon.major.search-result-item:before,
+    .search-results .s-status-editing .major.search-result-item.t-item-icon:before {
       font-size: 1.65em; }
   /* line 50, ../../../../general/res/sass/_icons.scss */
   .ui-symbol.icon-calendar:after, .icon-calendar.t-item-icon:after, .icon-calendar.s-icon-btn:after, .l-datetime-picker .l-month-year-pager .icon-calendar.pager:after {
     content: "\e605"; }
 
 /* line 55, ../../../../general/res/sass/_icons.scss */
-.bar .ui-symbol, .bar .t-item-icon, .bar .s-icon-btn, .bar .l-datetime-picker .l-month-year-pager .pager, .l-datetime-picker .l-month-year-pager .bar .pager, .bar .tree-item.active:before,
-.bar .search-result-item.active:before {
+.bar .ui-symbol, .bar .t-item-icon, .bar .s-icon-btn, .bar .l-datetime-picker .l-month-year-pager .pager, .l-datetime-picker .l-month-year-pager .bar .pager, .bar .tree .s-status-editing .tree-item:before, .tree .s-status-editing .bar .tree-item:before,
+.bar .tree .s-status-editing .search-result-item:before,
+.tree .s-status-editing .bar .search-result-item:before,
+.bar .search-results .s-status-editing .tree-item:before,
+.search-results .s-status-editing .bar .tree-item:before,
+.bar .search-results .s-status-editing .search-result-item:before,
+.search-results .s-status-editing .bar .search-result-item:before {
   display: inline-block; }
 
 /* line 59, ../../../../general/res/sass/_icons.scss */
@@ -2848,9 +2873,19 @@ label.checkbox.custom {
   left: 0;
   text-align: left; }
   /* line 62, ../../../../general/res/sass/controls/_menus.scss */
-  .s-menu-btn .menu .ui-symbol.icon, .s-menu-btn .menu .t-item-icon, .s-menu-btn .menu .icon.s-icon-btn, .s-menu-btn .menu .s-icon-btn.t-item-icon, .s-menu-btn .menu .l-datetime-picker .l-month-year-pager .icon.pager, .l-datetime-picker .l-month-year-pager .s-menu-btn .menu .icon.pager, .s-menu-btn .menu .l-datetime-picker .l-month-year-pager .pager.t-item-icon, .l-datetime-picker .l-month-year-pager .s-menu-btn .menu .pager.t-item-icon, .s-menu-btn .menu .icon.tree-item.active:before, .s-menu-btn .menu .tree-item.active.t-item-icon:before,
-  .s-menu-btn .menu .icon.search-result-item.active:before,
-  .s-menu-btn .menu .search-result-item.active.t-item-icon:before {
+  .s-menu-btn .menu .ui-symbol.icon, .s-menu-btn .menu .t-item-icon, .s-menu-btn .menu .icon.s-icon-btn, .s-menu-btn .menu .s-icon-btn.t-item-icon, .s-menu-btn .menu .l-datetime-picker .l-month-year-pager .icon.pager, .l-datetime-picker .l-month-year-pager .s-menu-btn .menu .icon.pager, .s-menu-btn .menu .l-datetime-picker .l-month-year-pager .pager.t-item-icon, .l-datetime-picker .l-month-year-pager .s-menu-btn .menu .pager.t-item-icon, .s-menu-btn .menu .tree .s-status-editing .icon.tree-item:before, .tree .s-status-editing .s-menu-btn .menu .icon.tree-item:before, .s-menu-btn .menu .tree .s-status-editing .tree-item.t-item-icon:before, .tree .s-status-editing .s-menu-btn .menu .tree-item.t-item-icon:before,
+  .s-menu-btn .menu .tree .s-status-editing .icon.search-result-item:before,
+  .tree .s-status-editing .s-menu-btn .menu .icon.search-result-item:before,
+  .s-menu-btn .menu .tree .s-status-editing .search-result-item.t-item-icon:before,
+  .tree .s-status-editing .s-menu-btn .menu .search-result-item.t-item-icon:before,
+  .s-menu-btn .menu .search-results .s-status-editing .icon.tree-item:before,
+  .search-results .s-status-editing .s-menu-btn .menu .icon.tree-item:before,
+  .s-menu-btn .menu .search-results .s-status-editing .tree-item.t-item-icon:before,
+  .search-results .s-status-editing .s-menu-btn .menu .tree-item.t-item-icon:before,
+  .s-menu-btn .menu .search-results .s-status-editing .icon.search-result-item:before,
+  .search-results .s-status-editing .s-menu-btn .menu .icon.search-result-item:before,
+  .s-menu-btn .menu .search-results .s-status-editing .search-result-item.t-item-icon:before,
+  .search-results .s-status-editing .s-menu-btn .menu .search-result-item.t-item-icon:before {
     width: 12px; }
 
 /******************************************************** MENUS THEMSELVES */
@@ -3572,9 +3607,19 @@ mct-include.l-time-controller {
       mct-include.l-time-controller .l-time-range-inputs-holder .l-time-range-inputs-elem .lbl {
         color: #666666; }
       /* line 65, ../../../../general/res/sass/controls/_time-controller.scss */
-      mct-include.l-time-controller .l-time-range-inputs-holder .l-time-range-input .ui-symbol.icon, mct-include.l-time-controller .l-time-range-inputs-holder .l-time-range-input .t-item-icon, mct-include.l-time-controller .l-time-range-inputs-holder .l-time-range-input .icon.s-icon-btn, mct-include.l-time-controller .l-time-range-inputs-holder .l-time-range-input .s-icon-btn.t-item-icon, mct-include.l-time-controller .l-time-range-inputs-holder .l-time-range-input .l-datetime-picker .l-month-year-pager .icon.pager, .l-datetime-picker .l-month-year-pager mct-include.l-time-controller .l-time-range-inputs-holder .l-time-range-input .icon.pager, mct-include.l-time-controller .l-time-range-inputs-holder .l-time-range-input .l-datetime-picker .l-month-year-pager .pager.t-item-icon, .l-datetime-picker .l-month-year-pager mct-include.l-time-controller .l-time-range-inputs-holder .l-time-range-input .pager.t-item-icon, mct-include.l-time-controller .l-time-range-inputs-holder .l-time-range-input .icon.tree-item.active:before, mct-include.l-time-controller .l-time-range-inputs-holder .l-time-range-input .tree-item.active.t-item-icon:before,
-      mct-include.l-time-controller .l-time-range-inputs-holder .l-time-range-input .icon.search-result-item.active:before,
-      mct-include.l-time-controller .l-time-range-inputs-holder .l-time-range-input .search-result-item.active.t-item-icon:before,
+      mct-include.l-time-controller .l-time-range-inputs-holder .l-time-range-input .ui-symbol.icon, mct-include.l-time-controller .l-time-range-inputs-holder .l-time-range-input .t-item-icon, mct-include.l-time-controller .l-time-range-inputs-holder .l-time-range-input .icon.s-icon-btn, mct-include.l-time-controller .l-time-range-inputs-holder .l-time-range-input .s-icon-btn.t-item-icon, mct-include.l-time-controller .l-time-range-inputs-holder .l-time-range-input .l-datetime-picker .l-month-year-pager .icon.pager, .l-datetime-picker .l-month-year-pager mct-include.l-time-controller .l-time-range-inputs-holder .l-time-range-input .icon.pager, mct-include.l-time-controller .l-time-range-inputs-holder .l-time-range-input .l-datetime-picker .l-month-year-pager .pager.t-item-icon, .l-datetime-picker .l-month-year-pager mct-include.l-time-controller .l-time-range-inputs-holder .l-time-range-input .pager.t-item-icon, mct-include.l-time-controller .l-time-range-inputs-holder .l-time-range-input .tree .s-status-editing .icon.tree-item:before, .tree .s-status-editing mct-include.l-time-controller .l-time-range-inputs-holder .l-time-range-input .icon.tree-item:before, mct-include.l-time-controller .l-time-range-inputs-holder .l-time-range-input .tree .s-status-editing .tree-item.t-item-icon:before, .tree .s-status-editing mct-include.l-time-controller .l-time-range-inputs-holder .l-time-range-input .tree-item.t-item-icon:before,
+      mct-include.l-time-controller .l-time-range-inputs-holder .l-time-range-input .tree .s-status-editing .icon.search-result-item:before,
+      .tree .s-status-editing mct-include.l-time-controller .l-time-range-inputs-holder .l-time-range-input .icon.search-result-item:before,
+      mct-include.l-time-controller .l-time-range-inputs-holder .l-time-range-input .tree .s-status-editing .search-result-item.t-item-icon:before,
+      .tree .s-status-editing mct-include.l-time-controller .l-time-range-inputs-holder .l-time-range-input .search-result-item.t-item-icon:before,
+      mct-include.l-time-controller .l-time-range-inputs-holder .l-time-range-input .search-results .s-status-editing .icon.tree-item:before,
+      .search-results .s-status-editing mct-include.l-time-controller .l-time-range-inputs-holder .l-time-range-input .icon.tree-item:before,
+      mct-include.l-time-controller .l-time-range-inputs-holder .l-time-range-input .search-results .s-status-editing .tree-item.t-item-icon:before,
+      .search-results .s-status-editing mct-include.l-time-controller .l-time-range-inputs-holder .l-time-range-input .tree-item.t-item-icon:before,
+      mct-include.l-time-controller .l-time-range-inputs-holder .l-time-range-input .search-results .s-status-editing .icon.search-result-item:before,
+      .search-results .s-status-editing mct-include.l-time-controller .l-time-range-inputs-holder .l-time-range-input .icon.search-result-item:before,
+      mct-include.l-time-controller .l-time-range-inputs-holder .l-time-range-input .search-results .s-status-editing .search-result-item.t-item-icon:before,
+      .search-results .s-status-editing mct-include.l-time-controller .l-time-range-inputs-holder .l-time-range-input .search-result-item.t-item-icon:before,
       mct-include.l-time-controller .l-time-range-inputs-holder .l-time-range-inputs-elem .ui-symbol.icon,
       mct-include.l-time-controller .l-time-range-inputs-holder .l-time-range-inputs-elem .t-item-icon,
       mct-include.l-time-controller .l-time-range-inputs-holder .l-time-range-inputs-elem .icon.s-icon-btn,
@@ -3583,10 +3628,22 @@ mct-include.l-time-controller {
       .l-datetime-picker .l-month-year-pager mct-include.l-time-controller .l-time-range-inputs-holder .l-time-range-inputs-elem .icon.pager,
       mct-include.l-time-controller .l-time-range-inputs-holder .l-time-range-inputs-elem .l-datetime-picker .l-month-year-pager .pager.t-item-icon,
       .l-datetime-picker .l-month-year-pager mct-include.l-time-controller .l-time-range-inputs-holder .l-time-range-inputs-elem .pager.t-item-icon,
-      mct-include.l-time-controller .l-time-range-inputs-holder .l-time-range-inputs-elem .icon.tree-item.active:before,
-      mct-include.l-time-controller .l-time-range-inputs-holder .l-time-range-inputs-elem .tree-item.active.t-item-icon:before,
-      mct-include.l-time-controller .l-time-range-inputs-holder .l-time-range-inputs-elem .icon.search-result-item.active:before,
-      mct-include.l-time-controller .l-time-range-inputs-holder .l-time-range-inputs-elem .search-result-item.active.t-item-icon:before {
+      mct-include.l-time-controller .l-time-range-inputs-holder .l-time-range-inputs-elem .tree .s-status-editing .icon.tree-item:before,
+      .tree .s-status-editing mct-include.l-time-controller .l-time-range-inputs-holder .l-time-range-inputs-elem .icon.tree-item:before,
+      mct-include.l-time-controller .l-time-range-inputs-holder .l-time-range-inputs-elem .tree .s-status-editing .tree-item.t-item-icon:before,
+      .tree .s-status-editing mct-include.l-time-controller .l-time-range-inputs-holder .l-time-range-inputs-elem .tree-item.t-item-icon:before,
+      mct-include.l-time-controller .l-time-range-inputs-holder .l-time-range-inputs-elem .tree .s-status-editing .icon.search-result-item:before,
+      .tree .s-status-editing mct-include.l-time-controller .l-time-range-inputs-holder .l-time-range-inputs-elem .icon.search-result-item:before,
+      mct-include.l-time-controller .l-time-range-inputs-holder .l-time-range-inputs-elem .tree .s-status-editing .search-result-item.t-item-icon:before,
+      .tree .s-status-editing mct-include.l-time-controller .l-time-range-inputs-holder .l-time-range-inputs-elem .search-result-item.t-item-icon:before,
+      mct-include.l-time-controller .l-time-range-inputs-holder .l-time-range-inputs-elem .search-results .s-status-editing .icon.tree-item:before,
+      .search-results .s-status-editing mct-include.l-time-controller .l-time-range-inputs-holder .l-time-range-inputs-elem .icon.tree-item:before,
+      mct-include.l-time-controller .l-time-range-inputs-holder .l-time-range-inputs-elem .search-results .s-status-editing .tree-item.t-item-icon:before,
+      .search-results .s-status-editing mct-include.l-time-controller .l-time-range-inputs-holder .l-time-range-inputs-elem .tree-item.t-item-icon:before,
+      mct-include.l-time-controller .l-time-range-inputs-holder .l-time-range-inputs-elem .search-results .s-status-editing .icon.search-result-item:before,
+      .search-results .s-status-editing mct-include.l-time-controller .l-time-range-inputs-holder .l-time-range-inputs-elem .icon.search-result-item:before,
+      mct-include.l-time-controller .l-time-range-inputs-holder .l-time-range-inputs-elem .search-results .s-status-editing .search-result-item.t-item-icon:before,
+      .search-results .s-status-editing mct-include.l-time-controller .l-time-range-inputs-holder .l-time-range-inputs-elem .search-result-item.t-item-icon:before {
         font-size: 11px;
         width: 11px; }
   /* line 72, ../../../../general/res/sass/controls/_time-controller.scss */
@@ -4278,9 +4335,19 @@ span.req {
 .t-filter input.t-filter-input:not(.ng-dirty) + .t-a-clear {
   display: none; }
 /* line 29, ../../../../general/res/sass/forms/_filter.scss */
-.filter .icon.ui-symbol, .filter .t-item-icon, .filter .icon.s-icon-btn, .filter .s-icon-btn.t-item-icon, .filter .l-datetime-picker .l-month-year-pager .icon.pager, .l-datetime-picker .l-month-year-pager .filter .icon.pager, .filter .l-datetime-picker .l-month-year-pager .pager.t-item-icon, .l-datetime-picker .l-month-year-pager .filter .pager.t-item-icon, .filter .icon.tree-item.active:before, .filter .tree-item.active.t-item-icon:before,
-.filter .icon.search-result-item.active:before,
-.filter .search-result-item.active.t-item-icon:before,
+.filter .icon.ui-symbol, .filter .t-item-icon, .filter .icon.s-icon-btn, .filter .s-icon-btn.t-item-icon, .filter .l-datetime-picker .l-month-year-pager .icon.pager, .l-datetime-picker .l-month-year-pager .filter .icon.pager, .filter .l-datetime-picker .l-month-year-pager .pager.t-item-icon, .l-datetime-picker .l-month-year-pager .filter .pager.t-item-icon, .filter .tree .s-status-editing .icon.tree-item:before, .tree .s-status-editing .filter .icon.tree-item:before, .filter .tree .s-status-editing .tree-item.t-item-icon:before, .tree .s-status-editing .filter .tree-item.t-item-icon:before,
+.filter .tree .s-status-editing .icon.search-result-item:before,
+.tree .s-status-editing .filter .icon.search-result-item:before,
+.filter .tree .s-status-editing .search-result-item.t-item-icon:before,
+.tree .s-status-editing .filter .search-result-item.t-item-icon:before,
+.filter .search-results .s-status-editing .icon.tree-item:before,
+.search-results .s-status-editing .filter .icon.tree-item:before,
+.filter .search-results .s-status-editing .tree-item.t-item-icon:before,
+.search-results .s-status-editing .filter .tree-item.t-item-icon:before,
+.filter .search-results .s-status-editing .icon.search-result-item:before,
+.search-results .s-status-editing .filter .icon.search-result-item:before,
+.filter .search-results .s-status-editing .search-result-item.t-item-icon:before,
+.search-results .s-status-editing .filter .search-result-item.t-item-icon:before,
 .t-filter .icon.ui-symbol,
 .t-filter .t-item-icon,
 .t-filter .icon.s-icon-btn,
@@ -4289,10 +4356,22 @@ span.req {
 .l-datetime-picker .l-month-year-pager .t-filter .icon.pager,
 .t-filter .l-datetime-picker .l-month-year-pager .pager.t-item-icon,
 .l-datetime-picker .l-month-year-pager .t-filter .pager.t-item-icon,
-.t-filter .icon.tree-item.active:before,
-.t-filter .tree-item.active.t-item-icon:before,
-.t-filter .icon.search-result-item.active:before,
-.t-filter .search-result-item.active.t-item-icon:before {
+.t-filter .tree .s-status-editing .icon.tree-item:before,
+.tree .s-status-editing .t-filter .icon.tree-item:before,
+.t-filter .tree .s-status-editing .tree-item.t-item-icon:before,
+.tree .s-status-editing .t-filter .tree-item.t-item-icon:before,
+.t-filter .tree .s-status-editing .icon.search-result-item:before,
+.tree .s-status-editing .t-filter .icon.search-result-item:before,
+.t-filter .tree .s-status-editing .search-result-item.t-item-icon:before,
+.tree .s-status-editing .t-filter .search-result-item.t-item-icon:before,
+.t-filter .search-results .s-status-editing .icon.tree-item:before,
+.search-results .s-status-editing .t-filter .icon.tree-item:before,
+.t-filter .search-results .s-status-editing .tree-item.t-item-icon:before,
+.search-results .s-status-editing .t-filter .tree-item.t-item-icon:before,
+.t-filter .search-results .s-status-editing .icon.search-result-item:before,
+.search-results .s-status-editing .t-filter .icon.search-result-item:before,
+.t-filter .search-results .s-status-editing .search-result-item.t-item-icon:before,
+.search-results .s-status-editing .t-filter .search-result-item.t-item-icon:before {
   -moz-border-radius: 3px;
   -webkit-border-radius: 3px;
   border-radius: 3px;
@@ -4303,9 +4382,19 @@ span.req {
   padding: 0px 5px;
   vertical-align: middle; }
   /* line 37, ../../../../general/res/sass/forms/_filter.scss */
-  .filter .icon.ui-symbol:hover, .filter .t-item-icon:hover, .filter .icon.s-icon-btn:hover, .filter .s-icon-btn.t-item-icon:hover, .filter .l-datetime-picker .l-month-year-pager .icon.pager:hover, .l-datetime-picker .l-month-year-pager .filter .icon.pager:hover, .filter .l-datetime-picker .l-month-year-pager .pager.t-item-icon:hover, .l-datetime-picker .l-month-year-pager .filter .pager.t-item-icon:hover, .filter .icon.tree-item.active:hover:before, .filter .tree-item.active.t-item-icon:hover:before,
-  .filter .icon.search-result-item.active:hover:before,
-  .filter .search-result-item.active.t-item-icon:hover:before,
+  .filter .icon.ui-symbol:hover, .filter .t-item-icon:hover, .filter .icon.s-icon-btn:hover, .filter .s-icon-btn.t-item-icon:hover, .filter .l-datetime-picker .l-month-year-pager .icon.pager:hover, .l-datetime-picker .l-month-year-pager .filter .icon.pager:hover, .filter .l-datetime-picker .l-month-year-pager .pager.t-item-icon:hover, .l-datetime-picker .l-month-year-pager .filter .pager.t-item-icon:hover, .filter .tree .s-status-editing .icon.tree-item:hover:before, .tree .s-status-editing .filter .icon.tree-item:hover:before, .filter .tree .s-status-editing .tree-item.t-item-icon:hover:before, .tree .s-status-editing .filter .tree-item.t-item-icon:hover:before,
+  .filter .tree .s-status-editing .icon.search-result-item:hover:before,
+  .tree .s-status-editing .filter .icon.search-result-item:hover:before,
+  .filter .tree .s-status-editing .search-result-item.t-item-icon:hover:before,
+  .tree .s-status-editing .filter .search-result-item.t-item-icon:hover:before,
+  .filter .search-results .s-status-editing .icon.tree-item:hover:before,
+  .search-results .s-status-editing .filter .icon.tree-item:hover:before,
+  .filter .search-results .s-status-editing .tree-item.t-item-icon:hover:before,
+  .search-results .s-status-editing .filter .tree-item.t-item-icon:hover:before,
+  .filter .search-results .s-status-editing .icon.search-result-item:hover:before,
+  .search-results .s-status-editing .filter .icon.search-result-item:hover:before,
+  .filter .search-results .s-status-editing .search-result-item.t-item-icon:hover:before,
+  .search-results .s-status-editing .filter .search-result-item.t-item-icon:hover:before,
   .t-filter .icon.ui-symbol:hover,
   .t-filter .t-item-icon:hover,
   .t-filter .icon.s-icon-btn:hover,
@@ -4314,21 +4403,44 @@ span.req {
   .l-datetime-picker .l-month-year-pager .t-filter .icon.pager:hover,
   .t-filter .l-datetime-picker .l-month-year-pager .pager.t-item-icon:hover,
   .l-datetime-picker .l-month-year-pager .t-filter .pager.t-item-icon:hover,
-  .t-filter .icon.tree-item.active:hover:before,
-  .t-filter .tree-item.active.t-item-icon:hover:before,
-  .t-filter .icon.search-result-item.active:hover:before,
-  .t-filter .search-result-item.active.t-item-icon:hover:before {
+  .t-filter .tree .s-status-editing .icon.tree-item:hover:before,
+  .tree .s-status-editing .t-filter .icon.tree-item:hover:before,
+  .t-filter .tree .s-status-editing .tree-item.t-item-icon:hover:before,
+  .tree .s-status-editing .t-filter .tree-item.t-item-icon:hover:before,
+  .t-filter .tree .s-status-editing .icon.search-result-item:hover:before,
+  .tree .s-status-editing .t-filter .icon.search-result-item:hover:before,
+  .t-filter .tree .s-status-editing .search-result-item.t-item-icon:hover:before,
+  .tree .s-status-editing .t-filter .search-result-item.t-item-icon:hover:before,
+  .t-filter .search-results .s-status-editing .icon.tree-item:hover:before,
+  .search-results .s-status-editing .t-filter .icon.tree-item:hover:before,
+  .t-filter .search-results .s-status-editing .tree-item.t-item-icon:hover:before,
+  .search-results .s-status-editing .t-filter .tree-item.t-item-icon:hover:before,
+  .t-filter .search-results .s-status-editing .icon.search-result-item:hover:before,
+  .search-results .s-status-editing .t-filter .icon.search-result-item:hover:before,
+  .t-filter .search-results .s-status-editing .search-result-item.t-item-icon:hover:before,
+  .search-results .s-status-editing .t-filter .search-result-item.t-item-icon:hover:before {
     background: rgba(255, 255, 255, 0.1); }
 /* line 41, ../../../../general/res/sass/forms/_filter.scss */
-.filter .s-a-clear.ui-symbol, .filter .s-a-clear.t-item-icon, .filter .s-a-clear.s-icon-btn, .filter .l-datetime-picker .l-month-year-pager .s-a-clear.pager, .l-datetime-picker .l-month-year-pager .filter .s-a-clear.pager, .filter .s-a-clear.tree-item.active:before,
-.filter .s-a-clear.search-result-item.active:before,
+.filter .s-a-clear.ui-symbol, .filter .s-a-clear.t-item-icon, .filter .s-a-clear.s-icon-btn, .filter .l-datetime-picker .l-month-year-pager .s-a-clear.pager, .l-datetime-picker .l-month-year-pager .filter .s-a-clear.pager, .filter .tree .s-status-editing .s-a-clear.tree-item:before, .tree .s-status-editing .filter .s-a-clear.tree-item:before,
+.filter .tree .s-status-editing .s-a-clear.search-result-item:before,
+.tree .s-status-editing .filter .s-a-clear.search-result-item:before,
+.filter .search-results .s-status-editing .s-a-clear.tree-item:before,
+.search-results .s-status-editing .filter .s-a-clear.tree-item:before,
+.filter .search-results .s-status-editing .s-a-clear.search-result-item:before,
+.search-results .s-status-editing .filter .s-a-clear.search-result-item:before,
 .t-filter .s-a-clear.ui-symbol,
 .t-filter .s-a-clear.t-item-icon,
 .t-filter .s-a-clear.s-icon-btn,
 .t-filter .l-datetime-picker .l-month-year-pager .s-a-clear.pager,
 .l-datetime-picker .l-month-year-pager .t-filter .s-a-clear.pager,
-.t-filter .s-a-clear.tree-item.active:before,
-.t-filter .s-a-clear.search-result-item.active:before {
+.t-filter .tree .s-status-editing .s-a-clear.tree-item:before,
+.tree .s-status-editing .t-filter .s-a-clear.tree-item:before,
+.t-filter .tree .s-status-editing .s-a-clear.search-result-item:before,
+.tree .s-status-editing .t-filter .s-a-clear.search-result-item:before,
+.t-filter .search-results .s-status-editing .s-a-clear.tree-item:before,
+.search-results .s-status-editing .t-filter .s-a-clear.tree-item:before,
+.t-filter .search-results .s-status-editing .s-a-clear.search-result-item:before,
+.search-results .s-status-editing .t-filter .s-a-clear.search-result-item:before {
   -moz-border-radius: 3px;
   -webkit-border-radius: 3px;
   border-radius: 3px;
@@ -4352,15 +4464,26 @@ span.req {
   text-align: center;
   z-index: 5; }
   /* line 61, ../../../../general/res/sass/forms/_filter.scss */
-  .filter .s-a-clear.ui-symbol:hover, .filter .s-a-clear.t-item-icon:hover, .filter .s-a-clear.s-icon-btn:hover, .filter .l-datetime-picker .l-month-year-pager .s-a-clear.pager:hover, .l-datetime-picker .l-month-year-pager .filter .s-a-clear.pager:hover, .filter .s-a-clear.tree-item.active:hover:before,
-  .filter .s-a-clear.search-result-item.active:hover:before,
+  .filter .s-a-clear.ui-symbol:hover, .filter .s-a-clear.t-item-icon:hover, .filter .s-a-clear.s-icon-btn:hover, .filter .l-datetime-picker .l-month-year-pager .s-a-clear.pager:hover, .l-datetime-picker .l-month-year-pager .filter .s-a-clear.pager:hover, .filter .tree .s-status-editing .s-a-clear.tree-item:hover:before, .tree .s-status-editing .filter .s-a-clear.tree-item:hover:before,
+  .filter .tree .s-status-editing .s-a-clear.search-result-item:hover:before,
+  .tree .s-status-editing .filter .s-a-clear.search-result-item:hover:before,
+  .filter .search-results .s-status-editing .s-a-clear.tree-item:hover:before,
+  .search-results .s-status-editing .filter .s-a-clear.tree-item:hover:before,
+  .filter .search-results .s-status-editing .s-a-clear.search-result-item:hover:before,
+  .search-results .s-status-editing .filter .s-a-clear.search-result-item:hover:before,
   .t-filter .s-a-clear.ui-symbol:hover,
   .t-filter .s-a-clear.t-item-icon:hover,
   .t-filter .s-a-clear.s-icon-btn:hover,
   .t-filter .l-datetime-picker .l-month-year-pager .s-a-clear.pager:hover,
   .l-datetime-picker .l-month-year-pager .t-filter .s-a-clear.pager:hover,
-  .t-filter .s-a-clear.tree-item.active:hover:before,
-  .t-filter .s-a-clear.search-result-item.active:hover:before {
+  .t-filter .tree .s-status-editing .s-a-clear.tree-item:hover:before,
+  .tree .s-status-editing .t-filter .s-a-clear.tree-item:hover:before,
+  .t-filter .tree .s-status-editing .s-a-clear.search-result-item:hover:before,
+  .tree .s-status-editing .t-filter .s-a-clear.search-result-item:hover:before,
+  .t-filter .search-results .s-status-editing .s-a-clear.tree-item:hover:before,
+  .search-results .s-status-editing .t-filter .s-a-clear.tree-item:hover:before,
+  .t-filter .search-results .s-status-editing .s-a-clear.search-result-item:hover:before,
+  .search-results .s-status-editing .t-filter .s-a-clear.search-result-item:hover:before {
     filter: progid:DXImageTransform.Microsoft.Alpha(Opacity=60);
     opacity: 0.6;
     background-color: #0099cc; }
@@ -4885,7 +5008,7 @@ span.req {
   .object-browse-bar .left {
     padding-right: 10px; }
     /* line 298, ../../../../general/res/sass/user-environ/_layout.scss */
-    .object-browse-bar .left .l-back {
+    .object-browse-bar .left .l-back:not(.s-status-editing) {
       margin-right: 10px; }
 
 /* line 307, ../../../../general/res/sass/user-environ/_layout.scss */
@@ -5988,31 +6111,57 @@ ul.tree {
       .search-result-item:not(.selected):hover .t-item-icon {
         color: #33ccff; } }
   /* line 146, ../../../../general/res/sass/tree/_tree.scss */
-  .tree-item.active,
-  .search-result-item.active {
-    background: #344154;
-    pointer-events: none; }
-    /* line 150, ../../../../general/res/sass/tree/_tree.scss */
-    .tree-item.active:before,
-    .search-result-item.active:before {
-      -moz-animation-name: pulse;
-      -webkit-animation-name: pulse;
-      animation-name: pulse;
-      -moz-animation-duration: 1s;
-      -webkit-animation-duration: 1s;
-      animation-duration: 1s;
-      -moz-animation-direction: alternate;
-      -webkit-animation-direction: alternate;
-      animation-direction: alternate;
-      -moz-animation-iteration-count: infinite;
-      -webkit-animation-iteration-count: infinite;
-      animation-iteration-count: infinite;
-      -moz-animation-timing-function: ease-in-out;
-      -webkit-animation-timing-function: ease-in-out;
-      animation-timing-function: ease-in-out;
-      color: #587ab5;
-      content: '\70';
-      margin-left: 3px; }
+  .tree-item:not(.loading),
+  .search-result-item:not(.loading) {
+    cursor: pointer; }
+  /* line 150, ../../../../general/res/sass/tree/_tree.scss */
+  .tree-item .context-trigger,
+  .search-result-item .context-trigger {
+    top: -1px;
+    position: absolute;
+    right: 3px; }
+    /* line 155, ../../../../general/res/sass/tree/_tree.scss */
+    .tree-item .context-trigger .invoke-menu,
+    .search-result-item .context-trigger .invoke-menu {
+      font-size: 0.75em;
+      height: 0.9rem;
+      line-height: 0.9rem; }
+
+/* line 165, ../../../../general/res/sass/tree/_tree.scss */
+.tree .tree-item .t-object-label,
+.search-results .s-status-editing .search-result-item .t-object-label {
+  left: 15px; }
+
+/* line 173, ../../../../general/res/sass/tree/_tree.scss */
+.tree .s-status-editing .tree-item,
+.tree .s-status-editing .search-result-item,
+.search-results .s-status-editing .tree-item,
+.search-results .s-status-editing .search-result-item {
+  background: #344154;
+  pointer-events: none; }
+  /* line 177, ../../../../general/res/sass/tree/_tree.scss */
+  .tree .s-status-editing .tree-item:before,
+  .tree .s-status-editing .search-result-item:before,
+  .search-results .s-status-editing .tree-item:before,
+  .search-results .s-status-editing .search-result-item:before {
+    -moz-animation-name: pulse;
+    -webkit-animation-name: pulse;
+    animation-name: pulse;
+    -moz-animation-duration: 1s;
+    -webkit-animation-duration: 1s;
+    animation-duration: 1s;
+    -moz-animation-direction: alternate;
+    -webkit-animation-direction: alternate;
+    animation-direction: alternate;
+    -moz-animation-iteration-count: infinite;
+    -webkit-animation-iteration-count: infinite;
+    animation-iteration-count: infinite;
+    -moz-animation-timing-function: ease-in-out;
+    -webkit-animation-timing-function: ease-in-out;
+    animation-timing-function: ease-in-out;
+    color: #587ab5;
+    content: '\70';
+    margin-left: 3px; }
 @-moz-keyframes pulse {
   0% {
     opacity: 0.25; }
@@ -6028,43 +6177,32 @@ ul.tree {
     opacity: 0.25; }
   100% {
     opacity: 1; } }
-    /* line 159, ../../../../general/res/sass/tree/_tree.scss */
-    .tree-item.active .t-object-label .t-item-icon,
-    .tree-item.active .t-object-label .t-title-label,
-    .search-result-item.active .t-object-label .t-item-icon,
-    .search-result-item.active .t-object-label .t-title-label {
-      color: #587ab5;
-      text-shadow: none; }
-    /* line 164, ../../../../general/res/sass/tree/_tree.scss */
-    .tree-item.active .t-object-label .t-title-label,
-    .search-result-item.active .t-object-label .t-title-label {
-      font-style: italic; }
-    /* line 168, ../../../../general/res/sass/tree/_tree.scss */
-    .tree-item.active .view-control, .tree-item.active + .tree-item-subtree,
-    .search-result-item.active .view-control,
-    .search-result-item.active + .tree-item-subtree {
-      display: none; }
-  /* line 171, ../../../../general/res/sass/tree/_tree.scss */
-  .tree-item:not(.loading),
-  .search-result-item:not(.loading) {
-    cursor: pointer; }
-  /* line 175, ../../../../general/res/sass/tree/_tree.scss */
-  .tree-item .context-trigger,
-  .search-result-item .context-trigger {
-    top: -1px;
-    position: absolute;
-    right: 3px; }
-    /* line 180, ../../../../general/res/sass/tree/_tree.scss */
-    .tree-item .context-trigger .invoke-menu,
-    .search-result-item .context-trigger .invoke-menu {
-      font-size: 0.75em;
-      height: 0.9rem;
-      line-height: 0.9rem; }
-
-/* line 190, ../../../../general/res/sass/tree/_tree.scss */
-.tree-item .t-object-label,
-.search-result-item.active .t-object-label {
-  left: 15px; }
+  /* line 186, ../../../../general/res/sass/tree/_tree.scss */
+  .tree .s-status-editing .tree-item .t-object-label .t-item-icon,
+  .tree .s-status-editing .tree-item .t-object-label .t-title-label,
+  .tree .s-status-editing .search-result-item .t-object-label .t-item-icon,
+  .tree .s-status-editing .search-result-item .t-object-label .t-title-label,
+  .search-results .s-status-editing .tree-item .t-object-label .t-item-icon,
+  .search-results .s-status-editing .tree-item .t-object-label .t-title-label,
+  .search-results .s-status-editing .search-result-item .t-object-label .t-item-icon,
+  .search-results .s-status-editing .search-result-item .t-object-label .t-title-label {
+    color: #587ab5;
+    text-shadow: none; }
+  /* line 191, ../../../../general/res/sass/tree/_tree.scss */
+  .tree .s-status-editing .tree-item .t-object-label .t-title-label,
+  .tree .s-status-editing .search-result-item .t-object-label .t-title-label,
+  .search-results .s-status-editing .tree-item .t-object-label .t-title-label,
+  .search-results .s-status-editing .search-result-item .t-object-label .t-title-label {
+    font-style: italic; }
+  /* line 195, ../../../../general/res/sass/tree/_tree.scss */
+  .tree .s-status-editing .tree-item .view-control, .tree .s-status-editing .tree-item + .tree-item-subtree,
+  .tree .s-status-editing .search-result-item .view-control,
+  .tree .s-status-editing .search-result-item + .tree-item-subtree,
+  .search-results .s-status-editing .tree-item .view-control,
+  .search-results .s-status-editing .tree-item + .tree-item-subtree,
+  .search-results .s-status-editing .search-result-item .view-control,
+  .search-results .s-status-editing .search-result-item + .tree-item-subtree {
+    display: none; }
 
 /*****************************************************************************
  * Open MCT Web, Copyright (c) 2014-2015, United States Government

--- a/platform/commonUI/themes/snow/res/css/theme-snow.css
+++ b/platform/commonUI/themes/snow/res/css/theme-snow.css
@@ -20,7 +20,7 @@
  * this source code distribution or the Licensing information page available
  * at runtime from the About dialog for additional information.
  *****************************************************************************/
-/* line 5, ../../../../../../../../../../Library/Ruby/Gems/2.0.0/gems/compass-core-1.0.3/stylesheets/compass/reset/_utilities.scss */
+/* line 5, ../../../../../../../../../../../Library/Ruby/Gems/2.0.0/gems/compass-core-1.0.3/stylesheets/compass/reset/_utilities.scss */
 html, body, div, span, applet, object, iframe,
 h1, h2, h3, h4, h5, h6, p, blockquote, pre,
 a, abbr, acronym, address, big, cite, code,
@@ -41,38 +41,38 @@ time, mark, audio, video {
   font-size: 100%;
   vertical-align: baseline; }
 
-/* line 22, ../../../../../../../../../../Library/Ruby/Gems/2.0.0/gems/compass-core-1.0.3/stylesheets/compass/reset/_utilities.scss */
+/* line 22, ../../../../../../../../../../../Library/Ruby/Gems/2.0.0/gems/compass-core-1.0.3/stylesheets/compass/reset/_utilities.scss */
 html {
   line-height: 1; }
 
-/* line 24, ../../../../../../../../../../Library/Ruby/Gems/2.0.0/gems/compass-core-1.0.3/stylesheets/compass/reset/_utilities.scss */
+/* line 24, ../../../../../../../../../../../Library/Ruby/Gems/2.0.0/gems/compass-core-1.0.3/stylesheets/compass/reset/_utilities.scss */
 ol, ul {
   list-style: none; }
 
-/* line 26, ../../../../../../../../../../Library/Ruby/Gems/2.0.0/gems/compass-core-1.0.3/stylesheets/compass/reset/_utilities.scss */
+/* line 26, ../../../../../../../../../../../Library/Ruby/Gems/2.0.0/gems/compass-core-1.0.3/stylesheets/compass/reset/_utilities.scss */
 table {
   border-collapse: collapse;
   border-spacing: 0; }
 
-/* line 28, ../../../../../../../../../../Library/Ruby/Gems/2.0.0/gems/compass-core-1.0.3/stylesheets/compass/reset/_utilities.scss */
+/* line 28, ../../../../../../../../../../../Library/Ruby/Gems/2.0.0/gems/compass-core-1.0.3/stylesheets/compass/reset/_utilities.scss */
 caption, th, td {
   text-align: left;
   font-weight: normal;
   vertical-align: middle; }
 
-/* line 30, ../../../../../../../../../../Library/Ruby/Gems/2.0.0/gems/compass-core-1.0.3/stylesheets/compass/reset/_utilities.scss */
+/* line 30, ../../../../../../../../../../../Library/Ruby/Gems/2.0.0/gems/compass-core-1.0.3/stylesheets/compass/reset/_utilities.scss */
 q, blockquote {
   quotes: none; }
-  /* line 103, ../../../../../../../../../../Library/Ruby/Gems/2.0.0/gems/compass-core-1.0.3/stylesheets/compass/reset/_utilities.scss */
+  /* line 103, ../../../../../../../../../../../Library/Ruby/Gems/2.0.0/gems/compass-core-1.0.3/stylesheets/compass/reset/_utilities.scss */
   q:before, q:after, blockquote:before, blockquote:after {
     content: "";
     content: none; }
 
-/* line 32, ../../../../../../../../../../Library/Ruby/Gems/2.0.0/gems/compass-core-1.0.3/stylesheets/compass/reset/_utilities.scss */
+/* line 32, ../../../../../../../../../../../Library/Ruby/Gems/2.0.0/gems/compass-core-1.0.3/stylesheets/compass/reset/_utilities.scss */
 a img {
   border: none; }
 
-/* line 116, ../../../../../../../../../../Library/Ruby/Gems/2.0.0/gems/compass-core-1.0.3/stylesheets/compass/reset/_utilities.scss */
+/* line 116, ../../../../../../../../../../../Library/Ruby/Gems/2.0.0/gems/compass-core-1.0.3/stylesheets/compass/reset/_utilities.scss */
 article, aside, details, figcaption, figure, footer, header, hgroup, main, menu, nav, section, summary {
   display: block; }
 
@@ -783,41 +783,66 @@ mct-container {
     border-right: 5px solid transparent; }
 
 /* line 31, ../../../../general/res/sass/_icons.scss */
-.ui-symbol, .t-item-icon, .s-icon-btn, .l-datetime-picker .l-month-year-pager .pager, .tree-item.active:before,
-.search-result-item.active:before {
+.ui-symbol, .t-item-icon, .s-icon-btn, .l-datetime-picker .l-month-year-pager .pager, .tree .s-status-editing .tree-item:before,
+.tree .s-status-editing .search-result-item:before,
+.search-results .s-status-editing .tree-item:before,
+.search-results .s-status-editing .search-result-item:before {
   font-family: 'symbolsfont'; }
   /* line 33, ../../../../general/res/sass/_icons.scss */
-  .ui-symbol.type-icon, .type-icon.t-item-icon, .type-icon.s-icon-btn, .l-datetime-picker .l-month-year-pager .type-icon.pager, .type-icon.tree-item.active:before,
-  .type-icon.search-result-item.active:before {
+  .ui-symbol.type-icon, .type-icon.t-item-icon, .type-icon.s-icon-btn, .l-datetime-picker .l-month-year-pager .type-icon.pager, .tree .s-status-editing .type-icon.tree-item:before,
+  .tree .s-status-editing .type-icon.search-result-item:before,
+  .search-results .s-status-editing .type-icon.tree-item:before,
+  .search-results .s-status-editing .type-icon.search-result-item:before {
     color: #b3b3b3; }
   /* line 36, ../../../../general/res/sass/_icons.scss */
-  .ui-symbol.icon, .t-item-icon, .icon.s-icon-btn, .l-datetime-picker .l-month-year-pager .icon.pager, .l-datetime-picker .l-month-year-pager .pager.t-item-icon, .icon.tree-item.active:before, .tree-item.active.t-item-icon:before,
-  .icon.search-result-item.active:before,
-  .search-result-item.active.t-item-icon:before {
+  .ui-symbol.icon, .t-item-icon, .icon.s-icon-btn, .l-datetime-picker .l-month-year-pager .icon.pager, .l-datetime-picker .l-month-year-pager .pager.t-item-icon, .tree .s-status-editing .icon.tree-item:before, .tree .s-status-editing .tree-item.t-item-icon:before,
+  .tree .s-status-editing .icon.search-result-item:before,
+  .tree .s-status-editing .search-result-item.t-item-icon:before,
+  .search-results .s-status-editing .icon.tree-item:before,
+  .search-results .s-status-editing .tree-item.t-item-icon:before,
+  .search-results .s-status-editing .icon.search-result-item:before,
+  .search-results .s-status-editing .search-result-item.t-item-icon:before {
     color: #0099cc;
     font-size: inherit; }
     /* line 40, ../../../../general/res/sass/_icons.scss */
-    .ui-symbol.icon.alert, .alert.t-item-icon, .icon.alert.s-icon-btn, .l-datetime-picker .l-month-year-pager .icon.alert.pager, .l-datetime-picker .l-month-year-pager .alert.pager.t-item-icon, .icon.alert.tree-item.active:before, .alert.tree-item.active.t-item-icon:before,
-    .icon.alert.search-result-item.active:before,
-    .alert.search-result-item.active.t-item-icon:before {
+    .ui-symbol.icon.alert, .alert.t-item-icon, .icon.alert.s-icon-btn, .l-datetime-picker .l-month-year-pager .icon.alert.pager, .l-datetime-picker .l-month-year-pager .alert.pager.t-item-icon, .tree .s-status-editing .icon.alert.tree-item:before, .tree .s-status-editing .alert.tree-item.t-item-icon:before,
+    .tree .s-status-editing .icon.alert.search-result-item:before,
+    .tree .s-status-editing .alert.search-result-item.t-item-icon:before,
+    .search-results .s-status-editing .icon.alert.tree-item:before,
+    .search-results .s-status-editing .alert.tree-item.t-item-icon:before,
+    .search-results .s-status-editing .icon.alert.search-result-item:before,
+    .search-results .s-status-editing .alert.search-result-item.t-item-icon:before {
       color: #ff3c00; }
       /* line 42, ../../../../general/res/sass/_icons.scss */
-      .ui-symbol.icon.alert:hover, .alert.t-item-icon:hover, .icon.alert.s-icon-btn:hover, .l-datetime-picker .l-month-year-pager .icon.alert.pager:hover, .icon.alert.tree-item.active:hover:before, .alert.tree-item.active.t-item-icon:hover:before,
-      .icon.alert.search-result-item.active:hover:before,
-      .alert.search-result-item.active.t-item-icon:hover:before {
+      .ui-symbol.icon.alert:hover, .alert.t-item-icon:hover, .icon.alert.s-icon-btn:hover, .l-datetime-picker .l-month-year-pager .icon.alert.pager:hover, .tree .s-status-editing .icon.alert.tree-item:hover:before, .tree .s-status-editing .alert.tree-item.t-item-icon:hover:before,
+      .tree .s-status-editing .icon.alert.search-result-item:hover:before,
+      .tree .s-status-editing .alert.search-result-item.t-item-icon:hover:before,
+      .search-results .s-status-editing .icon.alert.tree-item:hover:before,
+      .search-results .s-status-editing .alert.tree-item.t-item-icon:hover:before,
+      .search-results .s-status-editing .icon.alert.search-result-item:hover:before,
+      .search-results .s-status-editing .alert.search-result-item.t-item-icon:hover:before {
         color: #ff8a66; }
     /* line 46, ../../../../general/res/sass/_icons.scss */
-    .ui-symbol.icon.major, .major.t-item-icon, .icon.major.s-icon-btn, .l-datetime-picker .l-month-year-pager .icon.major.pager, .l-datetime-picker .l-month-year-pager .major.pager.t-item-icon, .icon.major.tree-item.active:before, .major.tree-item.active.t-item-icon:before,
-    .icon.major.search-result-item.active:before,
-    .major.search-result-item.active.t-item-icon:before {
+    .ui-symbol.icon.major, .major.t-item-icon, .icon.major.s-icon-btn, .l-datetime-picker .l-month-year-pager .icon.major.pager, .l-datetime-picker .l-month-year-pager .major.pager.t-item-icon, .tree .s-status-editing .icon.major.tree-item:before, .tree .s-status-editing .major.tree-item.t-item-icon:before,
+    .tree .s-status-editing .icon.major.search-result-item:before,
+    .tree .s-status-editing .major.search-result-item.t-item-icon:before,
+    .search-results .s-status-editing .icon.major.tree-item:before,
+    .search-results .s-status-editing .major.tree-item.t-item-icon:before,
+    .search-results .s-status-editing .icon.major.search-result-item:before,
+    .search-results .s-status-editing .major.search-result-item.t-item-icon:before {
       font-size: 1.65em; }
   /* line 50, ../../../../general/res/sass/_icons.scss */
   .ui-symbol.icon-calendar:after, .icon-calendar.t-item-icon:after, .icon-calendar.s-icon-btn:after, .l-datetime-picker .l-month-year-pager .icon-calendar.pager:after {
     content: "\e605"; }
 
 /* line 55, ../../../../general/res/sass/_icons.scss */
-.bar .ui-symbol, .bar .t-item-icon, .bar .s-icon-btn, .bar .l-datetime-picker .l-month-year-pager .pager, .l-datetime-picker .l-month-year-pager .bar .pager, .bar .tree-item.active:before,
-.bar .search-result-item.active:before {
+.bar .ui-symbol, .bar .t-item-icon, .bar .s-icon-btn, .bar .l-datetime-picker .l-month-year-pager .pager, .l-datetime-picker .l-month-year-pager .bar .pager, .bar .tree .s-status-editing .tree-item:before, .tree .s-status-editing .bar .tree-item:before,
+.bar .tree .s-status-editing .search-result-item:before,
+.tree .s-status-editing .bar .search-result-item:before,
+.bar .search-results .s-status-editing .tree-item:before,
+.search-results .s-status-editing .bar .tree-item:before,
+.bar .search-results .s-status-editing .search-result-item:before,
+.search-results .s-status-editing .bar .search-result-item:before {
   display: inline-block; }
 
 /* line 59, ../../../../general/res/sass/_icons.scss */
@@ -2793,9 +2818,19 @@ label.checkbox.custom {
   left: 0;
   text-align: left; }
   /* line 62, ../../../../general/res/sass/controls/_menus.scss */
-  .s-menu-btn .menu .ui-symbol.icon, .s-menu-btn .menu .t-item-icon, .s-menu-btn .menu .icon.s-icon-btn, .s-menu-btn .menu .s-icon-btn.t-item-icon, .s-menu-btn .menu .l-datetime-picker .l-month-year-pager .icon.pager, .l-datetime-picker .l-month-year-pager .s-menu-btn .menu .icon.pager, .s-menu-btn .menu .l-datetime-picker .l-month-year-pager .pager.t-item-icon, .l-datetime-picker .l-month-year-pager .s-menu-btn .menu .pager.t-item-icon, .s-menu-btn .menu .icon.tree-item.active:before, .s-menu-btn .menu .tree-item.active.t-item-icon:before,
-  .s-menu-btn .menu .icon.search-result-item.active:before,
-  .s-menu-btn .menu .search-result-item.active.t-item-icon:before {
+  .s-menu-btn .menu .ui-symbol.icon, .s-menu-btn .menu .t-item-icon, .s-menu-btn .menu .icon.s-icon-btn, .s-menu-btn .menu .s-icon-btn.t-item-icon, .s-menu-btn .menu .l-datetime-picker .l-month-year-pager .icon.pager, .l-datetime-picker .l-month-year-pager .s-menu-btn .menu .icon.pager, .s-menu-btn .menu .l-datetime-picker .l-month-year-pager .pager.t-item-icon, .l-datetime-picker .l-month-year-pager .s-menu-btn .menu .pager.t-item-icon, .s-menu-btn .menu .tree .s-status-editing .icon.tree-item:before, .tree .s-status-editing .s-menu-btn .menu .icon.tree-item:before, .s-menu-btn .menu .tree .s-status-editing .tree-item.t-item-icon:before, .tree .s-status-editing .s-menu-btn .menu .tree-item.t-item-icon:before,
+  .s-menu-btn .menu .tree .s-status-editing .icon.search-result-item:before,
+  .tree .s-status-editing .s-menu-btn .menu .icon.search-result-item:before,
+  .s-menu-btn .menu .tree .s-status-editing .search-result-item.t-item-icon:before,
+  .tree .s-status-editing .s-menu-btn .menu .search-result-item.t-item-icon:before,
+  .s-menu-btn .menu .search-results .s-status-editing .icon.tree-item:before,
+  .search-results .s-status-editing .s-menu-btn .menu .icon.tree-item:before,
+  .s-menu-btn .menu .search-results .s-status-editing .tree-item.t-item-icon:before,
+  .search-results .s-status-editing .s-menu-btn .menu .tree-item.t-item-icon:before,
+  .s-menu-btn .menu .search-results .s-status-editing .icon.search-result-item:before,
+  .search-results .s-status-editing .s-menu-btn .menu .icon.search-result-item:before,
+  .s-menu-btn .menu .search-results .s-status-editing .search-result-item.t-item-icon:before,
+  .search-results .s-status-editing .s-menu-btn .menu .search-result-item.t-item-icon:before {
     width: 12px; }
 
 /******************************************************** MENUS THEMSELVES */
@@ -3511,9 +3546,19 @@ mct-include.l-time-controller {
       mct-include.l-time-controller .l-time-range-inputs-holder .l-time-range-inputs-elem .lbl {
         color: #999999; }
       /* line 65, ../../../../general/res/sass/controls/_time-controller.scss */
-      mct-include.l-time-controller .l-time-range-inputs-holder .l-time-range-input .ui-symbol.icon, mct-include.l-time-controller .l-time-range-inputs-holder .l-time-range-input .t-item-icon, mct-include.l-time-controller .l-time-range-inputs-holder .l-time-range-input .icon.s-icon-btn, mct-include.l-time-controller .l-time-range-inputs-holder .l-time-range-input .s-icon-btn.t-item-icon, mct-include.l-time-controller .l-time-range-inputs-holder .l-time-range-input .l-datetime-picker .l-month-year-pager .icon.pager, .l-datetime-picker .l-month-year-pager mct-include.l-time-controller .l-time-range-inputs-holder .l-time-range-input .icon.pager, mct-include.l-time-controller .l-time-range-inputs-holder .l-time-range-input .l-datetime-picker .l-month-year-pager .pager.t-item-icon, .l-datetime-picker .l-month-year-pager mct-include.l-time-controller .l-time-range-inputs-holder .l-time-range-input .pager.t-item-icon, mct-include.l-time-controller .l-time-range-inputs-holder .l-time-range-input .icon.tree-item.active:before, mct-include.l-time-controller .l-time-range-inputs-holder .l-time-range-input .tree-item.active.t-item-icon:before,
-      mct-include.l-time-controller .l-time-range-inputs-holder .l-time-range-input .icon.search-result-item.active:before,
-      mct-include.l-time-controller .l-time-range-inputs-holder .l-time-range-input .search-result-item.active.t-item-icon:before,
+      mct-include.l-time-controller .l-time-range-inputs-holder .l-time-range-input .ui-symbol.icon, mct-include.l-time-controller .l-time-range-inputs-holder .l-time-range-input .t-item-icon, mct-include.l-time-controller .l-time-range-inputs-holder .l-time-range-input .icon.s-icon-btn, mct-include.l-time-controller .l-time-range-inputs-holder .l-time-range-input .s-icon-btn.t-item-icon, mct-include.l-time-controller .l-time-range-inputs-holder .l-time-range-input .l-datetime-picker .l-month-year-pager .icon.pager, .l-datetime-picker .l-month-year-pager mct-include.l-time-controller .l-time-range-inputs-holder .l-time-range-input .icon.pager, mct-include.l-time-controller .l-time-range-inputs-holder .l-time-range-input .l-datetime-picker .l-month-year-pager .pager.t-item-icon, .l-datetime-picker .l-month-year-pager mct-include.l-time-controller .l-time-range-inputs-holder .l-time-range-input .pager.t-item-icon, mct-include.l-time-controller .l-time-range-inputs-holder .l-time-range-input .tree .s-status-editing .icon.tree-item:before, .tree .s-status-editing mct-include.l-time-controller .l-time-range-inputs-holder .l-time-range-input .icon.tree-item:before, mct-include.l-time-controller .l-time-range-inputs-holder .l-time-range-input .tree .s-status-editing .tree-item.t-item-icon:before, .tree .s-status-editing mct-include.l-time-controller .l-time-range-inputs-holder .l-time-range-input .tree-item.t-item-icon:before,
+      mct-include.l-time-controller .l-time-range-inputs-holder .l-time-range-input .tree .s-status-editing .icon.search-result-item:before,
+      .tree .s-status-editing mct-include.l-time-controller .l-time-range-inputs-holder .l-time-range-input .icon.search-result-item:before,
+      mct-include.l-time-controller .l-time-range-inputs-holder .l-time-range-input .tree .s-status-editing .search-result-item.t-item-icon:before,
+      .tree .s-status-editing mct-include.l-time-controller .l-time-range-inputs-holder .l-time-range-input .search-result-item.t-item-icon:before,
+      mct-include.l-time-controller .l-time-range-inputs-holder .l-time-range-input .search-results .s-status-editing .icon.tree-item:before,
+      .search-results .s-status-editing mct-include.l-time-controller .l-time-range-inputs-holder .l-time-range-input .icon.tree-item:before,
+      mct-include.l-time-controller .l-time-range-inputs-holder .l-time-range-input .search-results .s-status-editing .tree-item.t-item-icon:before,
+      .search-results .s-status-editing mct-include.l-time-controller .l-time-range-inputs-holder .l-time-range-input .tree-item.t-item-icon:before,
+      mct-include.l-time-controller .l-time-range-inputs-holder .l-time-range-input .search-results .s-status-editing .icon.search-result-item:before,
+      .search-results .s-status-editing mct-include.l-time-controller .l-time-range-inputs-holder .l-time-range-input .icon.search-result-item:before,
+      mct-include.l-time-controller .l-time-range-inputs-holder .l-time-range-input .search-results .s-status-editing .search-result-item.t-item-icon:before,
+      .search-results .s-status-editing mct-include.l-time-controller .l-time-range-inputs-holder .l-time-range-input .search-result-item.t-item-icon:before,
       mct-include.l-time-controller .l-time-range-inputs-holder .l-time-range-inputs-elem .ui-symbol.icon,
       mct-include.l-time-controller .l-time-range-inputs-holder .l-time-range-inputs-elem .t-item-icon,
       mct-include.l-time-controller .l-time-range-inputs-holder .l-time-range-inputs-elem .icon.s-icon-btn,
@@ -3522,10 +3567,22 @@ mct-include.l-time-controller {
       .l-datetime-picker .l-month-year-pager mct-include.l-time-controller .l-time-range-inputs-holder .l-time-range-inputs-elem .icon.pager,
       mct-include.l-time-controller .l-time-range-inputs-holder .l-time-range-inputs-elem .l-datetime-picker .l-month-year-pager .pager.t-item-icon,
       .l-datetime-picker .l-month-year-pager mct-include.l-time-controller .l-time-range-inputs-holder .l-time-range-inputs-elem .pager.t-item-icon,
-      mct-include.l-time-controller .l-time-range-inputs-holder .l-time-range-inputs-elem .icon.tree-item.active:before,
-      mct-include.l-time-controller .l-time-range-inputs-holder .l-time-range-inputs-elem .tree-item.active.t-item-icon:before,
-      mct-include.l-time-controller .l-time-range-inputs-holder .l-time-range-inputs-elem .icon.search-result-item.active:before,
-      mct-include.l-time-controller .l-time-range-inputs-holder .l-time-range-inputs-elem .search-result-item.active.t-item-icon:before {
+      mct-include.l-time-controller .l-time-range-inputs-holder .l-time-range-inputs-elem .tree .s-status-editing .icon.tree-item:before,
+      .tree .s-status-editing mct-include.l-time-controller .l-time-range-inputs-holder .l-time-range-inputs-elem .icon.tree-item:before,
+      mct-include.l-time-controller .l-time-range-inputs-holder .l-time-range-inputs-elem .tree .s-status-editing .tree-item.t-item-icon:before,
+      .tree .s-status-editing mct-include.l-time-controller .l-time-range-inputs-holder .l-time-range-inputs-elem .tree-item.t-item-icon:before,
+      mct-include.l-time-controller .l-time-range-inputs-holder .l-time-range-inputs-elem .tree .s-status-editing .icon.search-result-item:before,
+      .tree .s-status-editing mct-include.l-time-controller .l-time-range-inputs-holder .l-time-range-inputs-elem .icon.search-result-item:before,
+      mct-include.l-time-controller .l-time-range-inputs-holder .l-time-range-inputs-elem .tree .s-status-editing .search-result-item.t-item-icon:before,
+      .tree .s-status-editing mct-include.l-time-controller .l-time-range-inputs-holder .l-time-range-inputs-elem .search-result-item.t-item-icon:before,
+      mct-include.l-time-controller .l-time-range-inputs-holder .l-time-range-inputs-elem .search-results .s-status-editing .icon.tree-item:before,
+      .search-results .s-status-editing mct-include.l-time-controller .l-time-range-inputs-holder .l-time-range-inputs-elem .icon.tree-item:before,
+      mct-include.l-time-controller .l-time-range-inputs-holder .l-time-range-inputs-elem .search-results .s-status-editing .tree-item.t-item-icon:before,
+      .search-results .s-status-editing mct-include.l-time-controller .l-time-range-inputs-holder .l-time-range-inputs-elem .tree-item.t-item-icon:before,
+      mct-include.l-time-controller .l-time-range-inputs-holder .l-time-range-inputs-elem .search-results .s-status-editing .icon.search-result-item:before,
+      .search-results .s-status-editing mct-include.l-time-controller .l-time-range-inputs-holder .l-time-range-inputs-elem .icon.search-result-item:before,
+      mct-include.l-time-controller .l-time-range-inputs-holder .l-time-range-inputs-elem .search-results .s-status-editing .search-result-item.t-item-icon:before,
+      .search-results .s-status-editing mct-include.l-time-controller .l-time-range-inputs-holder .l-time-range-inputs-elem .search-result-item.t-item-icon:before {
         font-size: 11px;
         width: 11px; }
   /* line 72, ../../../../general/res/sass/controls/_time-controller.scss */
@@ -4200,9 +4257,19 @@ span.req {
 .t-filter input.t-filter-input:not(.ng-dirty) + .t-a-clear {
   display: none; }
 /* line 29, ../../../../general/res/sass/forms/_filter.scss */
-.filter .icon.ui-symbol, .filter .t-item-icon, .filter .icon.s-icon-btn, .filter .s-icon-btn.t-item-icon, .filter .l-datetime-picker .l-month-year-pager .icon.pager, .l-datetime-picker .l-month-year-pager .filter .icon.pager, .filter .l-datetime-picker .l-month-year-pager .pager.t-item-icon, .l-datetime-picker .l-month-year-pager .filter .pager.t-item-icon, .filter .icon.tree-item.active:before, .filter .tree-item.active.t-item-icon:before,
-.filter .icon.search-result-item.active:before,
-.filter .search-result-item.active.t-item-icon:before,
+.filter .icon.ui-symbol, .filter .t-item-icon, .filter .icon.s-icon-btn, .filter .s-icon-btn.t-item-icon, .filter .l-datetime-picker .l-month-year-pager .icon.pager, .l-datetime-picker .l-month-year-pager .filter .icon.pager, .filter .l-datetime-picker .l-month-year-pager .pager.t-item-icon, .l-datetime-picker .l-month-year-pager .filter .pager.t-item-icon, .filter .tree .s-status-editing .icon.tree-item:before, .tree .s-status-editing .filter .icon.tree-item:before, .filter .tree .s-status-editing .tree-item.t-item-icon:before, .tree .s-status-editing .filter .tree-item.t-item-icon:before,
+.filter .tree .s-status-editing .icon.search-result-item:before,
+.tree .s-status-editing .filter .icon.search-result-item:before,
+.filter .tree .s-status-editing .search-result-item.t-item-icon:before,
+.tree .s-status-editing .filter .search-result-item.t-item-icon:before,
+.filter .search-results .s-status-editing .icon.tree-item:before,
+.search-results .s-status-editing .filter .icon.tree-item:before,
+.filter .search-results .s-status-editing .tree-item.t-item-icon:before,
+.search-results .s-status-editing .filter .tree-item.t-item-icon:before,
+.filter .search-results .s-status-editing .icon.search-result-item:before,
+.search-results .s-status-editing .filter .icon.search-result-item:before,
+.filter .search-results .s-status-editing .search-result-item.t-item-icon:before,
+.search-results .s-status-editing .filter .search-result-item.t-item-icon:before,
 .t-filter .icon.ui-symbol,
 .t-filter .t-item-icon,
 .t-filter .icon.s-icon-btn,
@@ -4211,10 +4278,22 @@ span.req {
 .l-datetime-picker .l-month-year-pager .t-filter .icon.pager,
 .t-filter .l-datetime-picker .l-month-year-pager .pager.t-item-icon,
 .l-datetime-picker .l-month-year-pager .t-filter .pager.t-item-icon,
-.t-filter .icon.tree-item.active:before,
-.t-filter .tree-item.active.t-item-icon:before,
-.t-filter .icon.search-result-item.active:before,
-.t-filter .search-result-item.active.t-item-icon:before {
+.t-filter .tree .s-status-editing .icon.tree-item:before,
+.tree .s-status-editing .t-filter .icon.tree-item:before,
+.t-filter .tree .s-status-editing .tree-item.t-item-icon:before,
+.tree .s-status-editing .t-filter .tree-item.t-item-icon:before,
+.t-filter .tree .s-status-editing .icon.search-result-item:before,
+.tree .s-status-editing .t-filter .icon.search-result-item:before,
+.t-filter .tree .s-status-editing .search-result-item.t-item-icon:before,
+.tree .s-status-editing .t-filter .search-result-item.t-item-icon:before,
+.t-filter .search-results .s-status-editing .icon.tree-item:before,
+.search-results .s-status-editing .t-filter .icon.tree-item:before,
+.t-filter .search-results .s-status-editing .tree-item.t-item-icon:before,
+.search-results .s-status-editing .t-filter .tree-item.t-item-icon:before,
+.t-filter .search-results .s-status-editing .icon.search-result-item:before,
+.search-results .s-status-editing .t-filter .icon.search-result-item:before,
+.t-filter .search-results .s-status-editing .search-result-item.t-item-icon:before,
+.search-results .s-status-editing .t-filter .search-result-item.t-item-icon:before {
   -moz-border-radius: 4px;
   -webkit-border-radius: 4px;
   border-radius: 4px;
@@ -4225,9 +4304,19 @@ span.req {
   padding: 0px 5px;
   vertical-align: middle; }
   /* line 37, ../../../../general/res/sass/forms/_filter.scss */
-  .filter .icon.ui-symbol:hover, .filter .t-item-icon:hover, .filter .icon.s-icon-btn:hover, .filter .s-icon-btn.t-item-icon:hover, .filter .l-datetime-picker .l-month-year-pager .icon.pager:hover, .l-datetime-picker .l-month-year-pager .filter .icon.pager:hover, .filter .l-datetime-picker .l-month-year-pager .pager.t-item-icon:hover, .l-datetime-picker .l-month-year-pager .filter .pager.t-item-icon:hover, .filter .icon.tree-item.active:hover:before, .filter .tree-item.active.t-item-icon:hover:before,
-  .filter .icon.search-result-item.active:hover:before,
-  .filter .search-result-item.active.t-item-icon:hover:before,
+  .filter .icon.ui-symbol:hover, .filter .t-item-icon:hover, .filter .icon.s-icon-btn:hover, .filter .s-icon-btn.t-item-icon:hover, .filter .l-datetime-picker .l-month-year-pager .icon.pager:hover, .l-datetime-picker .l-month-year-pager .filter .icon.pager:hover, .filter .l-datetime-picker .l-month-year-pager .pager.t-item-icon:hover, .l-datetime-picker .l-month-year-pager .filter .pager.t-item-icon:hover, .filter .tree .s-status-editing .icon.tree-item:hover:before, .tree .s-status-editing .filter .icon.tree-item:hover:before, .filter .tree .s-status-editing .tree-item.t-item-icon:hover:before, .tree .s-status-editing .filter .tree-item.t-item-icon:hover:before,
+  .filter .tree .s-status-editing .icon.search-result-item:hover:before,
+  .tree .s-status-editing .filter .icon.search-result-item:hover:before,
+  .filter .tree .s-status-editing .search-result-item.t-item-icon:hover:before,
+  .tree .s-status-editing .filter .search-result-item.t-item-icon:hover:before,
+  .filter .search-results .s-status-editing .icon.tree-item:hover:before,
+  .search-results .s-status-editing .filter .icon.tree-item:hover:before,
+  .filter .search-results .s-status-editing .tree-item.t-item-icon:hover:before,
+  .search-results .s-status-editing .filter .tree-item.t-item-icon:hover:before,
+  .filter .search-results .s-status-editing .icon.search-result-item:hover:before,
+  .search-results .s-status-editing .filter .icon.search-result-item:hover:before,
+  .filter .search-results .s-status-editing .search-result-item.t-item-icon:hover:before,
+  .search-results .s-status-editing .filter .search-result-item.t-item-icon:hover:before,
   .t-filter .icon.ui-symbol:hover,
   .t-filter .t-item-icon:hover,
   .t-filter .icon.s-icon-btn:hover,
@@ -4236,21 +4325,44 @@ span.req {
   .l-datetime-picker .l-month-year-pager .t-filter .icon.pager:hover,
   .t-filter .l-datetime-picker .l-month-year-pager .pager.t-item-icon:hover,
   .l-datetime-picker .l-month-year-pager .t-filter .pager.t-item-icon:hover,
-  .t-filter .icon.tree-item.active:hover:before,
-  .t-filter .tree-item.active.t-item-icon:hover:before,
-  .t-filter .icon.search-result-item.active:hover:before,
-  .t-filter .search-result-item.active.t-item-icon:hover:before {
+  .t-filter .tree .s-status-editing .icon.tree-item:hover:before,
+  .tree .s-status-editing .t-filter .icon.tree-item:hover:before,
+  .t-filter .tree .s-status-editing .tree-item.t-item-icon:hover:before,
+  .tree .s-status-editing .t-filter .tree-item.t-item-icon:hover:before,
+  .t-filter .tree .s-status-editing .icon.search-result-item:hover:before,
+  .tree .s-status-editing .t-filter .icon.search-result-item:hover:before,
+  .t-filter .tree .s-status-editing .search-result-item.t-item-icon:hover:before,
+  .tree .s-status-editing .t-filter .search-result-item.t-item-icon:hover:before,
+  .t-filter .search-results .s-status-editing .icon.tree-item:hover:before,
+  .search-results .s-status-editing .t-filter .icon.tree-item:hover:before,
+  .t-filter .search-results .s-status-editing .tree-item.t-item-icon:hover:before,
+  .search-results .s-status-editing .t-filter .tree-item.t-item-icon:hover:before,
+  .t-filter .search-results .s-status-editing .icon.search-result-item:hover:before,
+  .search-results .s-status-editing .t-filter .icon.search-result-item:hover:before,
+  .t-filter .search-results .s-status-editing .search-result-item.t-item-icon:hover:before,
+  .search-results .s-status-editing .t-filter .search-result-item.t-item-icon:hover:before {
     background: rgba(255, 255, 255, 0.1); }
 /* line 41, ../../../../general/res/sass/forms/_filter.scss */
-.filter .s-a-clear.ui-symbol, .filter .s-a-clear.t-item-icon, .filter .s-a-clear.s-icon-btn, .filter .l-datetime-picker .l-month-year-pager .s-a-clear.pager, .l-datetime-picker .l-month-year-pager .filter .s-a-clear.pager, .filter .s-a-clear.tree-item.active:before,
-.filter .s-a-clear.search-result-item.active:before,
+.filter .s-a-clear.ui-symbol, .filter .s-a-clear.t-item-icon, .filter .s-a-clear.s-icon-btn, .filter .l-datetime-picker .l-month-year-pager .s-a-clear.pager, .l-datetime-picker .l-month-year-pager .filter .s-a-clear.pager, .filter .tree .s-status-editing .s-a-clear.tree-item:before, .tree .s-status-editing .filter .s-a-clear.tree-item:before,
+.filter .tree .s-status-editing .s-a-clear.search-result-item:before,
+.tree .s-status-editing .filter .s-a-clear.search-result-item:before,
+.filter .search-results .s-status-editing .s-a-clear.tree-item:before,
+.search-results .s-status-editing .filter .s-a-clear.tree-item:before,
+.filter .search-results .s-status-editing .s-a-clear.search-result-item:before,
+.search-results .s-status-editing .filter .s-a-clear.search-result-item:before,
 .t-filter .s-a-clear.ui-symbol,
 .t-filter .s-a-clear.t-item-icon,
 .t-filter .s-a-clear.s-icon-btn,
 .t-filter .l-datetime-picker .l-month-year-pager .s-a-clear.pager,
 .l-datetime-picker .l-month-year-pager .t-filter .s-a-clear.pager,
-.t-filter .s-a-clear.tree-item.active:before,
-.t-filter .s-a-clear.search-result-item.active:before {
+.t-filter .tree .s-status-editing .s-a-clear.tree-item:before,
+.tree .s-status-editing .t-filter .s-a-clear.tree-item:before,
+.t-filter .tree .s-status-editing .s-a-clear.search-result-item:before,
+.tree .s-status-editing .t-filter .s-a-clear.search-result-item:before,
+.t-filter .search-results .s-status-editing .s-a-clear.tree-item:before,
+.search-results .s-status-editing .t-filter .s-a-clear.tree-item:before,
+.t-filter .search-results .s-status-editing .s-a-clear.search-result-item:before,
+.search-results .s-status-editing .t-filter .s-a-clear.search-result-item:before {
   -moz-border-radius: 4px;
   -webkit-border-radius: 4px;
   border-radius: 4px;
@@ -4274,15 +4386,26 @@ span.req {
   text-align: center;
   z-index: 5; }
   /* line 61, ../../../../general/res/sass/forms/_filter.scss */
-  .filter .s-a-clear.ui-symbol:hover, .filter .s-a-clear.t-item-icon:hover, .filter .s-a-clear.s-icon-btn:hover, .filter .l-datetime-picker .l-month-year-pager .s-a-clear.pager:hover, .l-datetime-picker .l-month-year-pager .filter .s-a-clear.pager:hover, .filter .s-a-clear.tree-item.active:hover:before,
-  .filter .s-a-clear.search-result-item.active:hover:before,
+  .filter .s-a-clear.ui-symbol:hover, .filter .s-a-clear.t-item-icon:hover, .filter .s-a-clear.s-icon-btn:hover, .filter .l-datetime-picker .l-month-year-pager .s-a-clear.pager:hover, .l-datetime-picker .l-month-year-pager .filter .s-a-clear.pager:hover, .filter .tree .s-status-editing .s-a-clear.tree-item:hover:before, .tree .s-status-editing .filter .s-a-clear.tree-item:hover:before,
+  .filter .tree .s-status-editing .s-a-clear.search-result-item:hover:before,
+  .tree .s-status-editing .filter .s-a-clear.search-result-item:hover:before,
+  .filter .search-results .s-status-editing .s-a-clear.tree-item:hover:before,
+  .search-results .s-status-editing .filter .s-a-clear.tree-item:hover:before,
+  .filter .search-results .s-status-editing .s-a-clear.search-result-item:hover:before,
+  .search-results .s-status-editing .filter .s-a-clear.search-result-item:hover:before,
   .t-filter .s-a-clear.ui-symbol:hover,
   .t-filter .s-a-clear.t-item-icon:hover,
   .t-filter .s-a-clear.s-icon-btn:hover,
   .t-filter .l-datetime-picker .l-month-year-pager .s-a-clear.pager:hover,
   .l-datetime-picker .l-month-year-pager .t-filter .s-a-clear.pager:hover,
-  .t-filter .s-a-clear.tree-item.active:hover:before,
-  .t-filter .s-a-clear.search-result-item.active:hover:before {
+  .t-filter .tree .s-status-editing .s-a-clear.tree-item:hover:before,
+  .tree .s-status-editing .t-filter .s-a-clear.tree-item:hover:before,
+  .t-filter .tree .s-status-editing .s-a-clear.search-result-item:hover:before,
+  .tree .s-status-editing .t-filter .s-a-clear.search-result-item:hover:before,
+  .t-filter .search-results .s-status-editing .s-a-clear.tree-item:hover:before,
+  .search-results .s-status-editing .t-filter .s-a-clear.tree-item:hover:before,
+  .t-filter .search-results .s-status-editing .s-a-clear.search-result-item:hover:before,
+  .search-results .s-status-editing .t-filter .s-a-clear.search-result-item:hover:before {
     filter: progid:DXImageTransform.Microsoft.Alpha(Opacity=60);
     opacity: 0.6;
     background-color: #0099cc; }
@@ -4807,7 +4930,7 @@ span.req {
   .object-browse-bar .left {
     padding-right: 10px; }
     /* line 298, ../../../../general/res/sass/user-environ/_layout.scss */
-    .object-browse-bar .left .l-back {
+    .object-browse-bar .left .l-back:not(.s-status-editing) {
       margin-right: 10px; }
 
 /* line 307, ../../../../general/res/sass/user-environ/_layout.scss */
@@ -5890,31 +6013,57 @@ ul.tree {
       .search-result-item:not(.selected):hover .t-item-icon {
         color: #0099cc; } }
   /* line 146, ../../../../general/res/sass/tree/_tree.scss */
-  .tree-item.active,
-  .search-result-item.active {
-    background: #caf1ff;
-    pointer-events: none; }
-    /* line 150, ../../../../general/res/sass/tree/_tree.scss */
-    .tree-item.active:before,
-    .search-result-item.active:before {
-      -moz-animation-name: pulse;
-      -webkit-animation-name: pulse;
-      animation-name: pulse;
-      -moz-animation-duration: 1s;
-      -webkit-animation-duration: 1s;
-      animation-duration: 1s;
-      -moz-animation-direction: alternate;
-      -webkit-animation-direction: alternate;
-      animation-direction: alternate;
-      -moz-animation-iteration-count: infinite;
-      -webkit-animation-iteration-count: infinite;
-      animation-iteration-count: infinite;
-      -moz-animation-timing-function: ease-in-out;
-      -webkit-animation-timing-function: ease-in-out;
-      animation-timing-function: ease-in-out;
-      color: #4bb1c7;
-      content: '\70';
-      margin-left: 3px; }
+  .tree-item:not(.loading),
+  .search-result-item:not(.loading) {
+    cursor: pointer; }
+  /* line 150, ../../../../general/res/sass/tree/_tree.scss */
+  .tree-item .context-trigger,
+  .search-result-item .context-trigger {
+    top: -1px;
+    position: absolute;
+    right: 3px; }
+    /* line 155, ../../../../general/res/sass/tree/_tree.scss */
+    .tree-item .context-trigger .invoke-menu,
+    .search-result-item .context-trigger .invoke-menu {
+      font-size: 0.75em;
+      height: 0.9rem;
+      line-height: 0.9rem; }
+
+/* line 165, ../../../../general/res/sass/tree/_tree.scss */
+.tree .tree-item .t-object-label,
+.search-results .s-status-editing .search-result-item .t-object-label {
+  left: 15px; }
+
+/* line 173, ../../../../general/res/sass/tree/_tree.scss */
+.tree .s-status-editing .tree-item,
+.tree .s-status-editing .search-result-item,
+.search-results .s-status-editing .tree-item,
+.search-results .s-status-editing .search-result-item {
+  background: #caf1ff;
+  pointer-events: none; }
+  /* line 177, ../../../../general/res/sass/tree/_tree.scss */
+  .tree .s-status-editing .tree-item:before,
+  .tree .s-status-editing .search-result-item:before,
+  .search-results .s-status-editing .tree-item:before,
+  .search-results .s-status-editing .search-result-item:before {
+    -moz-animation-name: pulse;
+    -webkit-animation-name: pulse;
+    animation-name: pulse;
+    -moz-animation-duration: 1s;
+    -webkit-animation-duration: 1s;
+    animation-duration: 1s;
+    -moz-animation-direction: alternate;
+    -webkit-animation-direction: alternate;
+    animation-direction: alternate;
+    -moz-animation-iteration-count: infinite;
+    -webkit-animation-iteration-count: infinite;
+    animation-iteration-count: infinite;
+    -moz-animation-timing-function: ease-in-out;
+    -webkit-animation-timing-function: ease-in-out;
+    animation-timing-function: ease-in-out;
+    color: #4bb1c7;
+    content: '\70';
+    margin-left: 3px; }
 @-moz-keyframes pulse {
   0% {
     opacity: 0.25; }
@@ -5930,43 +6079,32 @@ ul.tree {
     opacity: 0.25; }
   100% {
     opacity: 1; } }
-    /* line 159, ../../../../general/res/sass/tree/_tree.scss */
-    .tree-item.active .t-object-label .t-item-icon,
-    .tree-item.active .t-object-label .t-title-label,
-    .search-result-item.active .t-object-label .t-item-icon,
-    .search-result-item.active .t-object-label .t-title-label {
-      color: #4bb1c7;
-      text-shadow: none; }
-    /* line 164, ../../../../general/res/sass/tree/_tree.scss */
-    .tree-item.active .t-object-label .t-title-label,
-    .search-result-item.active .t-object-label .t-title-label {
-      font-style: italic; }
-    /* line 168, ../../../../general/res/sass/tree/_tree.scss */
-    .tree-item.active .view-control, .tree-item.active + .tree-item-subtree,
-    .search-result-item.active .view-control,
-    .search-result-item.active + .tree-item-subtree {
-      display: none; }
-  /* line 171, ../../../../general/res/sass/tree/_tree.scss */
-  .tree-item:not(.loading),
-  .search-result-item:not(.loading) {
-    cursor: pointer; }
-  /* line 175, ../../../../general/res/sass/tree/_tree.scss */
-  .tree-item .context-trigger,
-  .search-result-item .context-trigger {
-    top: -1px;
-    position: absolute;
-    right: 3px; }
-    /* line 180, ../../../../general/res/sass/tree/_tree.scss */
-    .tree-item .context-trigger .invoke-menu,
-    .search-result-item .context-trigger .invoke-menu {
-      font-size: 0.75em;
-      height: 0.9rem;
-      line-height: 0.9rem; }
-
-/* line 190, ../../../../general/res/sass/tree/_tree.scss */
-.tree-item .t-object-label,
-.search-result-item.active .t-object-label {
-  left: 15px; }
+  /* line 186, ../../../../general/res/sass/tree/_tree.scss */
+  .tree .s-status-editing .tree-item .t-object-label .t-item-icon,
+  .tree .s-status-editing .tree-item .t-object-label .t-title-label,
+  .tree .s-status-editing .search-result-item .t-object-label .t-item-icon,
+  .tree .s-status-editing .search-result-item .t-object-label .t-title-label,
+  .search-results .s-status-editing .tree-item .t-object-label .t-item-icon,
+  .search-results .s-status-editing .tree-item .t-object-label .t-title-label,
+  .search-results .s-status-editing .search-result-item .t-object-label .t-item-icon,
+  .search-results .s-status-editing .search-result-item .t-object-label .t-title-label {
+    color: #4bb1c7;
+    text-shadow: none; }
+  /* line 191, ../../../../general/res/sass/tree/_tree.scss */
+  .tree .s-status-editing .tree-item .t-object-label .t-title-label,
+  .tree .s-status-editing .search-result-item .t-object-label .t-title-label,
+  .search-results .s-status-editing .tree-item .t-object-label .t-title-label,
+  .search-results .s-status-editing .search-result-item .t-object-label .t-title-label {
+    font-style: italic; }
+  /* line 195, ../../../../general/res/sass/tree/_tree.scss */
+  .tree .s-status-editing .tree-item .view-control, .tree .s-status-editing .tree-item + .tree-item-subtree,
+  .tree .s-status-editing .search-result-item .view-control,
+  .tree .s-status-editing .search-result-item + .tree-item-subtree,
+  .search-results .s-status-editing .tree-item .view-control,
+  .search-results .s-status-editing .tree-item + .tree-item-subtree,
+  .search-results .s-status-editing .search-result-item .view-control,
+  .search-results .s-status-editing .search-result-item + .tree-item-subtree {
+    display: none; }
 
 /*****************************************************************************
  * Open MCT Web, Copyright (c) 2014-2015, United States Government


### PR DESCRIPTION
open #199
open #278
Changed CSS to use s-status-editing instead of .active
class;
Refined style defs to explicitly target tree and
search-results children in order to avoid items in
Inspector Elements pool from being designated as
being edited;
Removed {{searchText}} div from input-filter;