### PR TITLE
[Layout] Update raw positions on drop

### DIFF
--- a/platform/features/layout/src/LayoutController.js
+++ b/platform/features/layout/src/LayoutController.js
@@ -85,6 +85,8 @@ define(
                     $scope.commit("Dropped a frame.");
                 }
                 // Populate template-facing position for this id
+                self.rawPositions[id] =
+                    $scope.configuration.panels[id];
                 self.populatePosition(id);
                 // Layout may contain embedded views which will
                 // listen for drops, so call preventDefault() so

--- a/platform/features/layout/test/LayoutControllerSpec.js
+++ b/platform/features/layout/test/LayoutControllerSpec.js
@@ -274,6 +274,23 @@ define(
                 expect(parseInt(style.width, 10)).toBeGreaterThan(63);
                 expect(parseInt(style.height, 10)).toBeGreaterThan(31);
             });
+
+            it("updates positions of existing objects on a drop", function () {
+                var oldStyle;
+
+                mockScope.$watchCollection.mostRecentCall.args[1]();
+
+                oldStyle = controller.getFrameStyle("b");
+
+                expect(oldStyle).toBeDefined();
+
+                // ...drop event...
+                mockScope.$on.mostRecentCall
+                    .args[1](mockEvent, 'b', { x: 300, y: 100 });
+
+                expect(controller.getFrameStyle("b"))
+                    .not.toEqual(oldStyle);
+            });
         });
     }
 );


### PR DESCRIPTION
When handling a drop into the layout, store the panel's
new position to the LayoutController's internal table of
raw positions (in addition to writing it to the configuration.)

Avoids https://github.com/nasa/openmctweb/issues/384



### Author Checklist

1. Changes address original issue? Y
2. Unit tests included and/or updated with changes? Y
3. Command line build passes? Y
4. Changes have been smoke-tested? Y