### PR TITLE
[Documentation] Tweak spelling / phrasing

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,35 +1,35 @@
-# OpenMCTWeb Documentation
+# Open MCT Web Documentation
 
 ## Overview
 
- Documentation is provided to support the use and development of the 
- OpenMCTWeb mission operations software. It's recommended that before doing 
- any development with OpenMCTWeb you take some time to familiarize yourself 
+ Documentation is provided to support the use and development of
+ Open MCT Web. It's recommended that before doing
+ any development with Open MCT Web you take some time to familiarize yourself 
  with the documentation below.
 
- OpenMCTWeb provides functionality out of the box, but it's also a framework for
+ Open MCT Web provides functionality out of the box, but it's also a platform for
  building rich mission operations applications based on modern web technology. 
- The framework is configured declaratively, and defines conventions for 
+ The platform is configured declaratively, and defines conventions for
  building on the provided capabilities by creating modular 'bundles' that 
- extend the provided extension points. The details of how to extend the 
- framework are provided in the following documentation. 
+ extend the platform at a variety of extension points. The details of how to
+ extend the platform are provided in the following documentation.
 
 ## Sections
 
  * The [Architecture Overview](architecture/) describes the concepts used 
- throughout OpenMCTWeb, and gives a high level overview of the framework's design.
+ throughout Open MCT Web, and gives a high level overview of the platform's design.
  
- * The [Developer's guide](guide/) goes into more detail about how to use the 
- framework 
- and the capabilities that it provides.
+ * The [Developer's Guide](guide/) goes into more detail about how to use the
+ platform and the functionality that it provides.
  
  * The [Tutorials](tutorials/) give examples of extending the platform to add 
  functionality, 
  and integrate with data sources.
  
  * The [API](api/) document is generated from inline documentation 
- using jsdoc, and describes the javascript objects and functions that make up 
- the software framework.
+ using [JSDoc](http://usejsdoc.org/), and describes the JavaScript objects and
+ functions that make up the software platform.
 
  * Finally, the [Development Process](process/) document describes the 
- OpenMCTWeb software development cycle. 
+ Open MCT Web software development cycle.
+ 


### PR DESCRIPTION
* Add spaces to 'Open MCT Web' for consistency
* Use term 'platform' instead of 'framework' for consistency
  with the developer guide
* Avoid the term 'capabilities' (could be ambiguous in the context
  of other documentation)
* Use canonical casing for JSDoc and JavaScript
* Simplify phrasing of first sentence
* Change casing of 'Developer Guide' for consistency with
  other bullets

From review of https://github.com/nasa/openmctweb/pull/412