### PR TITLE
[Documentation] Code example in bar graph tutorial incorporates text from the following paragraph

### DIFF
--- a/docs/src/tutorials/index.md
+++ b/docs/src/tutorials/index.md
@@ -1697,8 +1697,7 @@ Next, we utilize this functionality from the template:
         </div>
     </div>
 </div>
-'''
-
+```
 __tutorials/bargraph/res/templates/bargraph.html__
 
 Here, we utilize the functions we just provided from the controller to position 


### PR DESCRIPTION
From #433

Fixed an error in the markdown that caused text to render incorrectly in the bar graph tutorial.