### PR TITLE
Review and integrate open431

### DIFF
--- a/platform/commonUI/edit/res/templates/elements.html
+++ b/platform/commonUI/edit/res/templates/elements.html
@@ -24,7 +24,9 @@
     <ul class="tree">
         <li ng-repeat="containedObject in composition">
             <span class="tree-item">
-                <mct-representation key="'label'" mct-object="containedObject">
+                <mct-representation key="'label'"
+                                    mct-object="containedObject"
+                                    class="rep-object-label">
                 </mct-representation>
             </span>
         </li>

--- a/platform/commonUI/general/res/sass/_icons.scss
+++ b/platform/commonUI/general/res/sass/_icons.scss
@@ -73,23 +73,21 @@
 }
 
 .l-icon-alert {
-	display: none !important; // Remove this when alerts are enabled
+	display: none !important;
 	&:before {
 		color: $colorAlert;
 		content: "!";
 	}
 }
 
-// NEW!!
 .t-item-icon {
 	// Used in grid-item.html, tree-item, inspector location, more?
 	@extend .ui-symbol;
     @extend .icon;
-    //display: inline-block;
     line-height: normal; // This is Ok for the symbolsfont
     position: relative;
     .t-item-icon-glyph {
-        position: relative;
+        position: absolute;
     }
     &.l-icon-link {
         .t-item-icon-glyph {

--- a/platform/commonUI/general/res/sass/_icons.scss
+++ b/platform/commonUI/general/res/sass/_icons.scss
@@ -85,9 +85,12 @@
 	// Used in grid-item.html, tree-item, inspector location, more?
 	@extend .ui-symbol;
     @extend .icon;
-    display: inline-block;
+    //display: inline-block;
     line-height: normal; // This is Ok for the symbolsfont
     position: relative;
+    .t-item-icon-glyph {
+        position: relative;
+    }
     &.l-icon-link {
         .t-item-icon-glyph {
             &:before {

--- a/platform/commonUI/general/res/sass/_inspector.scss
+++ b/platform/commonUI/general/res/sass/_inspector.scss
@@ -84,12 +84,20 @@
     }
 
     .inspector-location {
-        //line-height: 180%;
         .location-item {
+            $h: 1.2em;
+            @include box-sizing(border-box);
             cursor: pointer;
             display: inline-block;
+            line-height: $h;
             position: relative;
             padding: 2px 4px;
+            .t-object-label {
+                .t-item-icon {
+                    height: $h;
+                    width: 0.7rem;
+                }
+            }
             &:hover {
                 background: $colorItemTreeHoverBg;
                 color: $colorItemTreeHoverFg;
@@ -104,6 +112,7 @@
             display: inline-block;
             font-family: symbolsfont;
             font-size: 8px;
+            font-style: normal !important;
             line-height: inherit;
             margin-left: $interiorMarginSm;
             width: 4px;

--- a/platform/commonUI/general/res/sass/_main.scss
+++ b/platform/commonUI/general/res/sass/_main.scss
@@ -60,6 +60,7 @@
 @import "overlay/overlay";
 @import "mobile/overlay/overlay";
 @import "tree/tree";
+@import "object-label";
 @import "mobile/tree";
 @import "user-environ/frame";
 @import "user-environ/top-bar";

--- a/platform/commonUI/general/res/sass/_mixins.scss
+++ b/platform/commonUI/general/res/sass/_mixins.scss
@@ -300,7 +300,7 @@
 	@include desktop {
 		@if $bgHov != none {
 			&:not(.disabled):hover {
-				background: $bgHov;
+				@include background-image($bgHov);
 				>.icon {
 					color: lighten($ic, $ltGamma);
 				}

--- a/platform/commonUI/general/res/sass/_object-label.scss
+++ b/platform/commonUI/general/res/sass/_object-label.scss
@@ -33,9 +33,6 @@
     .t-item-icon {
         margin-right: $interiorMargin;
     }
-    .t-title-label {
-        @include ellipsize();
-    }
 }
 
 mct-representation {

--- a/platform/commonUI/general/res/sass/_object-label.scss
+++ b/platform/commonUI/general/res/sass/_object-label.scss
@@ -41,14 +41,14 @@ mct-representation {
             .t-item-icon {
                 &:before {
                     $spinBW: 4px;
-                    $spinD: 0; // $treeTypeIconW - ($spinBW * 2);
+                    $spinD: 0;
                     @include spinner($spinBW);
                     content: "";
                     display: block;
                     position: absolute;
                     left: 50%;
                     top: 50%;
-                    padding: 35%;
+                    padding: 30%;
                     width: $spinD;
                     height: $spinD;
                 }

--- a/platform/commonUI/general/res/sass/_object-label.scss
+++ b/platform/commonUI/general/res/sass/_object-label.scss
@@ -1,0 +1,72 @@
+/*****************************************************************************
+ * Open MCT Web, Copyright (c) 2014-2015, United States Government
+ * as represented by the Administrator of the National Aeronautics and Space
+ * Administration. All rights reserved.
+ *
+ * Open MCT Web is licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * Open MCT Web includes source code licensed under additional open source
+ * licenses. See the Open Source Licenses file (LICENSES.md) included with
+ * this source code distribution or the Licensing information page available
+ * at runtime from the About dialog for additional information.
+ *****************************************************************************/
+
+// mct-representation surrounding an object-label key="'label'"
+.rep-object-label {
+    @include flex-direction(row);
+    @include flex(1 1 auto);
+    height: inherit;
+    line-height: inherit;
+    min-width: 0;
+}
+
+.t-object-label {
+    .t-item-icon {
+        margin-right: $interiorMargin;
+    }
+    .t-title-label {
+        @include ellipsize();
+    }
+}
+
+mct-representation {
+    &.s-status-pending {
+        .t-object-label {
+            .t-item-icon {
+                &:before {
+                    $spinBW: 4px;
+                    $spinD: 0; // $treeTypeIconW - ($spinBW * 2);
+                    @include spinner($spinBW);
+                    content: "";
+                    display: block;
+                    position: absolute;
+                    left: 50%;
+                    top: 50%;
+                    padding: 35%;
+                    width: $spinD;
+                    height: $spinD;
+                }
+                .t-item-icon-glyph {
+                    display: none;
+                }
+            }
+            .t-title-label {
+                font-style: italic;
+                opacity: 0.6;
+            }
+        }
+    }
+}
+.selected mct-representation.s-status-pending .t-object-label .t-item-icon:before {
+    border-color: rgba($colorItemTreeSelectedFg, 0.25);
+    border-top-color: rgba($colorItemTreeSelectedFg, 1.0);
+}

--- a/platform/commonUI/general/res/sass/helpers/_wait-spinner.scss
+++ b/platform/commonUI/general/res/sass/helpers/_wait-spinner.scss
@@ -24,11 +24,11 @@
     100% { transform: rotate(359deg); }
 }
 
-@mixin wait-spinner2($b: 5px, $c: $colorAlt1) {
+@mixin spinner($b: 5px, $c: $colorAlt1) {
     @include keyframes(rotateCentered) {
-         0%   { transform: translateX(-50%) translateY(-50%) rotate(0deg); }
-         100% { transform: translateX(-50%) translateY(-50%) rotate(359deg); }
-     }
+        0%   { transform: translateX(-50%) translateY(-50%) rotate(0deg); }
+        100% { transform: translateX(-50%) translateY(-50%) rotate(359deg); }
+    }
     @include animation-name(rotateCentered);
     @include animation-duration(0.5s);
     @include animation-iteration-count(infinite);
@@ -36,8 +36,13 @@
     border-color: rgba($c, 0.25);
     border-top-color: rgba($c, 1.0);
     border-style: solid;
-    border-width: 5px;
+    border-width: $b;
     @include border-radius(100%);
+}
+
+
+@mixin wait-spinner2($b: 5px, $c: $colorAlt1) {
+    @include spinner($b, $c);
     @include box-sizing(border-box);
     display: block;
     position: absolute;

--- a/platform/commonUI/general/res/sass/helpers/_wait-spinner.scss
+++ b/platform/commonUI/general/res/sass/helpers/_wait-spinner.scss
@@ -24,7 +24,7 @@
     100% { transform: rotate(359deg); }
 }
 
-@mixin spinner($b: 5px, $c: $colorAlt1) {
+@mixin spinner($b: 5px) {
     @include keyframes(rotateCentered) {
         0%   { @include transform(translateX(-50%) translateY(-50%) rotate(0deg)); }
         100% { @include transform(translateX(-50%) translateY(-50%) rotate(359deg)); }
@@ -33,8 +33,6 @@
     @include animation-duration(0.5s);
     @include animation-iteration-count(infinite);
     @include animation-timing-function(linear);
-    border-color: rgba($c, 0.25);
-    border-top-color: rgba($c, 1.0);
     border-style: solid;
     border-width: $b;
     @include border-radius(100%);
@@ -42,8 +40,10 @@
 
 
 @mixin wait-spinner2($b: 5px, $c: $colorAlt1) {
-    @include spinner($b, $c);
+    @include spinner($b);
     @include box-sizing(border-box);
+    border-color: rgba($c, 0.25);
+    border-top-color: rgba($c, 1.0);
     display: block;
     position: absolute;
     height: 0; width: 0;

--- a/platform/commonUI/general/res/sass/helpers/_wait-spinner.scss
+++ b/platform/commonUI/general/res/sass/helpers/_wait-spinner.scss
@@ -26,8 +26,8 @@
 
 @mixin spinner($b: 5px, $c: $colorAlt1) {
     @include keyframes(rotateCentered) {
-        0%   { transform: translateX(-50%) translateY(-50%) rotate(0deg); }
-        100% { transform: translateX(-50%) translateY(-50%) rotate(359deg); }
+        0%   { @include transform(translateX(-50%) translateY(-50%) rotate(0deg)); }
+        100% { @include transform(translateX(-50%) translateY(-50%) rotate(359deg)); }
     }
     @include animation-name(rotateCentered);
     @include animation-duration(0.5s);

--- a/platform/commonUI/general/res/sass/helpers/_wait-spinner.scss
+++ b/platform/commonUI/general/res/sass/helpers/_wait-spinner.scss
@@ -33,6 +33,7 @@
     @include animation-duration(0.5s);
     @include animation-iteration-count(infinite);
     @include animation-timing-function(linear);
+    @include transform-origin(center);
     border-style: solid;
     border-width: $b;
     @include border-radius(100%);

--- a/platform/commonUI/general/res/sass/mobile/_constants.scss
+++ b/platform/commonUI/general/res/sass/mobile/_constants.scss
@@ -31,7 +31,7 @@ $tabletItemH: floor($ueBrowseGridItemLg/3);
 
 /************************** MOBILE TREE MENU DIMENSIONS */
 $mobileTreeItemH: 35px;
-$mobileTreeItemIndent: 20px;
+$mobileTreeItemIndent: 15px;
 $mobileTreeRightArrowW: 30px;
 
 /************************** DEVICE WIDTHS */

--- a/platform/commonUI/general/res/sass/mobile/_tree.scss
+++ b/platform/commonUI/general/res/sass/mobile/_tree.scss
@@ -30,9 +30,9 @@
     }
 	.tree-item,
 	.search-result-item {
-		height: $mobileTreeItemH;
-		line-height: $mobileTreeItemH;
-		margin-bottom: 0px;
+		height: $mobileTreeItemH !important;
+		line-height: $mobileTreeItemH !important;
+		margin-bottom: 0px !important;
 		.view-control {
             font-size: 1.2em;
             margin-right: 0;

--- a/platform/commonUI/general/res/sass/mobile/_tree.scss
+++ b/platform/commonUI/general/res/sass/mobile/_tree.scss
@@ -34,20 +34,20 @@
 		line-height: $mobileTreeItemH;
 		margin-bottom: 0px;
 		.view-control {
-			//@include test(red);
-			position: absolute;
-			font-size: 1.1em;
-			height: $mobileTreeItemH;
-			line-height: inherit;
-			right: 0px;
-			width: $mobileTreeRightArrowW;
-			text-align: center;
+            order: 2;
+            width: $mobileTreeItemH;
+            &.has-children {
+                &:before {
+                    content: "\7d";
+                    left: 50%;
+                    @include transform(translateX(-50%) rotate(90deg));
+                }
+                &.expanded:before {
+                    @include transform(translateX(-50%) rotate(270deg));
+                }
+            }
 		}
-
-		.label,
 		.t-object-label {
-			left: 0;
-			right: $mobileTreeRightArrowW + $interiorMargin; // Allows tree item name to stop prior to the arrow
 			line-height: inherit;
 		}
 	}

--- a/platform/commonUI/general/res/sass/mobile/search/_search.scss
+++ b/platform/commonUI/general/res/sass/mobile/search/_search.scss
@@ -1,5 +1,5 @@
 @include phone {
-	.search {
+	.search-holder {
 		.search-bar {
 			// Hide menu-icon and adjust spacing when in phone mode
 			.menu-icon {

--- a/platform/commonUI/general/res/sass/search/_search.scss
+++ b/platform/commonUI/general/res/sass/search/_search.scss
@@ -82,6 +82,7 @@
             left: $interiorMarginSm;
             @include trans-prop-nice(color, 250ms);
             pointer-events: none;
+            z-index: 1;
         }
 
 		// Make icon lighten when hovering over search bar

--- a/platform/commonUI/general/res/sass/search/_search.scss
+++ b/platform/commonUI/general/res/sass/search/_search.scss
@@ -128,7 +128,7 @@
 	}
 
 	.active-filter-display {
-		$s: 0.65em;
+		$s: 0.7em;
 		$p: $interiorMargin;
 		@include box-sizing(border-box);
 		line-height: 130%;
@@ -147,7 +147,6 @@
 
 	.search-results {
         @include trans-prop-nice((opacity, visibility), 250ms);
-        margin-top: $interiorMarginLg; // Always include margin here to fend off the search input
 		padding-right: $interiorMargin;
         .hint {
             margin-bottom: $interiorMarginLg;

--- a/platform/commonUI/general/res/sass/tree/_tree.scss
+++ b/platform/commonUI/general/res/sass/tree/_tree.scss
@@ -49,7 +49,7 @@ ul.tree {
 		color: $colorItemTreeVC;
         font-size: 0.75em;
 		margin-right: $interiorMargin;
-        height: 100%; //$menuLineH;
+        height: 100%;
         line-height: inherit;
 		width: $treeVCW;
         &.has-children {
@@ -93,12 +93,11 @@ ul.tree {
 			color: $colorItemTreeSelectedVC;
 		}
 		.t-object-label .t-item-icon {
-			color: $colorItemTreeSelectedFg; //$colorItemTreeIconHover;
+			color: $colorItemTreeSelectedFg;
 		}
 	}
 
 	&:not(.selected) {
-		// NOTE: [Mobile] Removed Hover on Mobile
 		@include desktop {
 			&:hover {
 				background: $colorItemTreeHoverBg;
@@ -148,7 +147,15 @@ ul.tree {
                         display: none;
                     }
                 }
+                .t-title-label {
+                    font-style: italic;
+                    opacity: 0.6;
+                }
             }
         }
+    }
+    &.selected mct-representation.s-status-pending .t-object-label .t-item-icon:before {
+        border-color: rgba($colorItemTreeSelectedFg, 0.25);
+        border-top-color: rgba($colorItemTreeSelectedFg, 1.0);
     }
 }

--- a/platform/commonUI/general/res/sass/tree/_tree.scss
+++ b/platform/commonUI/general/res/sass/tree/_tree.scss
@@ -79,6 +79,9 @@ ul.tree {
             color: $colorItemTreeIcon;
             width: $treeTypeIconW;
         }
+        .t-title-label {
+            @include ellipsize();
+        }
 	}
 
 	&.selected {

--- a/platform/commonUI/general/res/sass/tree/_tree.scss
+++ b/platform/commonUI/general/res/sass/tree/_tree.scss
@@ -35,6 +35,7 @@ ul.tree {
 .tree-item,
 .search-result-item {
 	$runningItemW: 0;
+    @extend .l-flex-row;
 	@include box-sizing(border-box);
 	@include border-radius($basicCr);
 	@include single-transition(background-color, 0.25s);
@@ -76,12 +77,8 @@ ul.tree {
             @include txtShdwSubtle($shdwItemTreeIcon);
             font-size: $treeTypeIconH;
             color: $colorItemTreeIcon;
-            margin-right: $interiorMargin;
             width: $treeTypeIconW;
         }
-        .t-title-label {
-            @include ellipsize();
-		}
 	}
 
 	&.selected {
@@ -124,36 +121,36 @@ ul.tree {
 	}
 }
 
-.tree-item {
-    mct-representation {
-        &.s-status-pending {
-            .t-object-label {
-                .t-item-icon {
-                    &:before {
-                        $spinBW: 4px;
-                        $spinD: $treeTypeIconW - ($spinBW * 2);
-                        @include spinner($spinBW, $colorItemTreeIcon);
-                        content: "";
-                        display: block;
-                        position: absolute;
-                        left: 50%;
-                        top: 50%;
-                        width: $spinD;
-                        height: $spinD;
-                    }
-                    .t-item-icon-glyph {
-                        display: none;
-                    }
+mct-representation {
+    &.s-status-pending {
+        .t-object-label {
+            .t-item-icon {
+                &:before {
+                    $spinBW: 4px;
+                    $spinD: $treeTypeIconW - ($spinBW * 2);
+                    @include spinner($spinBW);
+                    border-color: rgba($colorItemTreeIcon, 0.25);
+                    border-top-color: rgba($colorItemTreeIcon, 1.0);
+                    //content: "";
+                    //display: block;
+                    //position: absolute;
+                    //left: 50%;
+                    //top: 50%;
+                    width: $spinD;
+                    height: $spinD;
                 }
-                .t-title-label {
-                    font-style: italic;
-                    opacity: 0.6;
+                .t-item-icon-glyph {
+                    display: none;
                 }
+            }
+            .t-title-label {
+                font-style: italic;
+                opacity: 0.6;
             }
         }
     }
-    &.selected mct-representation.s-status-pending .t-object-label .t-item-icon:before {
-        border-color: rgba($colorItemTreeSelectedFg, 0.25);
-        border-top-color: rgba($colorItemTreeSelectedFg, 1.0);
-    }
+}
+.selected mct-representation.s-status-pending .t-object-label .t-item-icon:before {
+    border-color: rgba($colorItemTreeSelectedFg, 0.25);
+    border-top-color: rgba($colorItemTreeSelectedFg, 1.0);
 }

--- a/platform/commonUI/general/res/sass/tree/_tree.scss
+++ b/platform/commonUI/general/res/sass/tree/_tree.scss
@@ -72,7 +72,6 @@ ul.tree {
 
 	.t-object-label {
 		line-height: $menuLineH;
-
         .t-item-icon {
             @include txtShdwSubtle($shdwItemTreeIcon);
             font-size: $treeTypeIconH;
@@ -80,7 +79,6 @@ ul.tree {
             margin-right: $interiorMargin;
             width: $treeTypeIconW;
         }
-		.title-label,
         .t-title-label {
             @include ellipsize();
 		}

--- a/platform/commonUI/general/res/sass/tree/_tree.scss
+++ b/platform/commonUI/general/res/sass/tree/_tree.scss
@@ -59,7 +59,6 @@ ul.tree {
 		}
 	}
 
-	.label,
 	.t-object-label {
 		display: block;
 		@include absPosDefault();
@@ -76,38 +75,6 @@ ul.tree {
             @include transform(translateY(-50%));
         }
 
-		.type-icon {
-			//@include absPosDefault(0, false);
-			$d: $treeTypeIconH;
-			@include txtShdwSubtle($shdwItemTreeIcon);
-			font-size: $treeTypeIconH;
-			color: $colorItemTreeIcon;
-			left: $interiorMargin;
-			position: absolute;
-			@include verticalCenterBlock($menuLineHPx, $treeTypeIconHPx);
-			line-height: 100%;
-			right: auto; width: $treeTypeIconH;
-
-			.icon {
-				&.l-icon-link,
-				&.l-icon-alert {
-					position: absolute;
-					z-index: 2;
-				}
-				&.l-icon-alert {
-					$d: 8px;
-					@include ancillaryIcon($d, $colorAlert);
-					top: 1px;
-					right: -2px;
-				}
-				&.l-icon-link {
-					$d: 8px;
-					@include ancillaryIcon($d, $colorIconLink);
-					left: -3px;
-					bottom: 0px;
-				}
-			}
-		}
 		.title-label,
         .t-title-label {
 			@include absPosDefault();
@@ -161,7 +128,21 @@ ul.tree {
 }
 
 .tree-item {
-	.t-object-label {
-		left: $interiorMargin + $treeVCW;
-	}
+    mct-representation {
+        .t-object-label {
+            left: $interiorMargin + $treeVCW;
+        }
+        &.s-status-pending {
+            .t-object-label {
+                &:before {
+                    @include tItemIcon();
+                    @include spinner(0.25em, $colorItemTreeIcon);
+                    content: "";
+                }
+                .t-item-icon .t-item-icon-glyph {
+                    display: none;
+                }
+            }
+        }
+    }
 }

--- a/platform/commonUI/general/res/sass/tree/_tree.scss
+++ b/platform/commonUI/general/res/sass/tree/_tree.scss
@@ -38,20 +38,33 @@ ul.tree {
 	@include box-sizing(border-box);
 	@include border-radius($basicCr);
 	@include single-transition(background-color, 0.25s);
-	display: block;
 	font-size: 0.8rem;
 	height: $menuLineH;
 	line-height: $menuLineH;
 	margin-bottom: $interiorMarginSm;
+    padding: 0 $interiorMarginSm;
 	position: relative;
 
 	.view-control {
+        @extend .flex-elem;
 		color: $colorItemTreeVC;
-		display: inline-block;
-		margin-left: $interiorMargin;
+		//display: inline-block;
+		margin-right: $interiorMargin;
 		font-size: 0.75em;
 		width: $treeVCW;
-		$runningItemW: $interiorMargin + $treeVCW;
+        &.has-children {
+            &:before {
+                //@include trans-prop-nice(rotate);
+                content: ">";
+                //position: absolute;
+                //top: 50%;
+                //left: 50%;
+            }
+            &.expanded:before {
+                //@include transform(translateX(-50%) translateY(-50%) rotate(90deg));
+                content: "v";
+            }
+        }
 		@include desktop {
 			&:hover {
 				color: $colorItemTreeVCHover !important;
@@ -60,29 +73,27 @@ ul.tree {
 	}
 
 	.t-object-label {
-		display: block;
-		@include absPosDefault();
+		//display: block;
+		//@include absPosDefault();
 		line-height: $menuLineH;
 
         .t-item-icon {
             @include txtShdwSubtle($shdwItemTreeIcon);
             font-size: $treeTypeIconH;
             color: $colorItemTreeIcon;
-            position: absolute;
-            left: $interiorMargin;
-            top: 50%;
+            //position: absolute;
+            //left: $interiorMargin;
+            //top: 50%;
             width: $treeTypeIconH;
-            @include transform(translateY(-50%));
+            //@include transform(translateY(-50%));
         }
 
 		.title-label,
         .t-title-label {
-			@include absPosDefault();
-			display: block;
-			left: $runningItemW + ($interiorMargin * 3);
-			overflow: hidden;
-			text-overflow: ellipsis;
-			white-space: nowrap;
+            @include ellipsize();
+			//@include absPosDefault();
+			//display: block;
+			//left: $runningItemW + ($interiorMargin * 3);
 		}
 	}
 
@@ -129,13 +140,12 @@ ul.tree {
 
 .tree-item {
     mct-representation {
-        .t-object-label {
-            left: $interiorMargin + $treeVCW;
-        }
+        //.t-object-label {
+        //    left: $interiorMargin + $treeVCW;
+        //}
         &.s-status-pending {
             .t-object-label {
                 &:before {
-                    @include tItemIcon();
                     @include spinner(0.25em, $colorItemTreeIcon);
                     content: "";
                 }

--- a/platform/commonUI/general/res/sass/tree/_tree.scss
+++ b/platform/commonUI/general/res/sass/tree/_tree.scss
@@ -46,23 +46,21 @@ ul.tree {
 	position: relative;
 
 	.view-control {
-        @extend .flex-elem;
 		color: $colorItemTreeVC;
-		//display: inline-block;
+        font-size: 0.75em;
 		margin-right: $interiorMargin;
-		font-size: 0.75em;
+        height: 100%; //$menuLineH;
+        line-height: inherit;
 		width: $treeVCW;
         &.has-children {
             &:before {
-                //@include trans-prop-nice(rotate);
-                content: ">";
-                //position: absolute;
-                //top: 50%;
-                //left: 50%;
+                position: absolute;
+                @include trans-prop-nice(transform, 100ms);
+                content: "\3e";
+                @include transform-origin(center);
             }
             &.expanded:before {
-                //@include transform(translateX(-50%) translateY(-50%) rotate(90deg));
-                content: "v";
+                @include transform(rotate(90deg));
             }
         }
 		@include desktop {
@@ -73,27 +71,17 @@ ul.tree {
 	}
 
 	.t-object-label {
-		//display: block;
-		//@include absPosDefault();
 		line-height: $menuLineH;
 
         .t-item-icon {
             @include txtShdwSubtle($shdwItemTreeIcon);
             font-size: $treeTypeIconH;
             color: $colorItemTreeIcon;
-            //position: absolute;
-            //left: $interiorMargin;
-            //top: 50%;
             width: $treeTypeIconH;
-            //@include transform(translateY(-50%));
         }
-
 		.title-label,
         .t-title-label {
             @include ellipsize();
-			//@include absPosDefault();
-			//display: block;
-			//left: $runningItemW + ($interiorMargin * 3);
 		}
 	}
 

--- a/platform/commonUI/general/res/sass/tree/_tree.scss
+++ b/platform/commonUI/general/res/sass/tree/_tree.scss
@@ -130,17 +130,9 @@ mct-representation {
             .t-item-icon {
                 &:before {
                     $spinBW: 4px;
-                    $spinD: $treeTypeIconW - ($spinBW * 2);
                     @include spinner($spinBW);
                     border-color: rgba($colorItemTreeIcon, 0.25);
                     border-top-color: rgba($colorItemTreeIcon, 1.0);
-                    //content: "";
-                    //display: block;
-                    //position: absolute;
-                    //left: 50%;
-                    //top: 50%;
-                    width: $spinD;
-                    height: $spinD;
                 }
                 .t-item-icon-glyph {
                     display: none;

--- a/platform/commonUI/general/res/templates/label.html
+++ b/platform/commonUI/general/res/templates/label.html
@@ -20,6 +20,8 @@
  at runtime from the About dialog for additional information.
 -->
 <span class="t-object-label">
-<span class="t-item-icon" ng-class="{ 'l-icon-link':location.isLink() }">{{type.getGlyph()}}</span>
-<span class='t-title-label'>{{model.name}}</span>
+    <span class="t-item-icon" ng-class="{ 'l-icon-link':location.isLink() }">
+        <span class="t-item-icon-glyph">{{type.getGlyph()}}</span>
+    </span>
+    <span class='t-title-label'>{{model.name}}</span>
 </span>

--- a/platform/commonUI/general/res/templates/label.html
+++ b/platform/commonUI/general/res/templates/label.html
@@ -19,9 +19,9 @@
  this source code distribution or the Licensing information page available
  at runtime from the About dialog for additional information.
 -->
-<span class="t-object-label l-flex-row flex-elem grows">
-    <span class="t-item-icon flex-elem" ng-class="{ 'l-icon-link':location.isLink() }">
-        <span class="t-item-icon-glyph">{{type.getGlyph()}}</span>
-    </span>
-    <span class='t-title-label flex-elem grows'>{{model.name}}</span>
-</span>
+<div class="t-object-label l-flex-row flex-elem grows">
+    <div class="t-item-icon flex-elem" ng-class="{ 'l-icon-link':location.isLink() }">
+        <div class="t-item-icon-glyph">{{type.getGlyph()}}</div>
+    </div>
+    <div class='t-title-label flex-elem grows'>{{model.name}}</div>
+</div>

--- a/platform/commonUI/general/res/templates/label.html
+++ b/platform/commonUI/general/res/templates/label.html
@@ -19,9 +19,9 @@
  this source code distribution or the Licensing information page available
  at runtime from the About dialog for additional information.
 -->
-<span class="t-object-label">
-    <span class="t-item-icon" ng-class="{ 'l-icon-link':location.isLink() }">
+<span class="t-object-label l-flex-row flex-elem grows">
+    <span class="t-item-icon flex-elem" ng-class="{ 'l-icon-link':location.isLink() }">
         <span class="t-item-icon-glyph">{{type.getGlyph()}}</span>
     </span>
-    <span class='t-title-label'>{{model.name}}</span>
+    <span class='t-title-label flex-elem grows'>{{model.name}}</span>
 </span>

--- a/platform/commonUI/general/res/templates/object-inspector.html
+++ b/platform/commonUI/general/res/templates/object-inspector.html
@@ -41,7 +41,7 @@
                                     mct-object="parent"
                                     ng-model="ngModel"
                                     ng-click="ngModel.selectedObject = parent"
-                                    class="location-item">
+                                    class="location-item rep-object-label">
                 </mct-representation>
             </span>
         </li>
@@ -54,7 +54,7 @@
                                     mct-object="parent"
                                     ng-model="ngModel"
                                     ng-click="ngModel.selectedObject = parent"
-                                    class="location-item">
+                                    class="location-item rep-object-label">
                 </mct-representation>
             </span>
         </li>

--- a/platform/commonUI/general/res/templates/tree-node.html
+++ b/platform/commonUI/general/res/templates/tree-node.html
@@ -26,40 +26,18 @@
             ng-class="{selected: treeNode.isSelected()}"
             >
             <span
-                mct-device="desktop"
                 class='ui-symbol view-control flex-elem'
                 ng-class="{ 'has-children': model.composition !== undefined, expanded: toggle.isActive() }"
                 ng-click="toggle.toggle(); treeNode.trackExpansion()"
                 >
             </span>
-
             <mct-representation
-                mct-device="desktop"
-                class="mobile-hide l-flex-row flex-elem grows"
+                class="l-flex-row flex-elem grows"
                 key="'label'"
                 mct-object="domainObject"
                 ng-click="treeNode.select()"
                 >
             </mct-representation>
-            <mct-representation
-                mct-device="mobile"
-                class="desktop-hide"
-                key="'label'"
-                mct-object="domainObject"
-                ng-click="(model.composition === undefined) && treeNode.select();
-                          toggle.toggle();
-                          treeNode.trackExpansion();"
-                >
-            </mct-representation>
-
-            <span
-                mct-device="mobile"
-                class='ui-symbol view-control'
-                ng-model="ngModel"
-                ng-click="treeNode.select()"
-                >
-                }
-            </span>
         </span>
         <span
             class="tree-item-subtree"

--- a/platform/commonUI/general/res/templates/tree-node.html
+++ b/platform/commonUI/general/res/templates/tree-node.html
@@ -22,7 +22,7 @@
 <span ng-controller="ToggleController as toggle">
     <span ng-controller="TreeNodeController as treeNode">
         <span
-            class="tree-item l-flex-row menus-to-left"
+            class="tree-item menus-to-left"
             ng-class="{selected: treeNode.isSelected()}"
             >
             <span
@@ -32,7 +32,7 @@
                 >
             </span>
             <mct-representation
-                class="l-flex-row flex-elem grows"
+                class="rep-object-label"
                 key="'label'"
                 mct-object="domainObject"
                 ng-click="treeNode.select()"

--- a/platform/commonUI/general/res/templates/tree-node.html
+++ b/platform/commonUI/general/res/templates/tree-node.html
@@ -22,21 +22,20 @@
 <span ng-controller="ToggleController as toggle">
     <span ng-controller="TreeNodeController as treeNode">
         <span
-            class="tree-item menus-to-left"
+            class="tree-item l-flex-row menus-to-left"
             ng-class="{selected: treeNode.isSelected()}"
             >
             <span
                 mct-device="desktop"
-                class='ui-symbol view-control'
+                class='ui-symbol view-control flex-elem'
+                ng-class="{ 'has-children': model.composition !== undefined, expanded: toggle.isActive() }"
                 ng-click="toggle.toggle(); treeNode.trackExpansion()"
-                ng-if="model.composition !== undefined"
                 >
-                {{toggle.isActive() ? "v" : ">"}}
             </span>
 
             <mct-representation
                 mct-device="desktop"
-                class="mobile-hide"
+                class="mobile-hide l-flex-row flex-elem grows"
                 key="'label'"
                 mct-object="domainObject"
                 ng-click="treeNode.select()"

--- a/platform/commonUI/themes/espresso/res/css/theme-espresso.css
+++ b/platform/commonUI/themes/espresso/res/css/theme-espresso.css
@@ -838,14 +838,14 @@ mct-container {
     color: #ff3c00;
     content: "!"; }
 
-/* line 84, ../../../../general/res/sass/_icons.scss */
+/* line 83, ../../../../general/res/sass/_icons.scss */
 .t-item-icon {
   line-height: normal;
   position: relative; }
-  /* line 91, ../../../../general/res/sass/_icons.scss */
+  /* line 89, ../../../../general/res/sass/_icons.scss */
   .t-item-icon .t-item-icon-glyph {
-    position: relative; }
-  /* line 96, ../../../../general/res/sass/_icons.scss */
+    position: absolute; }
+  /* line 94, ../../../../general/res/sass/_icons.scss */
   .t-item-icon.l-icon-link .t-item-icon-glyph:before {
     color: #49dedb;
     content: "\f4";
@@ -1263,7 +1263,7 @@ tr[class*="s-limit"].s-limit-lwr td:first-child:before {
     transform: rotate(0deg); }
   100% {
     transform: rotate(359deg); } }
-/* line 68, ../../../../general/res/sass/helpers/_wait-spinner.scss */
+/* line 69, ../../../../general/res/sass/helpers/_wait-spinner.scss */
 .t-wait-spinner,
 .wait-spinner {
   display: block;
@@ -1288,7 +1288,7 @@ tr[class*="s-limit"].s-limit-lwr td:first-child:before {
   margin-top: -5%;
   margin-left: -5%;
   z-index: 2; }
-  /* line 79, ../../../../general/res/sass/helpers/_wait-spinner.scss */
+  /* line 80, ../../../../general/res/sass/helpers/_wait-spinner.scss */
   .t-wait-spinner.inline,
   .wait-spinner.inline {
     display: inline-block !important;
@@ -1296,26 +1296,26 @@ tr[class*="s-limit"].s-limit-lwr td:first-child:before {
     position: relative !important;
     vertical-align: middle; }
 
-/* line 87, ../../../../general/res/sass/helpers/_wait-spinner.scss */
+/* line 88, ../../../../general/res/sass/helpers/_wait-spinner.scss */
 .l-wait-spinner-holder {
   pointer-events: none;
   position: absolute; }
-  /* line 91, ../../../../general/res/sass/helpers/_wait-spinner.scss */
+  /* line 92, ../../../../general/res/sass/helpers/_wait-spinner.scss */
   .l-wait-spinner-holder.align-left .t-wait-spinner {
     left: 0;
     margin-left: 0; }
-  /* line 96, ../../../../general/res/sass/helpers/_wait-spinner.scss */
+  /* line 97, ../../../../general/res/sass/helpers/_wait-spinner.scss */
   .l-wait-spinner-holder.full-size {
     display: inline-block;
     height: 100%;
     width: 100%; }
-    /* line 99, ../../../../general/res/sass/helpers/_wait-spinner.scss */
+    /* line 100, ../../../../general/res/sass/helpers/_wait-spinner.scss */
     .l-wait-spinner-holder.full-size .t-wait-spinner {
       top: 0;
       margin-top: 0;
       padding: 30%; }
 
-/* line 108, ../../../../general/res/sass/helpers/_wait-spinner.scss */
+/* line 109, ../../../../general/res/sass/helpers/_wait-spinner.scss */
 .treeview .wait-spinner {
   display: block;
   position: absolute;
@@ -1337,7 +1337,7 @@ tr[class*="s-limit"].s-limit-lwr td:first-child:before {
   top: 2px;
   left: 0; }
 
-/* line 117, ../../../../general/res/sass/helpers/_wait-spinner.scss */
+/* line 118, ../../../../general/res/sass/helpers/_wait-spinner.scss */
 .wait-spinner.sm {
   display: block;
   position: absolute;
@@ -1360,13 +1360,13 @@ tr[class*="s-limit"].s-limit-lwr td:first-child:before {
   top: 0;
   left: 0; }
 
-/* line 127, ../../../../general/res/sass/helpers/_wait-spinner.scss */
+/* line 128, ../../../../general/res/sass/helpers/_wait-spinner.scss */
 .loading {
   pointer-events: none; }
-  /* line 130, ../../../../general/res/sass/helpers/_wait-spinner.scss */
+  /* line 131, ../../../../general/res/sass/helpers/_wait-spinner.scss */
   .loading:before, .loading:after {
     content: ''; }
-  /* line 134, ../../../../general/res/sass/helpers/_wait-spinner.scss */
+  /* line 135, ../../../../general/res/sass/helpers/_wait-spinner.scss */
   .loading:before {
     -moz-animation-name: rotateCentered;
     -webkit-animation-name: rotateCentered;
@@ -1380,6 +1380,10 @@ tr[class*="s-limit"].s-limit-lwr td:first-child:before {
     -moz-animation-timing-function: linear;
     -webkit-animation-timing-function: linear;
     animation-timing-function: linear;
+    -moz-transform-origin: center 50%;
+    -ms-transform-origin: center 50%;
+    -webkit-transform-origin: center 50%;
+    transform-origin: center 50%;
     border-style: solid;
     border-width: 5px;
     -moz-border-radius: 100%;
@@ -1423,7 +1427,7 @@ tr[class*="s-limit"].s-limit-lwr td:first-child:before {
     -ms-transform: translateX(-50%) translateY(-50%) rotate(359deg);
     -webkit-transform: translateX(-50%) translateY(-50%) rotate(359deg);
     transform: translateX(-50%) translateY(-50%) rotate(359deg); } }
-  /* line 138, ../../../../general/res/sass/helpers/_wait-spinner.scss */
+  /* line 139, ../../../../general/res/sass/helpers/_wait-spinner.scss */
   .loading:after {
     overflow: hidden;
     position: absolute;
@@ -1436,7 +1440,7 @@ tr[class*="s-limit"].s-limit-lwr td:first-child:before {
     background: rgba(153, 153, 153, 0.2);
     display: block;
     z-index: 9; }
-  /* line 144, ../../../../general/res/sass/helpers/_wait-spinner.scss */
+  /* line 145, ../../../../general/res/sass/helpers/_wait-spinner.scss */
   .loading.tree-item:before {
     padding: 0.375rem;
     border-width: 2px; }
@@ -1523,26 +1527,35 @@ tr[class*="s-limit"].s-limit-lwr td:first-child:before {
     .l-inspect .inspector-properties .value {
       color: #bfbfbf;
       word-break: break-all; }
-  /* line 88, ../../../../general/res/sass/_inspector.scss */
+  /* line 87, ../../../../general/res/sass/_inspector.scss */
   .l-inspect .inspector-location .location-item {
+    -moz-box-sizing: border-box;
+    -webkit-box-sizing: border-box;
+    box-sizing: border-box;
     cursor: pointer;
     display: inline-block;
+    line-height: 1.2em;
     position: relative;
     padding: 2px 4px; }
-    /* line 93, ../../../../general/res/sass/_inspector.scss */
+    /* line 96, ../../../../general/res/sass/_inspector.scss */
+    .l-inspect .inspector-location .location-item .t-object-label .t-item-icon {
+      height: 1.2em;
+      width: 0.7rem; }
+    /* line 101, ../../../../general/res/sass/_inspector.scss */
     .l-inspect .inspector-location .location-item:hover {
       background: rgba(153, 153, 153, 0.1);
       color: #cccccc; }
-      /* line 96, ../../../../general/res/sass/_inspector.scss */
+      /* line 104, ../../../../general/res/sass/_inspector.scss */
       .l-inspect .inspector-location .location-item:hover .icon, .l-inspect .inspector-location .location-item:hover .t-item-icon {
         color: #33ccff; }
-  /* line 101, ../../../../general/res/sass/_inspector.scss */
+  /* line 109, ../../../../general/res/sass/_inspector.scss */
   .l-inspect .inspector-location:not(.last) .t-object-label .t-title-label:after {
     color: #737373;
     content: '\3e';
     display: inline-block;
     font-family: symbolsfont;
     font-size: 8px;
+    font-style: normal !important;
     line-height: inherit;
     margin-left: 3px;
     width: 4px; }
@@ -1672,7 +1685,12 @@ tr[class*="s-limit"].s-limit-lwr td:first-child:before {
     @media only screen and (min-device-width: 1025px) and (-webkit-min-device-pixel-ratio: 1) {
       /* line 302, ../../../../general/res/sass/_mixins.scss */
       .s-btn.major:not(.disabled):hover, .major.s-menu-btn:not(.disabled):hover {
-        background: linear-gradient(#1ac6ff, #00bfff); }
+        background-image: url('data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4gPHN2ZyB2ZXJzaW9uPSIxLjEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PGRlZnM+PGxpbmVhckdyYWRpZW50IGlkPSJncmFkIiBncmFkaWVudFVuaXRzPSJvYmplY3RCb3VuZGluZ0JveCIgeDE9IjAuNSIgeTE9IjAuMCIgeDI9IjAuNSIgeTI9IjEuMCI+PHN0b3Agb2Zmc2V0PSIwJSIgc3RvcC1jb2xvcj0iIzFhYzZmZiIvPjxzdG9wIG9mZnNldD0iMTAwJSIgc3RvcC1jb2xvcj0iIzAwYmZmZiIvPjwvbGluZWFyR3JhZGllbnQ+PC9kZWZzPjxyZWN0IHg9IjAiIHk9IjAiIHdpZHRoPSIxMDAlIiBoZWlnaHQ9IjEwMCUiIGZpbGw9InVybCgjZ3JhZCkiIC8+PC9zdmc+IA==');
+        background-size: 100%;
+        background-image: -webkit-gradient(linear, 50% 0%, 50% 100%, color-stop(0%, #1ac6ff), color-stop(100%, #00bfff));
+        background-image: -moz-linear-gradient(#1ac6ff, #00bfff);
+        background-image: -webkit-linear-gradient(#1ac6ff, #00bfff);
+        background-image: linear-gradient(#1ac6ff, #00bfff); }
         /* line 304, ../../../../general/res/sass/_mixins.scss */
         .s-btn.major:not(.disabled):hover > .icon, .major.s-menu-btn:not(.disabled):hover > .icon, .s-btn.major:not(.disabled):hover > .t-item-icon, .major.s-menu-btn:not(.disabled):hover > .t-item-icon {
           color: white; } }
@@ -1711,7 +1729,12 @@ tr[class*="s-limit"].s-limit-lwr td:first-child:before {
     @media only screen and (min-device-width: 1025px) and (-webkit-min-device-pixel-ratio: 1) {
       /* line 302, ../../../../general/res/sass/_mixins.scss */
       .s-btn:not(.major):not(.disabled):hover, .s-menu-btn:not(.major):not(.disabled):hover {
-        background: linear-gradient(#6b6b6b, #5e5e5e); }
+        background-image: url('data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4gPHN2ZyB2ZXJzaW9uPSIxLjEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PGRlZnM+PGxpbmVhckdyYWRpZW50IGlkPSJncmFkIiBncmFkaWVudFVuaXRzPSJvYmplY3RCb3VuZGluZ0JveCIgeDE9IjAuNSIgeTE9IjAuMCIgeDI9IjAuNSIgeTI9IjEuMCI+PHN0b3Agb2Zmc2V0PSIwJSIgc3RvcC1jb2xvcj0iIzZiNmI2YiIvPjxzdG9wIG9mZnNldD0iMTAwJSIgc3RvcC1jb2xvcj0iIzVlNWU1ZSIvPjwvbGluZWFyR3JhZGllbnQ+PC9kZWZzPjxyZWN0IHg9IjAiIHk9IjAiIHdpZHRoPSIxMDAlIiBoZWlnaHQ9IjEwMCUiIGZpbGw9InVybCgjZ3JhZCkiIC8+PC9zdmc+IA==');
+        background-size: 100%;
+        background-image: -webkit-gradient(linear, 50% 0%, 50% 100%, color-stop(0%, #6b6b6b), color-stop(100%, #5e5e5e));
+        background-image: -moz-linear-gradient(#6b6b6b, #5e5e5e);
+        background-image: -webkit-linear-gradient(#6b6b6b, #5e5e5e);
+        background-image: linear-gradient(#6b6b6b, #5e5e5e); }
         /* line 304, ../../../../general/res/sass/_mixins.scss */
         .s-btn:not(.major):not(.disabled):hover > .icon, .s-menu-btn:not(.major):not(.disabled):hover > .icon, .s-btn:not(.major):not(.disabled):hover > .t-item-icon, .s-menu-btn:not(.major):not(.disabled):hover > .t-item-icon {
           color: #33ccff; } }
@@ -1753,7 +1776,12 @@ tr[class*="s-limit"].s-limit-lwr td:first-child:before {
     @media only screen and (min-device-width: 1025px) and (-webkit-min-device-pixel-ratio: 1) {
       /* line 302, ../../../../general/res/sass/_mixins.scss */
       .s-btn.pause-play.paused:not(.disabled):hover, .pause-play.paused.s-menu-btn:not(.disabled):hover {
-        background: linear-gradient(#fe9815, #f88c01); }
+        background-image: url('data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4gPHN2ZyB2ZXJzaW9uPSIxLjEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PGRlZnM+PGxpbmVhckdyYWRpZW50IGlkPSJncmFkIiBncmFkaWVudFVuaXRzPSJvYmplY3RCb3VuZGluZ0JveCIgeDE9IjAuNSIgeTE9IjAuMCIgeDI9IjAuNSIgeTI9IjEuMCI+PHN0b3Agb2Zmc2V0PSIwJSIgc3RvcC1jb2xvcj0iI2ZlOTgxNSIvPjxzdG9wIG9mZnNldD0iMTAwJSIgc3RvcC1jb2xvcj0iI2Y4OGMwMSIvPjwvbGluZWFyR3JhZGllbnQ+PC9kZWZzPjxyZWN0IHg9IjAiIHk9IjAiIHdpZHRoPSIxMDAlIiBoZWlnaHQ9IjEwMCUiIGZpbGw9InVybCgjZ3JhZCkiIC8+PC9zdmc+IA==');
+        background-size: 100%;
+        background-image: -webkit-gradient(linear, 50% 0%, 50% 100%, color-stop(0%, #fe9815), color-stop(100%, #f88c01));
+        background-image: -moz-linear-gradient(#fe9815, #f88c01);
+        background-image: -webkit-linear-gradient(#fe9815, #f88c01);
+        background-image: linear-gradient(#fe9815, #f88c01); }
         /* line 304, ../../../../general/res/sass/_mixins.scss */
         .s-btn.pause-play.paused:not(.disabled):hover > .icon, .pause-play.paused.s-menu-btn:not(.disabled):hover > .icon, .s-btn.pause-play.paused:not(.disabled):hover > .t-item-icon, .pause-play.paused.s-menu-btn:not(.disabled):hover > .t-item-icon {
           color: white; } }
@@ -1854,7 +1882,12 @@ tr[class*="s-limit"].s-limit-lwr td:first-child:before {
     @media only screen and (min-device-width: 1025px) and (-webkit-min-device-pixel-ratio: 1) and (min-device-width: 1025px) and (-webkit-min-device-pixel-ratio: 1) {
       /* line 302, ../../../../general/res/sass/_mixins.scss */
       .mini-tab.collapsed:not(.disabled):hover {
-        background: linear-gradient(#6b6b6b, #5e5e5e); }
+        background-image: url('data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4gPHN2ZyB2ZXJzaW9uPSIxLjEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PGRlZnM+PGxpbmVhckdyYWRpZW50IGlkPSJncmFkIiBncmFkaWVudFVuaXRzPSJvYmplY3RCb3VuZGluZ0JveCIgeDE9IjAuNSIgeTE9IjAuMCIgeDI9IjAuNSIgeTI9IjEuMCI+PHN0b3Agb2Zmc2V0PSIwJSIgc3RvcC1jb2xvcj0iIzZiNmI2YiIvPjxzdG9wIG9mZnNldD0iMTAwJSIgc3RvcC1jb2xvcj0iIzVlNWU1ZSIvPjwvbGluZWFyR3JhZGllbnQ+PC9kZWZzPjxyZWN0IHg9IjAiIHk9IjAiIHdpZHRoPSIxMDAlIiBoZWlnaHQ9IjEwMCUiIGZpbGw9InVybCgjZ3JhZCkiIC8+PC9zdmc+IA==');
+        background-size: 100%;
+        background-image: -webkit-gradient(linear, 50% 0%, 50% 100%, color-stop(0%, #6b6b6b), color-stop(100%, #5e5e5e));
+        background-image: -moz-linear-gradient(#6b6b6b, #5e5e5e);
+        background-image: -webkit-linear-gradient(#6b6b6b, #5e5e5e);
+        background-image: linear-gradient(#6b6b6b, #5e5e5e); }
         /* line 304, ../../../../general/res/sass/_mixins.scss */
         .mini-tab.collapsed:not(.disabled):hover > .icon, .mini-tab.collapsed:not(.disabled):hover > .t-item-icon {
           color: #33ccff; } }
@@ -3986,7 +4019,12 @@ textarea {
   @media only screen and (min-device-width: 1025px) and (-webkit-min-device-pixel-ratio: 1) {
     /* line 302, ../../../../general/res/sass/_mixins.scss */
     .select:not(.disabled):hover {
-      background: linear-gradient(#6b6b6b, #5e5e5e); }
+      background-image: url('data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4gPHN2ZyB2ZXJzaW9uPSIxLjEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PGRlZnM+PGxpbmVhckdyYWRpZW50IGlkPSJncmFkIiBncmFkaWVudFVuaXRzPSJvYmplY3RCb3VuZGluZ0JveCIgeDE9IjAuNSIgeTE9IjAuMCIgeDI9IjAuNSIgeTI9IjEuMCI+PHN0b3Agb2Zmc2V0PSIwJSIgc3RvcC1jb2xvcj0iIzZiNmI2YiIvPjxzdG9wIG9mZnNldD0iMTAwJSIgc3RvcC1jb2xvcj0iIzVlNWU1ZSIvPjwvbGluZWFyR3JhZGllbnQ+PC9kZWZzPjxyZWN0IHg9IjAiIHk9IjAiIHdpZHRoPSIxMDAlIiBoZWlnaHQ9IjEwMCUiIGZpbGw9InVybCgjZ3JhZCkiIC8+PC9zdmc+IA==');
+      background-size: 100%;
+      background-image: -webkit-gradient(linear, 50% 0%, 50% 100%, color-stop(0%, #6b6b6b), color-stop(100%, #5e5e5e));
+      background-image: -moz-linear-gradient(#6b6b6b, #5e5e5e);
+      background-image: -webkit-linear-gradient(#6b6b6b, #5e5e5e);
+      background-image: linear-gradient(#6b6b6b, #5e5e5e); }
       /* line 304, ../../../../general/res/sass/_mixins.scss */
       .select:not(.disabled):hover > .icon, .select:not(.disabled):hover > .t-item-icon {
         color: #33ccff; } }
@@ -5477,7 +5515,12 @@ span.req {
         @media only screen and (min-device-width: 1025px) and (-webkit-min-device-pixel-ratio: 1) {
           /* line 302, ../../../../general/res/sass/_mixins.scss */
           .overlay .bottom-bar .s-btn:not(.major):not(.disabled):hover, .overlay .bottom-bar .s-menu-btn:not(.major):not(.disabled):hover {
-            background: linear-gradient(#a6a6a6, #999999); }
+            background-image: url('data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4gPHN2ZyB2ZXJzaW9uPSIxLjEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PGRlZnM+PGxpbmVhckdyYWRpZW50IGlkPSJncmFkIiBncmFkaWVudFVuaXRzPSJvYmplY3RCb3VuZGluZ0JveCIgeDE9IjAuNSIgeTE9IjAuMCIgeDI9IjAuNSIgeTI9IjEuMCI+PHN0b3Agb2Zmc2V0PSIwJSIgc3RvcC1jb2xvcj0iI2E2YTZhNiIvPjxzdG9wIG9mZnNldD0iMTAwJSIgc3RvcC1jb2xvcj0iIzk5OTk5OSIvPjwvbGluZWFyR3JhZGllbnQ+PC9kZWZzPjxyZWN0IHg9IjAiIHk9IjAiIHdpZHRoPSIxMDAlIiBoZWlnaHQ9IjEwMCUiIGZpbGw9InVybCgjZ3JhZCkiIC8+PC9zdmc+IA==');
+            background-size: 100%;
+            background-image: -webkit-gradient(linear, 50% 0%, 50% 100%, color-stop(0%, #a6a6a6), color-stop(100%, #999999));
+            background-image: -moz-linear-gradient(#a6a6a6, #999999);
+            background-image: -webkit-linear-gradient(#a6a6a6, #999999);
+            background-image: linear-gradient(#a6a6a6, #999999); }
             /* line 304, ../../../../general/res/sass/_mixins.scss */
             .overlay .bottom-bar .s-btn:not(.major):not(.disabled):hover > .icon, .overlay .bottom-bar .s-menu-btn:not(.major):not(.disabled):hover > .icon, .overlay .bottom-bar .s-btn:not(.major):not(.disabled):hover > .t-item-icon, .overlay .bottom-bar .s-menu-btn:not(.major):not(.disabled):hover > .t-item-icon {
               color: white; } }
@@ -5778,15 +5821,17 @@ mct-representation.s-status-pending .t-object-label .t-item-icon:before {
   -moz-animation-timing-function: linear;
   -webkit-animation-timing-function: linear;
   animation-timing-function: linear;
+  -moz-transform-origin: center 50%;
+  -ms-transform-origin: center 50%;
+  -webkit-transform-origin: center 50%;
+  transform-origin: center 50%;
   border-style: solid;
   border-width: 4px;
   -moz-border-radius: 100%;
   -webkit-border-radius: 100%;
   border-radius: 100%;
   border-color: rgba(0, 153, 204, 0.25);
-  border-top-color: #0099cc;
-  width: 10px;
-  height: 10px; }
+  border-top-color: #0099cc; }
 @-moz-keyframes rotateCentered {
   0% {
     -moz-transform: translateX(-50%) translateY(-50%) rotate(0deg);
@@ -5812,15 +5857,15 @@ mct-representation.s-status-pending .t-object-label .t-item-icon:before {
     -ms-transform: translateX(-50%) translateY(-50%) rotate(359deg);
     -webkit-transform: translateX(-50%) translateY(-50%) rotate(359deg);
     transform: translateX(-50%) translateY(-50%) rotate(359deg); } }
-/* line 145, ../../../../general/res/sass/tree/_tree.scss */
+/* line 137, ../../../../general/res/sass/tree/_tree.scss */
 mct-representation.s-status-pending .t-object-label .t-item-icon .t-item-icon-glyph {
   display: none; }
-/* line 149, ../../../../general/res/sass/tree/_tree.scss */
+/* line 141, ../../../../general/res/sass/tree/_tree.scss */
 mct-representation.s-status-pending .t-object-label .t-title-label {
   font-style: italic;
   opacity: 0.6; }
 
-/* line 156, ../../../../general/res/sass/tree/_tree.scss */
+/* line 148, ../../../../general/res/sass/tree/_tree.scss */
 .selected mct-representation.s-status-pending .t-object-label .t-item-icon:before {
   border-color: rgba(204, 204, 204, 0.25);
   border-top-color: #cccccc; }
@@ -5874,6 +5919,10 @@ mct-representation.s-status-pending .t-object-label .t-item-icon:before {
   -moz-animation-timing-function: linear;
   -webkit-animation-timing-function: linear;
   animation-timing-function: linear;
+  -moz-transform-origin: center 50%;
+  -ms-transform-origin: center 50%;
+  -webkit-transform-origin: center 50%;
+  transform-origin: center 50%;
   border-style: solid;
   border-width: 4px;
   -moz-border-radius: 100%;
@@ -5884,7 +5933,7 @@ mct-representation.s-status-pending .t-object-label .t-item-icon:before {
   position: absolute;
   left: 50%;
   top: 50%;
-  padding: 35%;
+  padding: 30%;
   width: 0;
   height: 0; }
 @-moz-keyframes rotateCentered {
@@ -6953,7 +7002,12 @@ table {
     @media only screen and (min-device-width: 1025px) and (-webkit-min-device-pixel-ratio: 1) {
       /* line 302, ../../../../general/res/sass/_mixins.scss */
       .items-holder .item.grid-item:not(.disabled):hover {
-        background: linear-gradient(#666666, #595959); }
+        background-image: url('data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4gPHN2ZyB2ZXJzaW9uPSIxLjEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PGRlZnM+PGxpbmVhckdyYWRpZW50IGlkPSJncmFkIiBncmFkaWVudFVuaXRzPSJvYmplY3RCb3VuZGluZ0JveCIgeDE9IjAuNSIgeTE9IjAuMCIgeDI9IjAuNSIgeTI9IjEuMCI+PHN0b3Agb2Zmc2V0PSIwJSIgc3RvcC1jb2xvcj0iIzY2NjY2NiIvPjxzdG9wIG9mZnNldD0iMTAwJSIgc3RvcC1jb2xvcj0iIzU5NTk1OSIvPjwvbGluZWFyR3JhZGllbnQ+PC9kZWZzPjxyZWN0IHg9IjAiIHk9IjAiIHdpZHRoPSIxMDAlIiBoZWlnaHQ9IjEwMCUiIGZpbGw9InVybCgjZ3JhZCkiIC8+PC9zdmc+IA==');
+        background-size: 100%;
+        background-image: -webkit-gradient(linear, 50% 0%, 50% 100%, color-stop(0%, #666666), color-stop(100%, #595959));
+        background-image: -moz-linear-gradient(#666666, #595959);
+        background-image: -webkit-linear-gradient(#666666, #595959);
+        background-image: linear-gradient(#666666, #595959); }
         /* line 304, ../../../../general/res/sass/_mixins.scss */
         .items-holder .item.grid-item:not(.disabled):hover > .icon, .items-holder .item.grid-item:not(.disabled):hover > .t-item-icon {
           color: #33ccff; } }
@@ -7084,7 +7138,12 @@ table {
       @media only screen and (min-device-width: 1025px) and (-webkit-min-device-pixel-ratio: 1) {
         /* line 302, ../../../../general/res/sass/_mixins.scss */
         .items-holder .item.grid-item.selected:not(.disabled):hover {
-          background: linear-gradient(#1ac6ff, #00bfff); }
+          background-image: url('data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4gPHN2ZyB2ZXJzaW9uPSIxLjEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PGRlZnM+PGxpbmVhckdyYWRpZW50IGlkPSJncmFkIiBncmFkaWVudFVuaXRzPSJvYmplY3RCb3VuZGluZ0JveCIgeDE9IjAuNSIgeTE9IjAuMCIgeDI9IjAuNSIgeTI9IjEuMCI+PHN0b3Agb2Zmc2V0PSIwJSIgc3RvcC1jb2xvcj0iIzFhYzZmZiIvPjxzdG9wIG9mZnNldD0iMTAwJSIgc3RvcC1jb2xvcj0iIzAwYmZmZiIvPjwvbGluZWFyR3JhZGllbnQ+PC9kZWZzPjxyZWN0IHg9IjAiIHk9IjAiIHdpZHRoPSIxMDAlIiBoZWlnaHQ9IjEwMCUiIGZpbGw9InVybCgjZ3JhZCkiIC8+PC9zdmc+IA==');
+          background-size: 100%;
+          background-image: -webkit-gradient(linear, 50% 0%, 50% 100%, color-stop(0%, #1ac6ff), color-stop(100%, #00bfff));
+          background-image: -moz-linear-gradient(#1ac6ff, #00bfff);
+          background-image: -webkit-linear-gradient(#1ac6ff, #00bfff);
+          background-image: linear-gradient(#1ac6ff, #00bfff); }
           /* line 304, ../../../../general/res/sass/_mixins.scss */
           .items-holder .item.grid-item.selected:not(.disabled):hover > .icon, .items-holder .item.grid-item.selected:not(.disabled):hover > .t-item-icon {
             color: #33ccff; } }

--- a/platform/commonUI/themes/espresso/res/css/theme-espresso.css
+++ b/platform/commonUI/themes/espresso/res/css/theme-espresso.css
@@ -520,34 +520,40 @@ mct-container {
 
 /********************************************* FLEX STYLES */
 /* line 95, ../../../../general/res/sass/_archetypes.scss */
-.l-flex-row,
+.l-flex-row, .tree-item,
+.search-result-item,
 .l-flex-col {
   display: -webkit-flex;
   display: flex;
   -webkit-flex-wrap: nowrap;
   flex-wrap: nowrap; }
   /* line 99, ../../../../general/res/sass/_archetypes.scss */
-  .l-flex-row .flex-elem,
+  .l-flex-row .flex-elem, .tree-item .flex-elem,
+  .search-result-item .flex-elem,
   .l-flex-col .flex-elem {
     min-height: 0;
     position: relative; }
     /* line 102, ../../../../general/res/sass/_archetypes.scss */
-    .l-flex-row .flex-elem:not(.grows),
+    .l-flex-row .flex-elem:not(.grows), .tree-item .flex-elem:not(.grows),
+    .search-result-item .flex-elem:not(.grows),
     .l-flex-col .flex-elem:not(.grows) {
       -webkit-flex: 0 0 auto;
       flex: 0 0 auto; }
       /* line 104, ../../../../general/res/sass/_archetypes.scss */
-      .l-flex-row .flex-elem:not(.grows).flex-can-shrink,
+      .l-flex-row .flex-elem:not(.grows).flex-can-shrink, .tree-item .flex-elem:not(.grows).flex-can-shrink,
+      .search-result-item .flex-elem:not(.grows).flex-can-shrink,
       .l-flex-col .flex-elem:not(.grows).flex-can-shrink {
         -webkit-flex: 0 1 auto;
         flex: 0 1 auto; }
     /* line 108, ../../../../general/res/sass/_archetypes.scss */
-    .l-flex-row .flex-elem.grows,
+    .l-flex-row .flex-elem.grows, .tree-item .flex-elem.grows,
+    .search-result-item .flex-elem.grows,
     .l-flex-col .flex-elem.grows {
       -webkit-flex: 1 1 auto;
       flex: 1 1 auto; }
   /* line 112, ../../../../general/res/sass/_archetypes.scss */
-  .l-flex-row .flex-container,
+  .l-flex-row .flex-container, .tree-item .flex-container,
+  .search-result-item .flex-container,
   .l-flex-col .flex-container {
     display: -webkit-flex;
     display: flex;
@@ -558,20 +564,24 @@ mct-container {
     min-height: 0; }
 
 /* line 121, ../../../../general/res/sass/_archetypes.scss */
-.l-flex-row {
+.l-flex-row, .tree-item,
+.search-result-item {
   -webkit-flex-direction: row;
   flex-direction: row; }
   /* line 123, ../../../../general/res/sass/_archetypes.scss */
-  .l-flex-row.flex-elem {
+  .l-flex-row.flex-elem, .flex-elem.tree-item,
+  .flex-elem.search-result-item {
     -webkit-flex: 1 1 auto;
     flex: 1 1 auto; }
   /* line 124, ../../../../general/res/sass/_archetypes.scss */
-  .l-flex-row .flex-elem {
+  .l-flex-row .flex-elem, .tree-item .flex-elem,
+  .search-result-item .flex-elem {
     height: inherit;
     line-height: inherit;
     min-width: 0; }
   /* line 129, ../../../../general/res/sass/_archetypes.scss */
-  .l-flex-row .flex-container {
+  .l-flex-row .flex-container, .tree-item .flex-container,
+  .search-result-item .flex-container {
     -webkit-flex-direction: row;
     flex-direction: row; }
 
@@ -1370,8 +1380,6 @@ tr[class*="s-limit"].s-limit-lwr td:first-child:before {
     -moz-animation-timing-function: linear;
     -webkit-animation-timing-function: linear;
     animation-timing-function: linear;
-    border-color: rgba(255, 199, 0, 0.25);
-    border-top-color: #ffc700;
     border-style: solid;
     border-width: 5px;
     -moz-border-radius: 100%;
@@ -1380,6 +1388,8 @@ tr[class*="s-limit"].s-limit-lwr td:first-child:before {
     -moz-box-sizing: border-box;
     -webkit-box-sizing: border-box;
     box-sizing: border-box;
+    border-color: rgba(255, 199, 0, 0.25);
+    border-top-color: #ffc700;
     display: block;
     position: absolute;
     height: 0;
@@ -5651,7 +5661,7 @@ ul.tree {
   margin-bottom: 3px;
   padding: 0 3px;
   position: relative; }
-  /* line 48, ../../../../general/res/sass/tree/_tree.scss */
+  /* line 49, ../../../../general/res/sass/tree/_tree.scss */
   .tree-item .view-control,
   .search-result-item .view-control {
     color: rgba(255, 255, 255, 0.3);
@@ -5660,7 +5670,7 @@ ul.tree {
     height: 100%;
     line-height: inherit;
     width: 10px; }
-    /* line 56, ../../../../general/res/sass/tree/_tree.scss */
+    /* line 57, ../../../../general/res/sass/tree/_tree.scss */
     .tree-item .view-control.has-children:before,
     .search-result-item .view-control.has-children:before {
       position: absolute;
@@ -5685,7 +5695,7 @@ ul.tree {
       -ms-transform-origin: center 50%;
       -webkit-transform-origin: center 50%;
       transform-origin: center 50%; }
-    /* line 62, ../../../../general/res/sass/tree/_tree.scss */
+    /* line 63, ../../../../general/res/sass/tree/_tree.scss */
     .tree-item .view-control.has-children.expanded:before,
     .search-result-item .view-control.has-children.expanded:before {
       -moz-transform: rotate(90deg);
@@ -5693,11 +5703,11 @@ ul.tree {
       -webkit-transform: rotate(90deg);
       transform: rotate(90deg); }
     @media only screen and (min-device-width: 1025px) and (-webkit-min-device-pixel-ratio: 1) {
-      /* line 67, ../../../../general/res/sass/tree/_tree.scss */
+      /* line 68, ../../../../general/res/sass/tree/_tree.scss */
       .tree-item .view-control:hover,
       .search-result-item .view-control:hover {
         color: #ffc700 !important; } }
-  /* line 73, ../../../../general/res/sass/tree/_tree.scss */
+  /* line 74, ../../../../general/res/sass/tree/_tree.scss */
   .tree-item .t-object-label,
   .search-result-item .t-object-label {
     line-height: 1.5rem; }
@@ -5707,58 +5717,49 @@ ul.tree {
       text-shadow: rgba(0, 0, 0, 0.6) 0 1px 2px;
       font-size: 1.4em;
       color: #0099cc;
-      margin-right: 5px;
       width: 18px; }
-    /* line 83, ../../../../general/res/sass/tree/_tree.scss */
-    .tree-item .t-object-label .title-label,
-    .tree-item .t-object-label .t-title-label,
-    .search-result-item .t-object-label .title-label,
-    .search-result-item .t-object-label .t-title-label {
-      overflow: hidden;
-      text-overflow: ellipsis;
-      white-space: nowrap; }
-  /* line 89, ../../../../general/res/sass/tree/_tree.scss */
+  /* line 84, ../../../../general/res/sass/tree/_tree.scss */
   .tree-item.selected,
   .search-result-item.selected {
     background: #006080;
     color: #cccccc; }
-    /* line 92, ../../../../general/res/sass/tree/_tree.scss */
+    /* line 87, ../../../../general/res/sass/tree/_tree.scss */
     .tree-item.selected .view-control,
     .search-result-item.selected .view-control {
       color: rgba(255, 255, 255, 0.3); }
-    /* line 95, ../../../../general/res/sass/tree/_tree.scss */
+    /* line 90, ../../../../general/res/sass/tree/_tree.scss */
     .tree-item.selected .t-object-label .t-item-icon,
     .search-result-item.selected .t-object-label .t-item-icon {
       color: #cccccc; }
   @media only screen and (min-device-width: 1025px) and (-webkit-min-device-pixel-ratio: 1) {
-    /* line 102, ../../../../general/res/sass/tree/_tree.scss */
+    /* line 97, ../../../../general/res/sass/tree/_tree.scss */
     .tree-item:not(.selected):hover,
     .search-result-item:not(.selected):hover {
       background: rgba(153, 153, 153, 0.1);
       color: #cccccc; }
-      /* line 105, ../../../../general/res/sass/tree/_tree.scss */
+      /* line 100, ../../../../general/res/sass/tree/_tree.scss */
       .tree-item:not(.selected):hover .t-item-icon,
       .search-result-item:not(.selected):hover .t-item-icon {
         color: #33ccff; } }
-  /* line 112, ../../../../general/res/sass/tree/_tree.scss */
+  /* line 107, ../../../../general/res/sass/tree/_tree.scss */
   .tree-item:not(.loading),
   .search-result-item:not(.loading) {
     cursor: pointer; }
-  /* line 116, ../../../../general/res/sass/tree/_tree.scss */
+  /* line 111, ../../../../general/res/sass/tree/_tree.scss */
   .tree-item .context-trigger,
   .search-result-item .context-trigger {
     top: -1px;
     position: absolute;
     right: 3px; }
-    /* line 121, ../../../../general/res/sass/tree/_tree.scss */
+    /* line 116, ../../../../general/res/sass/tree/_tree.scss */
     .tree-item .context-trigger .invoke-menu,
     .search-result-item .context-trigger .invoke-menu {
       font-size: 0.75em;
       height: 0.9rem;
       line-height: 0.9rem; }
 
-/* line 134, ../../../../general/res/sass/tree/_tree.scss */
-.tree-item mct-representation.s-status-pending .t-object-label .t-item-icon:before {
+/* line 128, ../../../../general/res/sass/tree/_tree.scss */
+mct-representation.s-status-pending .t-object-label .t-item-icon:before {
   -moz-animation-name: rotateCentered;
   -webkit-animation-name: rotateCentered;
   animation-name: rotateCentered;
@@ -5771,18 +5772,13 @@ ul.tree {
   -moz-animation-timing-function: linear;
   -webkit-animation-timing-function: linear;
   animation-timing-function: linear;
-  border-color: rgba(0, 153, 204, 0.25);
-  border-top-color: #0099cc;
   border-style: solid;
   border-width: 4px;
   -moz-border-radius: 100%;
   -webkit-border-radius: 100%;
   border-radius: 100%;
-  content: "";
-  display: block;
-  position: absolute;
-  left: 50%;
-  top: 50%;
+  border-color: rgba(0, 153, 204, 0.25);
+  border-top-color: #0099cc;
   width: 10px;
   height: 10px; }
 @-moz-keyframes rotateCentered {
@@ -5810,15 +5806,121 @@ ul.tree {
     -ms-transform: translateX(-50%) translateY(-50%) rotate(359deg);
     -webkit-transform: translateX(-50%) translateY(-50%) rotate(359deg);
     transform: translateX(-50%) translateY(-50%) rotate(359deg); } }
-/* line 146, ../../../../general/res/sass/tree/_tree.scss */
-.tree-item mct-representation.s-status-pending .t-object-label .t-item-icon .t-item-icon-glyph {
+/* line 142, ../../../../general/res/sass/tree/_tree.scss */
+mct-representation.s-status-pending .t-object-label .t-item-icon .t-item-icon-glyph {
   display: none; }
-/* line 150, ../../../../general/res/sass/tree/_tree.scss */
-.tree-item mct-representation.s-status-pending .t-object-label .t-title-label {
+/* line 146, ../../../../general/res/sass/tree/_tree.scss */
+mct-representation.s-status-pending .t-object-label .t-title-label {
   font-style: italic;
   opacity: 0.6; }
-/* line 157, ../../../../general/res/sass/tree/_tree.scss */
-.tree-item.selected mct-representation.s-status-pending .t-object-label .t-item-icon:before {
+
+/* line 153, ../../../../general/res/sass/tree/_tree.scss */
+.selected mct-representation.s-status-pending .t-object-label .t-item-icon:before {
+  border-color: rgba(204, 204, 204, 0.25);
+  border-top-color: #cccccc; }
+
+/*****************************************************************************
+ * Open MCT Web, Copyright (c) 2014-2015, United States Government
+ * as represented by the Administrator of the National Aeronautics and Space
+ * Administration. All rights reserved.
+ *
+ * Open MCT Web is licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * Open MCT Web includes source code licensed under additional open source
+ * licenses. See the Open Source Licenses file (LICENSES.md) included with
+ * this source code distribution or the Licensing information page available
+ * at runtime from the About dialog for additional information.
+ *****************************************************************************/
+/* line 24, ../../../../general/res/sass/_object-label.scss */
+.rep-object-label {
+  -webkit-flex-direction: row;
+  flex-direction: row;
+  -webkit-flex: 1 1 auto;
+  flex: 1 1 auto;
+  height: inherit;
+  line-height: inherit;
+  min-width: 0; }
+
+/* line 33, ../../../../general/res/sass/_object-label.scss */
+.t-object-label .t-item-icon {
+  margin-right: 5px; }
+/* line 36, ../../../../general/res/sass/_object-label.scss */
+.t-object-label .t-title-label {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap; }
+
+/* line 45, ../../../../general/res/sass/_object-label.scss */
+mct-representation.s-status-pending .t-object-label .t-item-icon:before {
+  -moz-animation-name: rotateCentered;
+  -webkit-animation-name: rotateCentered;
+  animation-name: rotateCentered;
+  -moz-animation-duration: 0.5s;
+  -webkit-animation-duration: 0.5s;
+  animation-duration: 0.5s;
+  -moz-animation-iteration-count: infinite;
+  -webkit-animation-iteration-count: infinite;
+  animation-iteration-count: infinite;
+  -moz-animation-timing-function: linear;
+  -webkit-animation-timing-function: linear;
+  animation-timing-function: linear;
+  border-style: solid;
+  border-width: 4px;
+  -moz-border-radius: 100%;
+  -webkit-border-radius: 100%;
+  border-radius: 100%;
+  content: "";
+  display: block;
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  padding: 35%;
+  width: 0;
+  height: 0; }
+@-moz-keyframes rotateCentered {
+  0% {
+    -moz-transform: translateX(-50%) translateY(-50%) rotate(0deg);
+    transform: translateX(-50%) translateY(-50%) rotate(0deg); }
+  100% {
+    -moz-transform: translateX(-50%) translateY(-50%) rotate(359deg);
+    transform: translateX(-50%) translateY(-50%) rotate(359deg); } }
+@-webkit-keyframes rotateCentered {
+  0% {
+    -webkit-transform: translateX(-50%) translateY(-50%) rotate(0deg);
+    transform: translateX(-50%) translateY(-50%) rotate(0deg); }
+  100% {
+    -webkit-transform: translateX(-50%) translateY(-50%) rotate(359deg);
+    transform: translateX(-50%) translateY(-50%) rotate(359deg); } }
+@keyframes rotateCentered {
+  0% {
+    -moz-transform: translateX(-50%) translateY(-50%) rotate(0deg);
+    -ms-transform: translateX(-50%) translateY(-50%) rotate(0deg);
+    -webkit-transform: translateX(-50%) translateY(-50%) rotate(0deg);
+    transform: translateX(-50%) translateY(-50%) rotate(0deg); }
+  100% {
+    -moz-transform: translateX(-50%) translateY(-50%) rotate(359deg);
+    -ms-transform: translateX(-50%) translateY(-50%) rotate(359deg);
+    -webkit-transform: translateX(-50%) translateY(-50%) rotate(359deg);
+    transform: translateX(-50%) translateY(-50%) rotate(359deg); } }
+/* line 58, ../../../../general/res/sass/_object-label.scss */
+mct-representation.s-status-pending .t-object-label .t-item-icon .t-item-icon-glyph {
+  display: none; }
+/* line 62, ../../../../general/res/sass/_object-label.scss */
+mct-representation.s-status-pending .t-object-label .t-title-label {
+  font-style: italic;
+  opacity: 0.6; }
+
+/* line 69, ../../../../general/res/sass/_object-label.scss */
+.selected mct-representation.s-status-pending .t-object-label .t-item-icon:before {
   border-color: rgba(204, 204, 204, 0.25);
   border-top-color: #cccccc; }
 

--- a/platform/commonUI/themes/espresso/res/css/theme-espresso.css
+++ b/platform/commonUI/themes/espresso/res/css/theme-espresso.css
@@ -5246,8 +5246,8 @@ span.req {
   -webkit-box-sizing: border-box;
   box-sizing: border-box;
   line-height: 130%;
-  padding-left: 1.4625em;
-  font-size: 0.65em; }
+  padding-left: 1.575em;
+  font-size: 0.7em; }
   /* line 138, ../../../../general/res/sass/search/_search.scss */
   .holder-search .active-filter-display .clear-filters-icon {
     color: #737373;
@@ -5274,18 +5274,17 @@ span.req {
   -o-transition-delay: 0;
   -webkit-transition-delay: 0;
   transition-delay: 0;
-  margin-top: 10px;
   padding-right: 5px; }
-  /* line 152, ../../../../general/res/sass/search/_search.scss */
+  /* line 151, ../../../../general/res/sass/search/_search.scss */
   .holder-search .search-results .hint {
     margin-bottom: 10px;
     font-size: 0.65em;
     opacity: 0.6; }
-  /* line 157, ../../../../general/res/sass/search/_search.scss */
+  /* line 156, ../../../../general/res/sass/search/_search.scss */
   .holder-search .search-results.active {
     visibility: visible;
     opacity: 1; }
-  /* line 161, ../../../../general/res/sass/search/_search.scss */
+  /* line 160, ../../../../general/res/sass/search/_search.scss */
   .holder-search .search-results .load-more-button {
     -moz-transform: translateX(-50%);
     -ms-transform: translateX(-50%);

--- a/platform/commonUI/themes/espresso/res/css/theme-espresso.css
+++ b/platform/commonUI/themes/espresso/res/css/theme-espresso.css
@@ -527,23 +527,47 @@ mct-container {
   -webkit-flex-wrap: nowrap;
   flex-wrap: nowrap; }
   /* line 99, ../../../../general/res/sass/_archetypes.scss */
-  .l-flex-row .flex-elem,
-  .l-flex-col .flex-elem {
+  .l-flex-row .flex-elem, .l-flex-row .tree-item .view-control, .tree-item .l-flex-row .view-control,
+  .l-flex-row .search-result-item .view-control,
+  .search-result-item .l-flex-row .view-control,
+  .l-flex-col .flex-elem,
+  .l-flex-col .tree-item .view-control,
+  .tree-item .l-flex-col .view-control,
+  .l-flex-col .search-result-item .view-control,
+  .search-result-item .l-flex-col .view-control {
     min-height: 0;
     position: relative; }
     /* line 102, ../../../../general/res/sass/_archetypes.scss */
-    .l-flex-row .flex-elem:not(.grows),
-    .l-flex-col .flex-elem:not(.grows) {
+    .l-flex-row .flex-elem:not(.grows), .l-flex-row .tree-item .view-control:not(.grows), .tree-item .l-flex-row .view-control:not(.grows),
+    .l-flex-row .search-result-item .view-control:not(.grows),
+    .search-result-item .l-flex-row .view-control:not(.grows),
+    .l-flex-col .flex-elem:not(.grows),
+    .l-flex-col .tree-item .view-control:not(.grows),
+    .tree-item .l-flex-col .view-control:not(.grows),
+    .l-flex-col .search-result-item .view-control:not(.grows),
+    .search-result-item .l-flex-col .view-control:not(.grows) {
       -webkit-flex: 0 0 auto;
       flex: 0 0 auto; }
       /* line 104, ../../../../general/res/sass/_archetypes.scss */
-      .l-flex-row .flex-elem:not(.grows).flex-can-shrink,
-      .l-flex-col .flex-elem:not(.grows).flex-can-shrink {
+      .l-flex-row .flex-elem:not(.grows).flex-can-shrink, .l-flex-row .tree-item .view-control:not(.grows).flex-can-shrink, .tree-item .l-flex-row .view-control:not(.grows).flex-can-shrink,
+      .l-flex-row .search-result-item .view-control:not(.grows).flex-can-shrink,
+      .search-result-item .l-flex-row .view-control:not(.grows).flex-can-shrink,
+      .l-flex-col .flex-elem:not(.grows).flex-can-shrink,
+      .l-flex-col .tree-item .view-control:not(.grows).flex-can-shrink,
+      .tree-item .l-flex-col .view-control:not(.grows).flex-can-shrink,
+      .l-flex-col .search-result-item .view-control:not(.grows).flex-can-shrink,
+      .search-result-item .l-flex-col .view-control:not(.grows).flex-can-shrink {
         -webkit-flex: 0 1 auto;
         flex: 0 1 auto; }
     /* line 108, ../../../../general/res/sass/_archetypes.scss */
-    .l-flex-row .flex-elem.grows,
-    .l-flex-col .flex-elem.grows {
+    .l-flex-row .flex-elem.grows, .l-flex-row .tree-item .grows.view-control, .tree-item .l-flex-row .grows.view-control,
+    .l-flex-row .search-result-item .grows.view-control,
+    .search-result-item .l-flex-row .grows.view-control,
+    .l-flex-col .flex-elem.grows,
+    .l-flex-col .tree-item .grows.view-control,
+    .tree-item .l-flex-col .grows.view-control,
+    .l-flex-col .search-result-item .grows.view-control,
+    .search-result-item .l-flex-col .grows.view-control {
       -webkit-flex: 1 1 auto;
       flex: 1 1 auto; }
   /* line 112, ../../../../general/res/sass/_archetypes.scss */
@@ -562,11 +586,14 @@ mct-container {
   -webkit-flex-direction: row;
   flex-direction: row; }
   /* line 123, ../../../../general/res/sass/_archetypes.scss */
-  .l-flex-row.flex-elem {
+  .l-flex-row.flex-elem, .tree-item .l-flex-row.view-control,
+  .search-result-item .l-flex-row.view-control {
     -webkit-flex: 1 1 auto;
     flex: 1 1 auto; }
   /* line 124, ../../../../general/res/sass/_archetypes.scss */
-  .l-flex-row .flex-elem {
+  .l-flex-row .flex-elem, .l-flex-row .tree-item .view-control, .tree-item .l-flex-row .view-control,
+  .l-flex-row .search-result-item .view-control,
+  .search-result-item .l-flex-row .view-control {
     height: inherit;
     line-height: inherit;
     min-width: 0; }
@@ -580,10 +607,14 @@ mct-container {
   -webkit-flex-direction: column;
   flex-direction: column; }
   /* line 134, ../../../../general/res/sass/_archetypes.scss */
-  .l-flex-col .flex-elem {
+  .l-flex-col .flex-elem, .l-flex-col .tree-item .view-control, .tree-item .l-flex-col .view-control,
+  .l-flex-col .search-result-item .view-control,
+  .search-result-item .l-flex-col .view-control {
     min-height: 0; }
     /* line 136, ../../../../general/res/sass/_archetypes.scss */
-    .l-flex-col .flex-elem.holder:not(:last-child) {
+    .l-flex-col .flex-elem.holder:not(:last-child), .l-flex-col .tree-item .holder.view-control:not(:last-child), .tree-item .l-flex-col .holder.view-control:not(:last-child),
+    .l-flex-col .search-result-item .holder.view-control:not(:last-child),
+    .search-result-item .l-flex-col .holder.view-control:not(:last-child) {
       margin-bottom: 10px; }
   /* line 138, ../../../../general/res/sass/_archetypes.scss */
   .l-flex-col .flex-container {
@@ -1388,18 +1419,28 @@ tr[class*="s-limit"].s-limit-lwr td:first-child:before {
     z-index: 10; }
 @-moz-keyframes rotateCentered {
   0% {
+    -moz-transform: translateX(-50%) translateY(-50%) rotate(0deg);
     transform: translateX(-50%) translateY(-50%) rotate(0deg); }
   100% {
+    -moz-transform: translateX(-50%) translateY(-50%) rotate(359deg);
     transform: translateX(-50%) translateY(-50%) rotate(359deg); } }
 @-webkit-keyframes rotateCentered {
   0% {
+    -webkit-transform: translateX(-50%) translateY(-50%) rotate(0deg);
     transform: translateX(-50%) translateY(-50%) rotate(0deg); }
   100% {
+    -webkit-transform: translateX(-50%) translateY(-50%) rotate(359deg);
     transform: translateX(-50%) translateY(-50%) rotate(359deg); } }
 @keyframes rotateCentered {
   0% {
+    -moz-transform: translateX(-50%) translateY(-50%) rotate(0deg);
+    -ms-transform: translateX(-50%) translateY(-50%) rotate(0deg);
+    -webkit-transform: translateX(-50%) translateY(-50%) rotate(0deg);
     transform: translateX(-50%) translateY(-50%) rotate(0deg); }
   100% {
+    -moz-transform: translateX(-50%) translateY(-50%) rotate(359deg);
+    -ms-transform: translateX(-50%) translateY(-50%) rotate(359deg);
+    -webkit-transform: translateX(-50%) translateY(-50%) rotate(359deg);
     transform: translateX(-50%) translateY(-50%) rotate(359deg); } }
   /* line 138, ../../../../general/res/sass/helpers/_wait-spinner.scss */
   .loading:after {
@@ -5599,7 +5640,7 @@ span.req {
  * this source code distribution or the Licensing information page available
  * at runtime from the About dialog for additional information.
  *****************************************************************************/
-/* line 35, ../../../../general/res/sass/tree/_tree.scss */
+/* line 23, ../../../../general/res/sass/tree/_tree.scss */
 ul.tree {
   margin: 0;
   padding: 0;
@@ -5612,15 +5653,15 @@ ul.tree {
     list-style-type: none;
     margin: 0;
     padding: 0; }
-  /* line 38, ../../../../general/res/sass/tree/_tree.scss */
+  /* line 26, ../../../../general/res/sass/tree/_tree.scss */
   ul.tree li {
     display: block;
     position: relative; }
-  /* line 42, ../../../../general/res/sass/tree/_tree.scss */
+  /* line 30, ../../../../general/res/sass/tree/_tree.scss */
   ul.tree ul.tree {
     margin-left: 15px; }
 
-/* line 47, ../../../../general/res/sass/tree/_tree.scss */
+/* line 35, ../../../../general/res/sass/tree/_tree.scss */
 .tree-item,
 .search-result-item {
   -moz-box-sizing: border-box;
@@ -5633,126 +5674,93 @@ ul.tree {
   -o-transition: background-color 0.25s;
   -webkit-transition: background-color 0.25s;
   transition: background-color 0.25s;
-  display: block;
   font-size: 0.8rem;
   height: 1.5rem;
   line-height: 1.5rem;
   margin-bottom: 3px;
+  padding: 0 3px;
   position: relative; }
-  /* line 60, ../../../../general/res/sass/tree/_tree.scss */
+  /* line 48, ../../../../general/res/sass/tree/_tree.scss */
   .tree-item .view-control,
   .search-result-item .view-control {
     color: rgba(255, 255, 255, 0.3);
-    display: inline-block;
-    margin-left: 5px;
+    margin-right: 5px;
     font-size: 0.75em;
     width: 10px; }
+    /* line 56, ../../../../general/res/sass/tree/_tree.scss */
+    .tree-item .view-control.has-children:before,
+    .search-result-item .view-control.has-children:before {
+      content: ">"; }
+    /* line 63, ../../../../general/res/sass/tree/_tree.scss */
+    .tree-item .view-control.has-children.expanded:before,
+    .search-result-item .view-control.has-children.expanded:before {
+      content: "v"; }
     @media only screen and (min-device-width: 1025px) and (-webkit-min-device-pixel-ratio: 1) {
-      /* line 68, ../../../../general/res/sass/tree/_tree.scss */
+      /* line 69, ../../../../general/res/sass/tree/_tree.scss */
       .tree-item .view-control:hover,
       .search-result-item .view-control:hover {
         color: #ffc700 !important; } }
-  /* line 74, ../../../../general/res/sass/tree/_tree.scss */
+  /* line 75, ../../../../general/res/sass/tree/_tree.scss */
   .tree-item .t-object-label,
   .search-result-item .t-object-label {
-    display: block;
-    overflow: hidden;
-    position: absolute;
-    top: 0px;
-    right: 0px;
-    bottom: 0px;
-    left: 0px;
-    width: auto;
-    height: auto;
     line-height: 1.5rem; }
-    /* line 79, ../../../../general/res/sass/tree/_tree.scss */
+    /* line 80, ../../../../general/res/sass/tree/_tree.scss */
     .tree-item .t-object-label .t-item-icon,
     .search-result-item .t-object-label .t-item-icon {
       text-shadow: rgba(0, 0, 0, 0.6) 0 1px 2px;
       font-size: 1.4em;
       color: #0099cc;
-      position: absolute;
-      left: 5px;
-      top: 50%;
-      width: 1.4em;
-      -moz-transform: translateY(-50%);
-      -ms-transform: translateY(-50%);
-      -webkit-transform: translateY(-50%);
-      transform: translateY(-50%); }
-    /* line 83, ../../../../general/res/sass/tree/_tree.scss */
+      width: 1.4em; }
+    /* line 91, ../../../../general/res/sass/tree/_tree.scss */
     .tree-item .t-object-label .title-label,
     .tree-item .t-object-label .t-title-label,
     .search-result-item .t-object-label .title-label,
     .search-result-item .t-object-label .t-title-label {
       overflow: hidden;
-      position: absolute;
-      top: 0px;
-      right: 0px;
-      bottom: 0px;
-      left: 0px;
-      width: auto;
-      height: auto;
-      display: block;
-      left: 30px;
-      overflow: hidden;
       text-overflow: ellipsis;
       white-space: nowrap; }
-  /* line 94, ../../../../general/res/sass/tree/_tree.scss */
+  /* line 100, ../../../../general/res/sass/tree/_tree.scss */
   .tree-item.selected,
   .search-result-item.selected {
     background: #006080;
     color: #cccccc; }
-    /* line 97, ../../../../general/res/sass/tree/_tree.scss */
+    /* line 103, ../../../../general/res/sass/tree/_tree.scss */
     .tree-item.selected .view-control,
     .search-result-item.selected .view-control {
       color: rgba(255, 255, 255, 0.3); }
-    /* line 100, ../../../../general/res/sass/tree/_tree.scss */
+    /* line 106, ../../../../general/res/sass/tree/_tree.scss */
     .tree-item.selected .t-object-label .t-item-icon,
     .search-result-item.selected .t-object-label .t-item-icon {
       color: #cccccc; }
   @media only screen and (min-device-width: 1025px) and (-webkit-min-device-pixel-ratio: 1) {
-    /* line 108, ../../../../general/res/sass/tree/_tree.scss */
+    /* line 114, ../../../../general/res/sass/tree/_tree.scss */
     .tree-item:not(.selected):hover,
     .search-result-item:not(.selected):hover {
       background: rgba(153, 153, 153, 0.1);
       color: #cccccc; }
-      /* line 111, ../../../../general/res/sass/tree/_tree.scss */
+      /* line 117, ../../../../general/res/sass/tree/_tree.scss */
       .tree-item:not(.selected):hover .t-item-icon,
       .search-result-item:not(.selected):hover .t-item-icon {
         color: #33ccff; } }
-  /* line 118, ../../../../general/res/sass/tree/_tree.scss */
+  /* line 124, ../../../../general/res/sass/tree/_tree.scss */
   .tree-item:not(.loading),
   .search-result-item:not(.loading) {
     cursor: pointer; }
-  /* line 122, ../../../../general/res/sass/tree/_tree.scss */
+  /* line 128, ../../../../general/res/sass/tree/_tree.scss */
   .tree-item .context-trigger,
   .search-result-item .context-trigger {
     top: -1px;
     position: absolute;
     right: 3px; }
-    /* line 127, ../../../../general/res/sass/tree/_tree.scss */
+    /* line 133, ../../../../general/res/sass/tree/_tree.scss */
     .tree-item .context-trigger .invoke-menu,
     .search-result-item .context-trigger .invoke-menu {
       font-size: 0.75em;
       height: 0.9rem;
       line-height: 0.9rem; }
 
-/* line 137, ../../../../general/res/sass/tree/_tree.scss */
-.tree-item mct-representation .t-object-label {
-  left: 15px; }
-/* line 142, ../../../../general/res/sass/tree/_tree.scss */
+/* line 148, ../../../../general/res/sass/tree/_tree.scss */
 .tree-item mct-representation.s-status-pending .t-object-label:before {
-  text-shadow: rgba(0, 0, 0, 0.6) 0 1px 2px;
-  font-size: 1.4em;
-  color: #0099cc;
-  position: absolute;
-  left: 5px;
-  top: 50%;
-  width: 1.4em;
-  -moz-transform: translateY(-50%);
-  -ms-transform: translateY(-50%);
-  -webkit-transform: translateY(-50%);
-  transform: translateY(-50%);
   -moz-animation-name: rotateCentered;
   -webkit-animation-name: rotateCentered;
   animation-name: rotateCentered;
@@ -5765,30 +5773,40 @@ ul.tree {
   -moz-animation-timing-function: linear;
   -webkit-animation-timing-function: linear;
   animation-timing-function: linear;
-  border-color: rgba(0, 0, 255, 0.25);
-  border-top-color: blue;
+  border-color: rgba(0, 153, 204, 0.25);
+  border-top-color: #0099cc;
   border-style: solid;
-  border-width: 2px;
+  border-width: 0.25em;
   -moz-border-radius: 100%;
   -webkit-border-radius: 100%;
   border-radius: 100%;
   content: ""; }
 @-moz-keyframes rotateCentered {
   0% {
+    -moz-transform: translateX(-50%) translateY(-50%) rotate(0deg);
     transform: translateX(-50%) translateY(-50%) rotate(0deg); }
   100% {
+    -moz-transform: translateX(-50%) translateY(-50%) rotate(359deg);
     transform: translateX(-50%) translateY(-50%) rotate(359deg); } }
 @-webkit-keyframes rotateCentered {
   0% {
+    -webkit-transform: translateX(-50%) translateY(-50%) rotate(0deg);
     transform: translateX(-50%) translateY(-50%) rotate(0deg); }
   100% {
+    -webkit-transform: translateX(-50%) translateY(-50%) rotate(359deg);
     transform: translateX(-50%) translateY(-50%) rotate(359deg); } }
 @keyframes rotateCentered {
   0% {
+    -moz-transform: translateX(-50%) translateY(-50%) rotate(0deg);
+    -ms-transform: translateX(-50%) translateY(-50%) rotate(0deg);
+    -webkit-transform: translateX(-50%) translateY(-50%) rotate(0deg);
     transform: translateX(-50%) translateY(-50%) rotate(0deg); }
   100% {
+    -moz-transform: translateX(-50%) translateY(-50%) rotate(359deg);
+    -ms-transform: translateX(-50%) translateY(-50%) rotate(359deg);
+    -webkit-transform: translateX(-50%) translateY(-50%) rotate(359deg);
     transform: translateX(-50%) translateY(-50%) rotate(359deg); } }
-/* line 147, ../../../../general/res/sass/tree/_tree.scss */
+/* line 152, ../../../../general/res/sass/tree/_tree.scss */
 .tree-item mct-representation.s-status-pending .t-object-label .t-item-icon .t-item-icon-glyph {
   display: none; }
 

--- a/platform/commonUI/themes/espresso/res/css/theme-espresso.css
+++ b/platform/commonUI/themes/espresso/res/css/theme-espresso.css
@@ -5718,47 +5718,53 @@ ul.tree {
       font-size: 1.4em;
       color: #0099cc;
       width: 18px; }
-  /* line 84, ../../../../general/res/sass/tree/_tree.scss */
+    /* line 82, ../../../../general/res/sass/tree/_tree.scss */
+    .tree-item .t-object-label .t-title-label,
+    .search-result-item .t-object-label .t-title-label {
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap; }
+  /* line 87, ../../../../general/res/sass/tree/_tree.scss */
   .tree-item.selected,
   .search-result-item.selected {
     background: #006080;
     color: #cccccc; }
-    /* line 87, ../../../../general/res/sass/tree/_tree.scss */
+    /* line 90, ../../../../general/res/sass/tree/_tree.scss */
     .tree-item.selected .view-control,
     .search-result-item.selected .view-control {
       color: rgba(255, 255, 255, 0.3); }
-    /* line 90, ../../../../general/res/sass/tree/_tree.scss */
+    /* line 93, ../../../../general/res/sass/tree/_tree.scss */
     .tree-item.selected .t-object-label .t-item-icon,
     .search-result-item.selected .t-object-label .t-item-icon {
       color: #cccccc; }
   @media only screen and (min-device-width: 1025px) and (-webkit-min-device-pixel-ratio: 1) {
-    /* line 97, ../../../../general/res/sass/tree/_tree.scss */
+    /* line 100, ../../../../general/res/sass/tree/_tree.scss */
     .tree-item:not(.selected):hover,
     .search-result-item:not(.selected):hover {
       background: rgba(153, 153, 153, 0.1);
       color: #cccccc; }
-      /* line 100, ../../../../general/res/sass/tree/_tree.scss */
+      /* line 103, ../../../../general/res/sass/tree/_tree.scss */
       .tree-item:not(.selected):hover .t-item-icon,
       .search-result-item:not(.selected):hover .t-item-icon {
         color: #33ccff; } }
-  /* line 107, ../../../../general/res/sass/tree/_tree.scss */
+  /* line 110, ../../../../general/res/sass/tree/_tree.scss */
   .tree-item:not(.loading),
   .search-result-item:not(.loading) {
     cursor: pointer; }
-  /* line 111, ../../../../general/res/sass/tree/_tree.scss */
+  /* line 114, ../../../../general/res/sass/tree/_tree.scss */
   .tree-item .context-trigger,
   .search-result-item .context-trigger {
     top: -1px;
     position: absolute;
     right: 3px; }
-    /* line 116, ../../../../general/res/sass/tree/_tree.scss */
+    /* line 119, ../../../../general/res/sass/tree/_tree.scss */
     .tree-item .context-trigger .invoke-menu,
     .search-result-item .context-trigger .invoke-menu {
       font-size: 0.75em;
       height: 0.9rem;
       line-height: 0.9rem; }
 
-/* line 128, ../../../../general/res/sass/tree/_tree.scss */
+/* line 131, ../../../../general/res/sass/tree/_tree.scss */
 mct-representation.s-status-pending .t-object-label .t-item-icon:before {
   -moz-animation-name: rotateCentered;
   -webkit-animation-name: rotateCentered;
@@ -5806,15 +5812,15 @@ mct-representation.s-status-pending .t-object-label .t-item-icon:before {
     -ms-transform: translateX(-50%) translateY(-50%) rotate(359deg);
     -webkit-transform: translateX(-50%) translateY(-50%) rotate(359deg);
     transform: translateX(-50%) translateY(-50%) rotate(359deg); } }
-/* line 142, ../../../../general/res/sass/tree/_tree.scss */
+/* line 145, ../../../../general/res/sass/tree/_tree.scss */
 mct-representation.s-status-pending .t-object-label .t-item-icon .t-item-icon-glyph {
   display: none; }
-/* line 146, ../../../../general/res/sass/tree/_tree.scss */
+/* line 149, ../../../../general/res/sass/tree/_tree.scss */
 mct-representation.s-status-pending .t-object-label .t-title-label {
   font-style: italic;
   opacity: 0.6; }
 
-/* line 153, ../../../../general/res/sass/tree/_tree.scss */
+/* line 156, ../../../../general/res/sass/tree/_tree.scss */
 .selected mct-representation.s-status-pending .t-object-label .t-item-icon:before {
   border-color: rgba(204, 204, 204, 0.25);
   border-top-color: #cccccc; }
@@ -5853,13 +5859,8 @@ mct-representation.s-status-pending .t-object-label .t-title-label {
 /* line 33, ../../../../general/res/sass/_object-label.scss */
 .t-object-label .t-item-icon {
   margin-right: 5px; }
-/* line 36, ../../../../general/res/sass/_object-label.scss */
-.t-object-label .t-title-label {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap; }
 
-/* line 45, ../../../../general/res/sass/_object-label.scss */
+/* line 42, ../../../../general/res/sass/_object-label.scss */
 mct-representation.s-status-pending .t-object-label .t-item-icon:before {
   -moz-animation-name: rotateCentered;
   -webkit-animation-name: rotateCentered;
@@ -5911,15 +5912,15 @@ mct-representation.s-status-pending .t-object-label .t-item-icon:before {
     -ms-transform: translateX(-50%) translateY(-50%) rotate(359deg);
     -webkit-transform: translateX(-50%) translateY(-50%) rotate(359deg);
     transform: translateX(-50%) translateY(-50%) rotate(359deg); } }
-/* line 58, ../../../../general/res/sass/_object-label.scss */
+/* line 55, ../../../../general/res/sass/_object-label.scss */
 mct-representation.s-status-pending .t-object-label .t-item-icon .t-item-icon-glyph {
   display: none; }
-/* line 62, ../../../../general/res/sass/_object-label.scss */
+/* line 59, ../../../../general/res/sass/_object-label.scss */
 mct-representation.s-status-pending .t-object-label .t-title-label {
   font-style: italic;
   opacity: 0.6; }
 
-/* line 69, ../../../../general/res/sass/_object-label.scss */
+/* line 66, ../../../../general/res/sass/_object-label.scss */
 .selected mct-representation.s-status-pending .t-object-label .t-item-icon:before {
   border-color: rgba(204, 204, 204, 0.25);
   border-top-color: #cccccc; }

--- a/platform/commonUI/themes/espresso/res/css/theme-espresso.css
+++ b/platform/commonUI/themes/espresso/res/css/theme-espresso.css
@@ -830,10 +830,12 @@ mct-container {
 
 /* line 84, ../../../../general/res/sass/_icons.scss */
 .t-item-icon {
-  display: inline-block;
   line-height: normal;
   position: relative; }
-  /* line 93, ../../../../general/res/sass/_icons.scss */
+  /* line 91, ../../../../general/res/sass/_icons.scss */
+  .t-item-icon .t-item-icon-glyph {
+    position: relative; }
+  /* line 96, ../../../../general/res/sass/_icons.scss */
   .t-item-icon.l-icon-link .t-item-icon-glyph:before {
     color: #49dedb;
     content: "\f4";

--- a/platform/commonUI/themes/espresso/res/css/theme-espresso.css
+++ b/platform/commonUI/themes/espresso/res/css/theme-espresso.css
@@ -527,47 +527,23 @@ mct-container {
   -webkit-flex-wrap: nowrap;
   flex-wrap: nowrap; }
   /* line 99, ../../../../general/res/sass/_archetypes.scss */
-  .l-flex-row .flex-elem, .l-flex-row .tree-item .view-control, .tree-item .l-flex-row .view-control,
-  .l-flex-row .search-result-item .view-control,
-  .search-result-item .l-flex-row .view-control,
-  .l-flex-col .flex-elem,
-  .l-flex-col .tree-item .view-control,
-  .tree-item .l-flex-col .view-control,
-  .l-flex-col .search-result-item .view-control,
-  .search-result-item .l-flex-col .view-control {
+  .l-flex-row .flex-elem,
+  .l-flex-col .flex-elem {
     min-height: 0;
     position: relative; }
     /* line 102, ../../../../general/res/sass/_archetypes.scss */
-    .l-flex-row .flex-elem:not(.grows), .l-flex-row .tree-item .view-control:not(.grows), .tree-item .l-flex-row .view-control:not(.grows),
-    .l-flex-row .search-result-item .view-control:not(.grows),
-    .search-result-item .l-flex-row .view-control:not(.grows),
-    .l-flex-col .flex-elem:not(.grows),
-    .l-flex-col .tree-item .view-control:not(.grows),
-    .tree-item .l-flex-col .view-control:not(.grows),
-    .l-flex-col .search-result-item .view-control:not(.grows),
-    .search-result-item .l-flex-col .view-control:not(.grows) {
+    .l-flex-row .flex-elem:not(.grows),
+    .l-flex-col .flex-elem:not(.grows) {
       -webkit-flex: 0 0 auto;
       flex: 0 0 auto; }
       /* line 104, ../../../../general/res/sass/_archetypes.scss */
-      .l-flex-row .flex-elem:not(.grows).flex-can-shrink, .l-flex-row .tree-item .view-control:not(.grows).flex-can-shrink, .tree-item .l-flex-row .view-control:not(.grows).flex-can-shrink,
-      .l-flex-row .search-result-item .view-control:not(.grows).flex-can-shrink,
-      .search-result-item .l-flex-row .view-control:not(.grows).flex-can-shrink,
-      .l-flex-col .flex-elem:not(.grows).flex-can-shrink,
-      .l-flex-col .tree-item .view-control:not(.grows).flex-can-shrink,
-      .tree-item .l-flex-col .view-control:not(.grows).flex-can-shrink,
-      .l-flex-col .search-result-item .view-control:not(.grows).flex-can-shrink,
-      .search-result-item .l-flex-col .view-control:not(.grows).flex-can-shrink {
+      .l-flex-row .flex-elem:not(.grows).flex-can-shrink,
+      .l-flex-col .flex-elem:not(.grows).flex-can-shrink {
         -webkit-flex: 0 1 auto;
         flex: 0 1 auto; }
     /* line 108, ../../../../general/res/sass/_archetypes.scss */
-    .l-flex-row .flex-elem.grows, .l-flex-row .tree-item .grows.view-control, .tree-item .l-flex-row .grows.view-control,
-    .l-flex-row .search-result-item .grows.view-control,
-    .search-result-item .l-flex-row .grows.view-control,
-    .l-flex-col .flex-elem.grows,
-    .l-flex-col .tree-item .grows.view-control,
-    .tree-item .l-flex-col .grows.view-control,
-    .l-flex-col .search-result-item .grows.view-control,
-    .search-result-item .l-flex-col .grows.view-control {
+    .l-flex-row .flex-elem.grows,
+    .l-flex-col .flex-elem.grows {
       -webkit-flex: 1 1 auto;
       flex: 1 1 auto; }
   /* line 112, ../../../../general/res/sass/_archetypes.scss */
@@ -586,14 +562,11 @@ mct-container {
   -webkit-flex-direction: row;
   flex-direction: row; }
   /* line 123, ../../../../general/res/sass/_archetypes.scss */
-  .l-flex-row.flex-elem, .tree-item .l-flex-row.view-control,
-  .search-result-item .l-flex-row.view-control {
+  .l-flex-row.flex-elem {
     -webkit-flex: 1 1 auto;
     flex: 1 1 auto; }
   /* line 124, ../../../../general/res/sass/_archetypes.scss */
-  .l-flex-row .flex-elem, .l-flex-row .tree-item .view-control, .tree-item .l-flex-row .view-control,
-  .l-flex-row .search-result-item .view-control,
-  .search-result-item .l-flex-row .view-control {
+  .l-flex-row .flex-elem {
     height: inherit;
     line-height: inherit;
     min-width: 0; }
@@ -607,14 +580,10 @@ mct-container {
   -webkit-flex-direction: column;
   flex-direction: column; }
   /* line 134, ../../../../general/res/sass/_archetypes.scss */
-  .l-flex-col .flex-elem, .l-flex-col .tree-item .view-control, .tree-item .l-flex-col .view-control,
-  .l-flex-col .search-result-item .view-control,
-  .search-result-item .l-flex-col .view-control {
+  .l-flex-col .flex-elem {
     min-height: 0; }
     /* line 136, ../../../../general/res/sass/_archetypes.scss */
-    .l-flex-col .flex-elem.holder:not(:last-child), .l-flex-col .tree-item .holder.view-control:not(:last-child), .tree-item .l-flex-col .holder.view-control:not(:last-child),
-    .l-flex-col .search-result-item .holder.view-control:not(:last-child),
-    .search-result-item .l-flex-col .holder.view-control:not(:last-child) {
+    .l-flex-col .flex-elem.holder:not(:last-child) {
       margin-bottom: 10px; }
   /* line 138, ../../../../general/res/sass/_archetypes.scss */
   .l-flex-col .flex-container {
@@ -5684,34 +5653,60 @@ ul.tree {
   .tree-item .view-control,
   .search-result-item .view-control {
     color: rgba(255, 255, 255, 0.3);
-    margin-right: 5px;
     font-size: 0.75em;
+    margin-right: 5px;
+    height: 100%;
+    line-height: inherit;
     width: 10px; }
     /* line 56, ../../../../general/res/sass/tree/_tree.scss */
     .tree-item .view-control.has-children:before,
     .search-result-item .view-control.has-children:before {
-      content: ">"; }
-    /* line 63, ../../../../general/res/sass/tree/_tree.scss */
+      position: absolute;
+      -moz-transition-property: -moz-transform;
+      -o-transition-property: -o-transform;
+      -webkit-transition-property: -webkit-transform;
+      transition-property: transform;
+      -moz-transition-duration: 100ms;
+      -o-transition-duration: 100ms;
+      -webkit-transition-duration: 100ms;
+      transition-duration: 100ms;
+      -moz-transition-timing-function: ease-in-out;
+      -o-transition-timing-function: ease-in-out;
+      -webkit-transition-timing-function: ease-in-out;
+      transition-timing-function: ease-in-out;
+      -moz-transition-delay: 0;
+      -o-transition-delay: 0;
+      -webkit-transition-delay: 0;
+      transition-delay: 0;
+      content: "\3e";
+      -moz-transform-origin: center 50%;
+      -ms-transform-origin: center 50%;
+      -webkit-transform-origin: center 50%;
+      transform-origin: center 50%; }
+    /* line 62, ../../../../general/res/sass/tree/_tree.scss */
     .tree-item .view-control.has-children.expanded:before,
     .search-result-item .view-control.has-children.expanded:before {
-      content: "v"; }
+      -moz-transform: rotate(90deg);
+      -ms-transform: rotate(90deg);
+      -webkit-transform: rotate(90deg);
+      transform: rotate(90deg); }
     @media only screen and (min-device-width: 1025px) and (-webkit-min-device-pixel-ratio: 1) {
-      /* line 69, ../../../../general/res/sass/tree/_tree.scss */
+      /* line 67, ../../../../general/res/sass/tree/_tree.scss */
       .tree-item .view-control:hover,
       .search-result-item .view-control:hover {
         color: #ffc700 !important; } }
-  /* line 75, ../../../../general/res/sass/tree/_tree.scss */
+  /* line 73, ../../../../general/res/sass/tree/_tree.scss */
   .tree-item .t-object-label,
   .search-result-item .t-object-label {
     line-height: 1.5rem; }
-    /* line 80, ../../../../general/res/sass/tree/_tree.scss */
+    /* line 76, ../../../../general/res/sass/tree/_tree.scss */
     .tree-item .t-object-label .t-item-icon,
     .search-result-item .t-object-label .t-item-icon {
       text-shadow: rgba(0, 0, 0, 0.6) 0 1px 2px;
       font-size: 1.4em;
       color: #0099cc;
       width: 1.4em; }
-    /* line 91, ../../../../general/res/sass/tree/_tree.scss */
+    /* line 82, ../../../../general/res/sass/tree/_tree.scss */
     .tree-item .t-object-label .title-label,
     .tree-item .t-object-label .t-title-label,
     .search-result-item .t-object-label .title-label,
@@ -5719,47 +5714,47 @@ ul.tree {
       overflow: hidden;
       text-overflow: ellipsis;
       white-space: nowrap; }
-  /* line 100, ../../../../general/res/sass/tree/_tree.scss */
+  /* line 88, ../../../../general/res/sass/tree/_tree.scss */
   .tree-item.selected,
   .search-result-item.selected {
     background: #006080;
     color: #cccccc; }
-    /* line 103, ../../../../general/res/sass/tree/_tree.scss */
+    /* line 91, ../../../../general/res/sass/tree/_tree.scss */
     .tree-item.selected .view-control,
     .search-result-item.selected .view-control {
       color: rgba(255, 255, 255, 0.3); }
-    /* line 106, ../../../../general/res/sass/tree/_tree.scss */
+    /* line 94, ../../../../general/res/sass/tree/_tree.scss */
     .tree-item.selected .t-object-label .t-item-icon,
     .search-result-item.selected .t-object-label .t-item-icon {
       color: #cccccc; }
   @media only screen and (min-device-width: 1025px) and (-webkit-min-device-pixel-ratio: 1) {
-    /* line 114, ../../../../general/res/sass/tree/_tree.scss */
+    /* line 102, ../../../../general/res/sass/tree/_tree.scss */
     .tree-item:not(.selected):hover,
     .search-result-item:not(.selected):hover {
       background: rgba(153, 153, 153, 0.1);
       color: #cccccc; }
-      /* line 117, ../../../../general/res/sass/tree/_tree.scss */
+      /* line 105, ../../../../general/res/sass/tree/_tree.scss */
       .tree-item:not(.selected):hover .t-item-icon,
       .search-result-item:not(.selected):hover .t-item-icon {
         color: #33ccff; } }
-  /* line 124, ../../../../general/res/sass/tree/_tree.scss */
+  /* line 112, ../../../../general/res/sass/tree/_tree.scss */
   .tree-item:not(.loading),
   .search-result-item:not(.loading) {
     cursor: pointer; }
-  /* line 128, ../../../../general/res/sass/tree/_tree.scss */
+  /* line 116, ../../../../general/res/sass/tree/_tree.scss */
   .tree-item .context-trigger,
   .search-result-item .context-trigger {
     top: -1px;
     position: absolute;
     right: 3px; }
-    /* line 133, ../../../../general/res/sass/tree/_tree.scss */
+    /* line 121, ../../../../general/res/sass/tree/_tree.scss */
     .tree-item .context-trigger .invoke-menu,
     .search-result-item .context-trigger .invoke-menu {
       font-size: 0.75em;
       height: 0.9rem;
       line-height: 0.9rem; }
 
-/* line 148, ../../../../general/res/sass/tree/_tree.scss */
+/* line 136, ../../../../general/res/sass/tree/_tree.scss */
 .tree-item mct-representation.s-status-pending .t-object-label:before {
   -moz-animation-name: rotateCentered;
   -webkit-animation-name: rotateCentered;
@@ -5806,7 +5801,7 @@ ul.tree {
     -ms-transform: translateX(-50%) translateY(-50%) rotate(359deg);
     -webkit-transform: translateX(-50%) translateY(-50%) rotate(359deg);
     transform: translateX(-50%) translateY(-50%) rotate(359deg); } }
-/* line 152, ../../../../general/res/sass/tree/_tree.scss */
+/* line 140, ../../../../general/res/sass/tree/_tree.scss */
 .tree-item mct-representation.s-status-pending .t-object-label .t-item-icon .t-item-icon-glyph {
   display: none; }
 
@@ -5834,7 +5829,7 @@ ul.tree {
 @media only screen and (orientation: portrait) and (max-device-width: 767px), only screen and (orientation: landscape) and (max-device-width: 767px), only screen and (orientation: portrait) and (min-device-width: 768px) and (max-device-width: 1024px), only screen and (orientation: landscape) and (min-device-width: 768px) and (max-device-width: 1024px) {
   /* line 27, ../../../../general/res/sass/mobile/_tree.scss */
   ul.tree ul.tree {
-    margin-left: 20px; }
+    margin-left: 15px; }
 
   /* line 31, ../../../../general/res/sass/mobile/_tree.scss */
   .tree-item,
@@ -5845,20 +5840,27 @@ ul.tree {
     /* line 36, ../../../../general/res/sass/mobile/_tree.scss */
     .tree-item .view-control,
     .search-result-item .view-control {
-      position: absolute;
-      font-size: 1.1em;
-      height: 35px;
-      line-height: inherit;
-      right: 0px;
-      width: 30px;
-      text-align: center; }
-    /* line 47, ../../../../general/res/sass/mobile/_tree.scss */
-    .tree-item .label,
+      order: 2;
+      width: 35px; }
+      /* line 40, ../../../../general/res/sass/mobile/_tree.scss */
+      .tree-item .view-control.has-children:before,
+      .search-result-item .view-control.has-children:before {
+        content: "\7d";
+        left: 50%;
+        -moz-transform: translateX(-50%) rotate(90deg);
+        -ms-transform: translateX(-50%) rotate(90deg);
+        -webkit-transform: translateX(-50%) rotate(90deg);
+        transform: translateX(-50%) rotate(90deg); }
+      /* line 45, ../../../../general/res/sass/mobile/_tree.scss */
+      .tree-item .view-control.has-children.expanded:before,
+      .search-result-item .view-control.has-children.expanded:before {
+        -moz-transform: translateX(-50%) rotate(270deg);
+        -ms-transform: translateX(-50%) rotate(270deg);
+        -webkit-transform: translateX(-50%) rotate(270deg);
+        transform: translateX(-50%) rotate(270deg); }
+    /* line 50, ../../../../general/res/sass/mobile/_tree.scss */
     .tree-item .t-object-label,
-    .search-result-item .label,
     .search-result-item .t-object-label {
-      left: 0;
-      right: 35px;
       line-height: inherit; } }
 /*****************************************************************************
  * Open MCT Web, Copyright (c) 2014-2015, United States Government

--- a/platform/commonUI/themes/espresso/res/css/theme-espresso.css
+++ b/platform/commonUI/themes/espresso/res/css/theme-espresso.css
@@ -20,7 +20,7 @@
  * this source code distribution or the Licensing information page available
  * at runtime from the About dialog for additional information.
  *****************************************************************************/
-/* line 5, ../../../../../../../../../../Library/Ruby/Gems/2.0.0/gems/compass-core-1.0.3/stylesheets/compass/reset/_utilities.scss */
+/* line 5, ../../../../../../../../../../../Library/Ruby/Gems/2.0.0/gems/compass-core-1.0.3/stylesheets/compass/reset/_utilities.scss */
 html, body, div, span, applet, object, iframe,
 h1, h2, h3, h4, h5, h6, p, blockquote, pre,
 a, abbr, acronym, address, big, cite, code,
@@ -41,38 +41,38 @@ time, mark, audio, video {
   font-size: 100%;
   vertical-align: baseline; }
 
-/* line 22, ../../../../../../../../../../Library/Ruby/Gems/2.0.0/gems/compass-core-1.0.3/stylesheets/compass/reset/_utilities.scss */
+/* line 22, ../../../../../../../../../../../Library/Ruby/Gems/2.0.0/gems/compass-core-1.0.3/stylesheets/compass/reset/_utilities.scss */
 html {
   line-height: 1; }
 
-/* line 24, ../../../../../../../../../../Library/Ruby/Gems/2.0.0/gems/compass-core-1.0.3/stylesheets/compass/reset/_utilities.scss */
+/* line 24, ../../../../../../../../../../../Library/Ruby/Gems/2.0.0/gems/compass-core-1.0.3/stylesheets/compass/reset/_utilities.scss */
 ol, ul {
   list-style: none; }
 
-/* line 26, ../../../../../../../../../../Library/Ruby/Gems/2.0.0/gems/compass-core-1.0.3/stylesheets/compass/reset/_utilities.scss */
+/* line 26, ../../../../../../../../../../../Library/Ruby/Gems/2.0.0/gems/compass-core-1.0.3/stylesheets/compass/reset/_utilities.scss */
 table {
   border-collapse: collapse;
   border-spacing: 0; }
 
-/* line 28, ../../../../../../../../../../Library/Ruby/Gems/2.0.0/gems/compass-core-1.0.3/stylesheets/compass/reset/_utilities.scss */
+/* line 28, ../../../../../../../../../../../Library/Ruby/Gems/2.0.0/gems/compass-core-1.0.3/stylesheets/compass/reset/_utilities.scss */
 caption, th, td {
   text-align: left;
   font-weight: normal;
   vertical-align: middle; }
 
-/* line 30, ../../../../../../../../../../Library/Ruby/Gems/2.0.0/gems/compass-core-1.0.3/stylesheets/compass/reset/_utilities.scss */
+/* line 30, ../../../../../../../../../../../Library/Ruby/Gems/2.0.0/gems/compass-core-1.0.3/stylesheets/compass/reset/_utilities.scss */
 q, blockquote {
   quotes: none; }
-  /* line 103, ../../../../../../../../../../Library/Ruby/Gems/2.0.0/gems/compass-core-1.0.3/stylesheets/compass/reset/_utilities.scss */
+  /* line 103, ../../../../../../../../../../../Library/Ruby/Gems/2.0.0/gems/compass-core-1.0.3/stylesheets/compass/reset/_utilities.scss */
   q:before, q:after, blockquote:before, blockquote:after {
     content: "";
     content: none; }
 
-/* line 32, ../../../../../../../../../../Library/Ruby/Gems/2.0.0/gems/compass-core-1.0.3/stylesheets/compass/reset/_utilities.scss */
+/* line 32, ../../../../../../../../../../../Library/Ruby/Gems/2.0.0/gems/compass-core-1.0.3/stylesheets/compass/reset/_utilities.scss */
 a img {
   border: none; }
 
-/* line 116, ../../../../../../../../../../Library/Ruby/Gems/2.0.0/gems/compass-core-1.0.3/stylesheets/compass/reset/_utilities.scss */
+/* line 116, ../../../../../../../../../../../Library/Ruby/Gems/2.0.0/gems/compass-core-1.0.3/stylesheets/compass/reset/_utilities.scss */
 article, aside, details, figcaption, figure, footer, header, hgroup, main, menu, nav, section, summary {
   display: block; }
 
@@ -5729,33 +5729,33 @@ ul.tree {
     .search-result-item.selected .t-object-label .t-item-icon {
       color: #cccccc; }
   @media only screen and (min-device-width: 1025px) and (-webkit-min-device-pixel-ratio: 1) {
-    /* line 103, ../../../../general/res/sass/tree/_tree.scss */
+    /* line 102, ../../../../general/res/sass/tree/_tree.scss */
     .tree-item:not(.selected):hover,
     .search-result-item:not(.selected):hover {
       background: rgba(153, 153, 153, 0.1);
       color: #cccccc; }
-      /* line 106, ../../../../general/res/sass/tree/_tree.scss */
+      /* line 105, ../../../../general/res/sass/tree/_tree.scss */
       .tree-item:not(.selected):hover .t-item-icon,
       .search-result-item:not(.selected):hover .t-item-icon {
         color: #33ccff; } }
-  /* line 113, ../../../../general/res/sass/tree/_tree.scss */
+  /* line 112, ../../../../general/res/sass/tree/_tree.scss */
   .tree-item:not(.loading),
   .search-result-item:not(.loading) {
     cursor: pointer; }
-  /* line 117, ../../../../general/res/sass/tree/_tree.scss */
+  /* line 116, ../../../../general/res/sass/tree/_tree.scss */
   .tree-item .context-trigger,
   .search-result-item .context-trigger {
     top: -1px;
     position: absolute;
     right: 3px; }
-    /* line 122, ../../../../general/res/sass/tree/_tree.scss */
+    /* line 121, ../../../../general/res/sass/tree/_tree.scss */
     .tree-item .context-trigger .invoke-menu,
     .search-result-item .context-trigger .invoke-menu {
       font-size: 0.75em;
       height: 0.9rem;
       line-height: 0.9rem; }
 
-/* line 135, ../../../../general/res/sass/tree/_tree.scss */
+/* line 134, ../../../../general/res/sass/tree/_tree.scss */
 .tree-item mct-representation.s-status-pending .t-object-label .t-item-icon:before {
   -moz-animation-name: rotateCentered;
   -webkit-animation-name: rotateCentered;
@@ -5808,9 +5808,17 @@ ul.tree {
     -ms-transform: translateX(-50%) translateY(-50%) rotate(359deg);
     -webkit-transform: translateX(-50%) translateY(-50%) rotate(359deg);
     transform: translateX(-50%) translateY(-50%) rotate(359deg); } }
-/* line 147, ../../../../general/res/sass/tree/_tree.scss */
+/* line 146, ../../../../general/res/sass/tree/_tree.scss */
 .tree-item mct-representation.s-status-pending .t-object-label .t-item-icon .t-item-icon-glyph {
   display: none; }
+/* line 150, ../../../../general/res/sass/tree/_tree.scss */
+.tree-item mct-representation.s-status-pending .t-object-label .t-title-label {
+  font-style: italic;
+  opacity: 0.6; }
+/* line 157, ../../../../general/res/sass/tree/_tree.scss */
+.tree-item.selected mct-representation.s-status-pending .t-object-label .t-item-icon:before {
+  border-color: rgba(204, 204, 204, 0.25);
+  border-top-color: #cccccc; }
 
 /*****************************************************************************
  * Open MCT Web, Copyright (c) 2014-2015, United States Government

--- a/platform/commonUI/themes/espresso/res/css/theme-espresso.css
+++ b/platform/commonUI/themes/espresso/res/css/theme-espresso.css
@@ -20,7 +20,7 @@
  * this source code distribution or the Licensing information page available
  * at runtime from the About dialog for additional information.
  *****************************************************************************/
-/* line 5, ../../../../../../../../../../../Library/Ruby/Gems/2.0.0/gems/compass-core-1.0.3/stylesheets/compass/reset/_utilities.scss */
+/* line 5, ../../../../../../../../../../Library/Ruby/Gems/2.0.0/gems/compass-core-1.0.3/stylesheets/compass/reset/_utilities.scss */
 html, body, div, span, applet, object, iframe,
 h1, h2, h3, h4, h5, h6, p, blockquote, pre,
 a, abbr, acronym, address, big, cite, code,
@@ -41,38 +41,38 @@ time, mark, audio, video {
   font-size: 100%;
   vertical-align: baseline; }
 
-/* line 22, ../../../../../../../../../../../Library/Ruby/Gems/2.0.0/gems/compass-core-1.0.3/stylesheets/compass/reset/_utilities.scss */
+/* line 22, ../../../../../../../../../../Library/Ruby/Gems/2.0.0/gems/compass-core-1.0.3/stylesheets/compass/reset/_utilities.scss */
 html {
   line-height: 1; }
 
-/* line 24, ../../../../../../../../../../../Library/Ruby/Gems/2.0.0/gems/compass-core-1.0.3/stylesheets/compass/reset/_utilities.scss */
+/* line 24, ../../../../../../../../../../Library/Ruby/Gems/2.0.0/gems/compass-core-1.0.3/stylesheets/compass/reset/_utilities.scss */
 ol, ul {
   list-style: none; }
 
-/* line 26, ../../../../../../../../../../../Library/Ruby/Gems/2.0.0/gems/compass-core-1.0.3/stylesheets/compass/reset/_utilities.scss */
+/* line 26, ../../../../../../../../../../Library/Ruby/Gems/2.0.0/gems/compass-core-1.0.3/stylesheets/compass/reset/_utilities.scss */
 table {
   border-collapse: collapse;
   border-spacing: 0; }
 
-/* line 28, ../../../../../../../../../../../Library/Ruby/Gems/2.0.0/gems/compass-core-1.0.3/stylesheets/compass/reset/_utilities.scss */
+/* line 28, ../../../../../../../../../../Library/Ruby/Gems/2.0.0/gems/compass-core-1.0.3/stylesheets/compass/reset/_utilities.scss */
 caption, th, td {
   text-align: left;
   font-weight: normal;
   vertical-align: middle; }
 
-/* line 30, ../../../../../../../../../../../Library/Ruby/Gems/2.0.0/gems/compass-core-1.0.3/stylesheets/compass/reset/_utilities.scss */
+/* line 30, ../../../../../../../../../../Library/Ruby/Gems/2.0.0/gems/compass-core-1.0.3/stylesheets/compass/reset/_utilities.scss */
 q, blockquote {
   quotes: none; }
-  /* line 103, ../../../../../../../../../../../Library/Ruby/Gems/2.0.0/gems/compass-core-1.0.3/stylesheets/compass/reset/_utilities.scss */
+  /* line 103, ../../../../../../../../../../Library/Ruby/Gems/2.0.0/gems/compass-core-1.0.3/stylesheets/compass/reset/_utilities.scss */
   q:before, q:after, blockquote:before, blockquote:after {
     content: "";
     content: none; }
 
-/* line 32, ../../../../../../../../../../../Library/Ruby/Gems/2.0.0/gems/compass-core-1.0.3/stylesheets/compass/reset/_utilities.scss */
+/* line 32, ../../../../../../../../../../Library/Ruby/Gems/2.0.0/gems/compass-core-1.0.3/stylesheets/compass/reset/_utilities.scss */
 a img {
   border: none; }
 
-/* line 116, ../../../../../../../../../../../Library/Ruby/Gems/2.0.0/gems/compass-core-1.0.3/stylesheets/compass/reset/_utilities.scss */
+/* line 116, ../../../../../../../../../../Library/Ruby/Gems/2.0.0/gems/compass-core-1.0.3/stylesheets/compass/reset/_utilities.scss */
 article, aside, details, figcaption, figure, footer, header, hgroup, main, menu, nav, section, summary {
   display: block; }
 
@@ -5205,41 +5205,42 @@ span.req {
     -o-transition-delay: 0;
     -webkit-transition-delay: 0;
     transition-delay: 0;
-    pointer-events: none; }
-  /* line 88, ../../../../general/res/sass/search/_search.scss */
+    pointer-events: none;
+    z-index: 1; }
+  /* line 89, ../../../../general/res/sass/search/_search.scss */
   .holder-search .search-bar:hover:before {
     color: #8c8c8c; }
-  /* line 92, ../../../../general/res/sass/search/_search.scss */
+  /* line 93, ../../../../general/res/sass/search/_search.scss */
   .holder-search .search-bar .clear-icon {
     right: 22px;
     visibility: hidden;
     opacity: 0; }
-    /* line 98, ../../../../general/res/sass/search/_search.scss */
+    /* line 99, ../../../../general/res/sass/search/_search.scss */
     .holder-search .search-bar .clear-icon.show {
       visibility: visible;
       opacity: 1; }
-    /* line 103, ../../../../general/res/sass/search/_search.scss */
+    /* line 104, ../../../../general/res/sass/search/_search.scss */
     .holder-search .search-bar .clear-icon:hover {
       color: #8c8c8c; }
-  /* line 108, ../../../../general/res/sass/search/_search.scss */
+  /* line 109, ../../../../general/res/sass/search/_search.scss */
   .holder-search .search-bar .menu-icon {
     font-size: 0.8em;
     padding-right: 4px;
     right: 4px;
     text-align: right; }
-    /* line 110, ../../../../general/res/sass/search/_search.scss */
+    /* line 111, ../../../../general/res/sass/search/_search.scss */
     .holder-search .search-bar .menu-icon:before {
       content: '\76'; }
-    /* line 116, ../../../../general/res/sass/search/_search.scss */
+    /* line 117, ../../../../general/res/sass/search/_search.scss */
     .holder-search .search-bar .menu-icon:hover {
       color: #8c8c8c; }
-  /* line 121, ../../../../general/res/sass/search/_search.scss */
+  /* line 122, ../../../../general/res/sass/search/_search.scss */
   .holder-search .search-bar .search-menu-holder {
     float: right;
     left: -20px;
     z-index: 70;
     transition: visibility .05s, opacity .05s; }
-/* line 129, ../../../../general/res/sass/search/_search.scss */
+/* line 130, ../../../../general/res/sass/search/_search.scss */
 .holder-search .active-filter-display {
   -moz-box-sizing: border-box;
   -webkit-box-sizing: border-box;
@@ -5247,7 +5248,7 @@ span.req {
   line-height: 130%;
   padding-left: 1.4625em;
   font-size: 0.65em; }
-  /* line 137, ../../../../general/res/sass/search/_search.scss */
+  /* line 138, ../../../../general/res/sass/search/_search.scss */
   .holder-search .active-filter-display .clear-filters-icon {
     color: #737373;
     opacity: 1;
@@ -5255,7 +5256,7 @@ span.req {
     position: absolute;
     left: 1px;
     cursor: pointer; }
-/* line 147, ../../../../general/res/sass/search/_search.scss */
+/* line 148, ../../../../general/res/sass/search/_search.scss */
 .holder-search .search-results {
   -moz-transition-property: opacity, visibility;
   -o-transition-property: opacity, visibility;
@@ -5275,16 +5276,16 @@ span.req {
   transition-delay: 0;
   margin-top: 10px;
   padding-right: 5px; }
-  /* line 151, ../../../../general/res/sass/search/_search.scss */
+  /* line 152, ../../../../general/res/sass/search/_search.scss */
   .holder-search .search-results .hint {
     margin-bottom: 10px;
     font-size: 0.65em;
     opacity: 0.6; }
-  /* line 156, ../../../../general/res/sass/search/_search.scss */
+  /* line 157, ../../../../general/res/sass/search/_search.scss */
   .holder-search .search-results.active {
     visibility: visible;
     opacity: 1; }
-  /* line 160, ../../../../general/res/sass/search/_search.scss */
+  /* line 161, ../../../../general/res/sass/search/_search.scss */
   .holder-search .search-results .load-more-button {
     -moz-transform: translateX(-50%);
     -ms-transform: translateX(-50%);
@@ -5299,10 +5300,10 @@ span.req {
 
 @media only screen and (orientation: portrait) and (max-device-width: 767px), only screen and (orientation: landscape) and (max-device-width: 767px) {
   /* line 5, ../../../../general/res/sass/mobile/search/_search.scss */
-  .search .search-bar .menu-icon {
+  .search-holder .search-bar .menu-icon {
     display: none; }
   /* line 8, ../../../../general/res/sass/mobile/search/_search.scss */
-  .search .search-bar .clear-icon {
+  .search-holder .search-bar .clear-icon {
     right: 5px; } }
 /*****************************************************************************
  * Open MCT Web, Copyright (c) 2014-2015, United States Government
@@ -5954,9 +5955,9 @@ mct-representation.s-status-pending .t-object-label .t-title-label {
   /* line 31, ../../../../general/res/sass/mobile/_tree.scss */
   .tree-item,
   .search-result-item {
-    height: 35px;
-    line-height: 35px;
-    margin-bottom: 0px; }
+    height: 35px !important;
+    line-height: 35px !important;
+    margin-bottom: 0px !important; }
     /* line 36, ../../../../general/res/sass/mobile/_tree.scss */
     .tree-item .view-control,
     .search-result-item .view-control {

--- a/platform/commonUI/themes/espresso/res/css/theme-espresso.css
+++ b/platform/commonUI/themes/espresso/res/css/theme-espresso.css
@@ -1251,7 +1251,7 @@ tr[class*="s-limit"].s-limit-lwr td:first-child:before {
     transform: rotate(0deg); }
   100% {
     transform: rotate(359deg); } }
-/* line 63, ../../../../general/res/sass/helpers/_wait-spinner.scss */
+/* line 68, ../../../../general/res/sass/helpers/_wait-spinner.scss */
 .t-wait-spinner,
 .wait-spinner {
   display: block;
@@ -1276,7 +1276,7 @@ tr[class*="s-limit"].s-limit-lwr td:first-child:before {
   margin-top: -5%;
   margin-left: -5%;
   z-index: 2; }
-  /* line 74, ../../../../general/res/sass/helpers/_wait-spinner.scss */
+  /* line 79, ../../../../general/res/sass/helpers/_wait-spinner.scss */
   .t-wait-spinner.inline,
   .wait-spinner.inline {
     display: inline-block !important;
@@ -1284,26 +1284,26 @@ tr[class*="s-limit"].s-limit-lwr td:first-child:before {
     position: relative !important;
     vertical-align: middle; }
 
-/* line 82, ../../../../general/res/sass/helpers/_wait-spinner.scss */
+/* line 87, ../../../../general/res/sass/helpers/_wait-spinner.scss */
 .l-wait-spinner-holder {
   pointer-events: none;
   position: absolute; }
-  /* line 86, ../../../../general/res/sass/helpers/_wait-spinner.scss */
+  /* line 91, ../../../../general/res/sass/helpers/_wait-spinner.scss */
   .l-wait-spinner-holder.align-left .t-wait-spinner {
     left: 0;
     margin-left: 0; }
-  /* line 91, ../../../../general/res/sass/helpers/_wait-spinner.scss */
+  /* line 96, ../../../../general/res/sass/helpers/_wait-spinner.scss */
   .l-wait-spinner-holder.full-size {
     display: inline-block;
     height: 100%;
     width: 100%; }
-    /* line 94, ../../../../general/res/sass/helpers/_wait-spinner.scss */
+    /* line 99, ../../../../general/res/sass/helpers/_wait-spinner.scss */
     .l-wait-spinner-holder.full-size .t-wait-spinner {
       top: 0;
       margin-top: 0;
       padding: 30%; }
 
-/* line 103, ../../../../general/res/sass/helpers/_wait-spinner.scss */
+/* line 108, ../../../../general/res/sass/helpers/_wait-spinner.scss */
 .treeview .wait-spinner {
   display: block;
   position: absolute;
@@ -1325,7 +1325,7 @@ tr[class*="s-limit"].s-limit-lwr td:first-child:before {
   top: 2px;
   left: 0; }
 
-/* line 112, ../../../../general/res/sass/helpers/_wait-spinner.scss */
+/* line 117, ../../../../general/res/sass/helpers/_wait-spinner.scss */
 .wait-spinner.sm {
   display: block;
   position: absolute;
@@ -1348,13 +1348,13 @@ tr[class*="s-limit"].s-limit-lwr td:first-child:before {
   top: 0;
   left: 0; }
 
-/* line 122, ../../../../general/res/sass/helpers/_wait-spinner.scss */
+/* line 127, ../../../../general/res/sass/helpers/_wait-spinner.scss */
 .loading {
   pointer-events: none; }
-  /* line 125, ../../../../general/res/sass/helpers/_wait-spinner.scss */
+  /* line 130, ../../../../general/res/sass/helpers/_wait-spinner.scss */
   .loading:before, .loading:after {
     content: ''; }
-  /* line 129, ../../../../general/res/sass/helpers/_wait-spinner.scss */
+  /* line 134, ../../../../general/res/sass/helpers/_wait-spinner.scss */
   .loading:before {
     -moz-animation-name: rotateCentered;
     -webkit-animation-name: rotateCentered;
@@ -1401,7 +1401,7 @@ tr[class*="s-limit"].s-limit-lwr td:first-child:before {
     transform: translateX(-50%) translateY(-50%) rotate(0deg); }
   100% {
     transform: translateX(-50%) translateY(-50%) rotate(359deg); } }
-  /* line 133, ../../../../general/res/sass/helpers/_wait-spinner.scss */
+  /* line 138, ../../../../general/res/sass/helpers/_wait-spinner.scss */
   .loading:after {
     overflow: hidden;
     position: absolute;
@@ -1414,7 +1414,7 @@ tr[class*="s-limit"].s-limit-lwr td:first-child:before {
     background: rgba(153, 153, 153, 0.2);
     display: block;
     z-index: 9; }
-  /* line 139, ../../../../general/res/sass/helpers/_wait-spinner.scss */
+  /* line 144, ../../../../general/res/sass/helpers/_wait-spinner.scss */
   .loading.tree-item:before {
     padding: 0.375rem;
     border-width: 2px; }
@@ -5599,7 +5599,7 @@ span.req {
  * this source code distribution or the Licensing information page available
  * at runtime from the About dialog for additional information.
  *****************************************************************************/
-/* line 23, ../../../../general/res/sass/tree/_tree.scss */
+/* line 35, ../../../../general/res/sass/tree/_tree.scss */
 ul.tree {
   margin: 0;
   padding: 0;
@@ -5612,15 +5612,15 @@ ul.tree {
     list-style-type: none;
     margin: 0;
     padding: 0; }
-  /* line 26, ../../../../general/res/sass/tree/_tree.scss */
+  /* line 38, ../../../../general/res/sass/tree/_tree.scss */
   ul.tree li {
     display: block;
     position: relative; }
-  /* line 30, ../../../../general/res/sass/tree/_tree.scss */
+  /* line 42, ../../../../general/res/sass/tree/_tree.scss */
   ul.tree ul.tree {
     margin-left: 15px; }
 
-/* line 35, ../../../../general/res/sass/tree/_tree.scss */
+/* line 47, ../../../../general/res/sass/tree/_tree.scss */
 .tree-item,
 .search-result-item {
   -moz-box-sizing: border-box;
@@ -5639,7 +5639,7 @@ ul.tree {
   line-height: 1.5rem;
   margin-bottom: 3px;
   position: relative; }
-  /* line 48, ../../../../general/res/sass/tree/_tree.scss */
+  /* line 60, ../../../../general/res/sass/tree/_tree.scss */
   .tree-item .view-control,
   .search-result-item .view-control {
     color: rgba(255, 255, 255, 0.3);
@@ -5648,14 +5648,12 @@ ul.tree {
     font-size: 0.75em;
     width: 10px; }
     @media only screen and (min-device-width: 1025px) and (-webkit-min-device-pixel-ratio: 1) {
-      /* line 56, ../../../../general/res/sass/tree/_tree.scss */
+      /* line 68, ../../../../general/res/sass/tree/_tree.scss */
       .tree-item .view-control:hover,
       .search-result-item .view-control:hover {
         color: #ffc700 !important; } }
-  /* line 62, ../../../../general/res/sass/tree/_tree.scss */
-  .tree-item .label,
+  /* line 74, ../../../../general/res/sass/tree/_tree.scss */
   .tree-item .t-object-label,
-  .search-result-item .label,
   .search-result-item .t-object-label {
     display: block;
     overflow: hidden;
@@ -5667,10 +5665,8 @@ ul.tree {
     width: auto;
     height: auto;
     line-height: 1.5rem; }
-    /* line 68, ../../../../general/res/sass/tree/_tree.scss */
-    .tree-item .label .t-item-icon,
+    /* line 79, ../../../../general/res/sass/tree/_tree.scss */
     .tree-item .t-object-label .t-item-icon,
-    .search-result-item .label .t-item-icon,
     .search-result-item .t-object-label .t-item-icon {
       text-shadow: rgba(0, 0, 0, 0.6) 0 1px 2px;
       font-size: 1.4em;
@@ -5683,75 +5679,9 @@ ul.tree {
       -ms-transform: translateY(-50%);
       -webkit-transform: translateY(-50%);
       transform: translateY(-50%); }
-    /* line 79, ../../../../general/res/sass/tree/_tree.scss */
-    .tree-item .label .type-icon,
-    .tree-item .t-object-label .type-icon,
-    .search-result-item .label .type-icon,
-    .search-result-item .t-object-label .type-icon {
-      text-shadow: rgba(0, 0, 0, 0.6) 0 1px 2px;
-      font-size: 1.4em;
-      color: #0099cc;
-      left: 5px;
-      position: absolute;
-      top: 4px;
-      bottom: auto;
-      height: 16px;
-      line-height: 100%;
-      right: auto;
-      width: 1.4em; }
-      /* line 92, ../../../../general/res/sass/tree/_tree.scss */
-      .tree-item .label .type-icon .icon.l-icon-link, .tree-item .label .type-icon .l-icon-link.t-item-icon, .tree-item .label .type-icon .icon.l-icon-alert, .tree-item .label .type-icon .l-icon-alert.t-item-icon,
-      .tree-item .t-object-label .type-icon .icon.l-icon-link,
-      .tree-item .t-object-label .type-icon .l-icon-link.t-item-icon,
-      .tree-item .t-object-label .type-icon .icon.l-icon-alert,
-      .tree-item .t-object-label .type-icon .l-icon-alert.t-item-icon,
-      .search-result-item .label .type-icon .icon.l-icon-link,
-      .search-result-item .label .type-icon .l-icon-link.t-item-icon,
-      .search-result-item .label .type-icon .icon.l-icon-alert,
-      .search-result-item .label .type-icon .l-icon-alert.t-item-icon,
-      .search-result-item .t-object-label .type-icon .icon.l-icon-link,
-      .search-result-item .t-object-label .type-icon .l-icon-link.t-item-icon,
-      .search-result-item .t-object-label .type-icon .icon.l-icon-alert,
-      .search-result-item .t-object-label .type-icon .l-icon-alert.t-item-icon {
-        position: absolute;
-        z-index: 2; }
-      /* line 97, ../../../../general/res/sass/tree/_tree.scss */
-      .tree-item .label .type-icon .icon.l-icon-alert, .tree-item .label .type-icon .l-icon-alert.t-item-icon,
-      .tree-item .t-object-label .type-icon .icon.l-icon-alert,
-      .tree-item .t-object-label .type-icon .l-icon-alert.t-item-icon,
-      .search-result-item .label .type-icon .icon.l-icon-alert,
-      .search-result-item .label .type-icon .l-icon-alert.t-item-icon,
-      .search-result-item .t-object-label .type-icon .icon.l-icon-alert,
-      .search-result-item .t-object-label .type-icon .l-icon-alert.t-item-icon {
-        color: #ff3c00;
-        font-size: 8px;
-        line-height: 8px;
-        height: 8px;
-        width: 8px;
-        top: 1px;
-        right: -2px; }
-      /* line 103, ../../../../general/res/sass/tree/_tree.scss */
-      .tree-item .label .type-icon .icon.l-icon-link, .tree-item .label .type-icon .l-icon-link.t-item-icon,
-      .tree-item .t-object-label .type-icon .icon.l-icon-link,
-      .tree-item .t-object-label .type-icon .l-icon-link.t-item-icon,
-      .search-result-item .label .type-icon .icon.l-icon-link,
-      .search-result-item .label .type-icon .l-icon-link.t-item-icon,
-      .search-result-item .t-object-label .type-icon .icon.l-icon-link,
-      .search-result-item .t-object-label .type-icon .l-icon-link.t-item-icon {
-        color: #49dedb;
-        font-size: 8px;
-        line-height: 8px;
-        height: 8px;
-        width: 8px;
-        left: -3px;
-        bottom: 0px; }
-    /* line 111, ../../../../general/res/sass/tree/_tree.scss */
-    .tree-item .label .title-label,
-    .tree-item .label .t-title-label,
+    /* line 83, ../../../../general/res/sass/tree/_tree.scss */
     .tree-item .t-object-label .title-label,
     .tree-item .t-object-label .t-title-label,
-    .search-result-item .label .title-label,
-    .search-result-item .label .t-title-label,
     .search-result-item .t-object-label .title-label,
     .search-result-item .t-object-label .t-title-label {
       overflow: hidden;
@@ -5767,49 +5697,100 @@ ul.tree {
       overflow: hidden;
       text-overflow: ellipsis;
       white-space: nowrap; }
-  /* line 122, ../../../../general/res/sass/tree/_tree.scss */
+  /* line 94, ../../../../general/res/sass/tree/_tree.scss */
   .tree-item.selected,
   .search-result-item.selected {
     background: #006080;
     color: #cccccc; }
-    /* line 125, ../../../../general/res/sass/tree/_tree.scss */
+    /* line 97, ../../../../general/res/sass/tree/_tree.scss */
     .tree-item.selected .view-control,
     .search-result-item.selected .view-control {
       color: rgba(255, 255, 255, 0.3); }
-    /* line 128, ../../../../general/res/sass/tree/_tree.scss */
+    /* line 100, ../../../../general/res/sass/tree/_tree.scss */
     .tree-item.selected .t-object-label .t-item-icon,
     .search-result-item.selected .t-object-label .t-item-icon {
       color: #cccccc; }
   @media only screen and (min-device-width: 1025px) and (-webkit-min-device-pixel-ratio: 1) {
-    /* line 136, ../../../../general/res/sass/tree/_tree.scss */
+    /* line 108, ../../../../general/res/sass/tree/_tree.scss */
     .tree-item:not(.selected):hover,
     .search-result-item:not(.selected):hover {
       background: rgba(153, 153, 153, 0.1);
       color: #cccccc; }
-      /* line 139, ../../../../general/res/sass/tree/_tree.scss */
+      /* line 111, ../../../../general/res/sass/tree/_tree.scss */
       .tree-item:not(.selected):hover .t-item-icon,
       .search-result-item:not(.selected):hover .t-item-icon {
         color: #33ccff; } }
-  /* line 146, ../../../../general/res/sass/tree/_tree.scss */
+  /* line 118, ../../../../general/res/sass/tree/_tree.scss */
   .tree-item:not(.loading),
   .search-result-item:not(.loading) {
     cursor: pointer; }
-  /* line 150, ../../../../general/res/sass/tree/_tree.scss */
+  /* line 122, ../../../../general/res/sass/tree/_tree.scss */
   .tree-item .context-trigger,
   .search-result-item .context-trigger {
     top: -1px;
     position: absolute;
     right: 3px; }
-    /* line 155, ../../../../general/res/sass/tree/_tree.scss */
+    /* line 127, ../../../../general/res/sass/tree/_tree.scss */
     .tree-item .context-trigger .invoke-menu,
     .search-result-item .context-trigger .invoke-menu {
       font-size: 0.75em;
       height: 0.9rem;
       line-height: 0.9rem; }
 
-/* line 164, ../../../../general/res/sass/tree/_tree.scss */
-.tree-item .t-object-label {
+/* line 137, ../../../../general/res/sass/tree/_tree.scss */
+.tree-item mct-representation .t-object-label {
   left: 15px; }
+/* line 142, ../../../../general/res/sass/tree/_tree.scss */
+.tree-item mct-representation.s-status-pending .t-object-label:before {
+  text-shadow: rgba(0, 0, 0, 0.6) 0 1px 2px;
+  font-size: 1.4em;
+  color: #0099cc;
+  position: absolute;
+  left: 5px;
+  top: 50%;
+  width: 1.4em;
+  -moz-transform: translateY(-50%);
+  -ms-transform: translateY(-50%);
+  -webkit-transform: translateY(-50%);
+  transform: translateY(-50%);
+  -moz-animation-name: rotateCentered;
+  -webkit-animation-name: rotateCentered;
+  animation-name: rotateCentered;
+  -moz-animation-duration: 0.5s;
+  -webkit-animation-duration: 0.5s;
+  animation-duration: 0.5s;
+  -moz-animation-iteration-count: infinite;
+  -webkit-animation-iteration-count: infinite;
+  animation-iteration-count: infinite;
+  -moz-animation-timing-function: linear;
+  -webkit-animation-timing-function: linear;
+  animation-timing-function: linear;
+  border-color: rgba(0, 0, 255, 0.25);
+  border-top-color: blue;
+  border-style: solid;
+  border-width: 2px;
+  -moz-border-radius: 100%;
+  -webkit-border-radius: 100%;
+  border-radius: 100%;
+  content: ""; }
+@-moz-keyframes rotateCentered {
+  0% {
+    transform: translateX(-50%) translateY(-50%) rotate(0deg); }
+  100% {
+    transform: translateX(-50%) translateY(-50%) rotate(359deg); } }
+@-webkit-keyframes rotateCentered {
+  0% {
+    transform: translateX(-50%) translateY(-50%) rotate(0deg); }
+  100% {
+    transform: translateX(-50%) translateY(-50%) rotate(359deg); } }
+@keyframes rotateCentered {
+  0% {
+    transform: translateX(-50%) translateY(-50%) rotate(0deg); }
+  100% {
+    transform: translateX(-50%) translateY(-50%) rotate(359deg); } }
+/* line 147, ../../../../general/res/sass/tree/_tree.scss */
+.tree-item mct-representation.s-status-pending .t-object-label .t-item-icon .t-item-icon-glyph {
+  display: none; }
 
 /*****************************************************************************
  * Open MCT Web, Copyright (c) 2014-2015, United States Government

--- a/platform/commonUI/themes/snow/res/css/theme-snow.css
+++ b/platform/commonUI/themes/snow/res/css/theme-snow.css
@@ -520,34 +520,40 @@ mct-container {
 
 /********************************************* FLEX STYLES */
 /* line 95, ../../../../general/res/sass/_archetypes.scss */
-.l-flex-row,
+.l-flex-row, .tree-item,
+.search-result-item,
 .l-flex-col {
   display: -webkit-flex;
   display: flex;
   -webkit-flex-wrap: nowrap;
   flex-wrap: nowrap; }
   /* line 99, ../../../../general/res/sass/_archetypes.scss */
-  .l-flex-row .flex-elem,
+  .l-flex-row .flex-elem, .tree-item .flex-elem,
+  .search-result-item .flex-elem,
   .l-flex-col .flex-elem {
     min-height: 0;
     position: relative; }
     /* line 102, ../../../../general/res/sass/_archetypes.scss */
-    .l-flex-row .flex-elem:not(.grows),
+    .l-flex-row .flex-elem:not(.grows), .tree-item .flex-elem:not(.grows),
+    .search-result-item .flex-elem:not(.grows),
     .l-flex-col .flex-elem:not(.grows) {
       -webkit-flex: 0 0 auto;
       flex: 0 0 auto; }
       /* line 104, ../../../../general/res/sass/_archetypes.scss */
-      .l-flex-row .flex-elem:not(.grows).flex-can-shrink,
+      .l-flex-row .flex-elem:not(.grows).flex-can-shrink, .tree-item .flex-elem:not(.grows).flex-can-shrink,
+      .search-result-item .flex-elem:not(.grows).flex-can-shrink,
       .l-flex-col .flex-elem:not(.grows).flex-can-shrink {
         -webkit-flex: 0 1 auto;
         flex: 0 1 auto; }
     /* line 108, ../../../../general/res/sass/_archetypes.scss */
-    .l-flex-row .flex-elem.grows,
+    .l-flex-row .flex-elem.grows, .tree-item .flex-elem.grows,
+    .search-result-item .flex-elem.grows,
     .l-flex-col .flex-elem.grows {
       -webkit-flex: 1 1 auto;
       flex: 1 1 auto; }
   /* line 112, ../../../../general/res/sass/_archetypes.scss */
-  .l-flex-row .flex-container,
+  .l-flex-row .flex-container, .tree-item .flex-container,
+  .search-result-item .flex-container,
   .l-flex-col .flex-container {
     display: -webkit-flex;
     display: flex;
@@ -558,20 +564,24 @@ mct-container {
     min-height: 0; }
 
 /* line 121, ../../../../general/res/sass/_archetypes.scss */
-.l-flex-row {
+.l-flex-row, .tree-item,
+.search-result-item {
   -webkit-flex-direction: row;
   flex-direction: row; }
   /* line 123, ../../../../general/res/sass/_archetypes.scss */
-  .l-flex-row.flex-elem {
+  .l-flex-row.flex-elem, .flex-elem.tree-item,
+  .flex-elem.search-result-item {
     -webkit-flex: 1 1 auto;
     flex: 1 1 auto; }
   /* line 124, ../../../../general/res/sass/_archetypes.scss */
-  .l-flex-row .flex-elem {
+  .l-flex-row .flex-elem, .tree-item .flex-elem,
+  .search-result-item .flex-elem {
     height: inherit;
     line-height: inherit;
     min-width: 0; }
   /* line 129, ../../../../general/res/sass/_archetypes.scss */
-  .l-flex-row .flex-container {
+  .l-flex-row .flex-container, .tree-item .flex-container,
+  .search-result-item .flex-container {
     -webkit-flex-direction: row;
     flex-direction: row; }
 
@@ -1351,8 +1361,6 @@ tr[class*="s-limit"].s-limit-lwr td:first-child:before {
     -moz-animation-timing-function: linear;
     -webkit-animation-timing-function: linear;
     animation-timing-function: linear;
-    border-color: rgba(119, 107, 162, 0.25);
-    border-top-color: #776ba2;
     border-style: solid;
     border-width: 5px;
     -moz-border-radius: 100%;
@@ -1361,6 +1369,8 @@ tr[class*="s-limit"].s-limit-lwr td:first-child:before {
     -moz-box-sizing: border-box;
     -webkit-box-sizing: border-box;
     box-sizing: border-box;
+    border-color: rgba(119, 107, 162, 0.25);
+    border-top-color: #776ba2;
     display: block;
     position: absolute;
     height: 0;
@@ -5555,7 +5565,7 @@ ul.tree {
   margin-bottom: 3px;
   padding: 0 3px;
   position: relative; }
-  /* line 48, ../../../../general/res/sass/tree/_tree.scss */
+  /* line 49, ../../../../general/res/sass/tree/_tree.scss */
   .tree-item .view-control,
   .search-result-item .view-control {
     color: #666;
@@ -5564,7 +5574,7 @@ ul.tree {
     height: 100%;
     line-height: inherit;
     width: 10px; }
-    /* line 56, ../../../../general/res/sass/tree/_tree.scss */
+    /* line 57, ../../../../general/res/sass/tree/_tree.scss */
     .tree-item .view-control.has-children:before,
     .search-result-item .view-control.has-children:before {
       position: absolute;
@@ -5589,7 +5599,7 @@ ul.tree {
       -ms-transform-origin: center 50%;
       -webkit-transform-origin: center 50%;
       transform-origin: center 50%; }
-    /* line 62, ../../../../general/res/sass/tree/_tree.scss */
+    /* line 63, ../../../../general/res/sass/tree/_tree.scss */
     .tree-item .view-control.has-children.expanded:before,
     .search-result-item .view-control.has-children.expanded:before {
       -moz-transform: rotate(90deg);
@@ -5597,11 +5607,11 @@ ul.tree {
       -webkit-transform: rotate(90deg);
       transform: rotate(90deg); }
     @media only screen and (min-device-width: 1025px) and (-webkit-min-device-pixel-ratio: 1) {
-      /* line 67, ../../../../general/res/sass/tree/_tree.scss */
+      /* line 68, ../../../../general/res/sass/tree/_tree.scss */
       .tree-item .view-control:hover,
       .search-result-item .view-control:hover {
         color: #0099cc !important; } }
-  /* line 73, ../../../../general/res/sass/tree/_tree.scss */
+  /* line 74, ../../../../general/res/sass/tree/_tree.scss */
   .tree-item .t-object-label,
   .search-result-item .t-object-label {
     line-height: 1.5rem; }
@@ -5610,58 +5620,49 @@ ul.tree {
     .search-result-item .t-object-label .t-item-icon {
       font-size: 1.4em;
       color: #0099cc;
-      margin-right: 5px;
       width: 18px; }
-    /* line 83, ../../../../general/res/sass/tree/_tree.scss */
-    .tree-item .t-object-label .title-label,
-    .tree-item .t-object-label .t-title-label,
-    .search-result-item .t-object-label .title-label,
-    .search-result-item .t-object-label .t-title-label {
-      overflow: hidden;
-      text-overflow: ellipsis;
-      white-space: nowrap; }
-  /* line 89, ../../../../general/res/sass/tree/_tree.scss */
+  /* line 84, ../../../../general/res/sass/tree/_tree.scss */
   .tree-item.selected,
   .search-result-item.selected {
     background: #1ac6ff;
     color: #fcfcfc; }
-    /* line 92, ../../../../general/res/sass/tree/_tree.scss */
+    /* line 87, ../../../../general/res/sass/tree/_tree.scss */
     .tree-item.selected .view-control,
     .search-result-item.selected .view-control {
       color: #fcfcfc; }
-    /* line 95, ../../../../general/res/sass/tree/_tree.scss */
+    /* line 90, ../../../../general/res/sass/tree/_tree.scss */
     .tree-item.selected .t-object-label .t-item-icon,
     .search-result-item.selected .t-object-label .t-item-icon {
       color: #fcfcfc; }
   @media only screen and (min-device-width: 1025px) and (-webkit-min-device-pixel-ratio: 1) {
-    /* line 102, ../../../../general/res/sass/tree/_tree.scss */
+    /* line 97, ../../../../general/res/sass/tree/_tree.scss */
     .tree-item:not(.selected):hover,
     .search-result-item:not(.selected):hover {
       background: rgba(102, 102, 102, 0.1);
       color: #333333; }
-      /* line 105, ../../../../general/res/sass/tree/_tree.scss */
+      /* line 100, ../../../../general/res/sass/tree/_tree.scss */
       .tree-item:not(.selected):hover .t-item-icon,
       .search-result-item:not(.selected):hover .t-item-icon {
         color: #0099cc; } }
-  /* line 112, ../../../../general/res/sass/tree/_tree.scss */
+  /* line 107, ../../../../general/res/sass/tree/_tree.scss */
   .tree-item:not(.loading),
   .search-result-item:not(.loading) {
     cursor: pointer; }
-  /* line 116, ../../../../general/res/sass/tree/_tree.scss */
+  /* line 111, ../../../../general/res/sass/tree/_tree.scss */
   .tree-item .context-trigger,
   .search-result-item .context-trigger {
     top: -1px;
     position: absolute;
     right: 3px; }
-    /* line 121, ../../../../general/res/sass/tree/_tree.scss */
+    /* line 116, ../../../../general/res/sass/tree/_tree.scss */
     .tree-item .context-trigger .invoke-menu,
     .search-result-item .context-trigger .invoke-menu {
       font-size: 0.75em;
       height: 0.9rem;
       line-height: 0.9rem; }
 
-/* line 134, ../../../../general/res/sass/tree/_tree.scss */
-.tree-item mct-representation.s-status-pending .t-object-label .t-item-icon:before {
+/* line 128, ../../../../general/res/sass/tree/_tree.scss */
+mct-representation.s-status-pending .t-object-label .t-item-icon:before {
   -moz-animation-name: rotateCentered;
   -webkit-animation-name: rotateCentered;
   animation-name: rotateCentered;
@@ -5674,18 +5675,13 @@ ul.tree {
   -moz-animation-timing-function: linear;
   -webkit-animation-timing-function: linear;
   animation-timing-function: linear;
-  border-color: rgba(0, 153, 204, 0.25);
-  border-top-color: #0099cc;
   border-style: solid;
   border-width: 4px;
   -moz-border-radius: 100%;
   -webkit-border-radius: 100%;
   border-radius: 100%;
-  content: "";
-  display: block;
-  position: absolute;
-  left: 50%;
-  top: 50%;
+  border-color: rgba(0, 153, 204, 0.25);
+  border-top-color: #0099cc;
   width: 10px;
   height: 10px; }
 @-moz-keyframes rotateCentered {
@@ -5713,15 +5709,121 @@ ul.tree {
     -ms-transform: translateX(-50%) translateY(-50%) rotate(359deg);
     -webkit-transform: translateX(-50%) translateY(-50%) rotate(359deg);
     transform: translateX(-50%) translateY(-50%) rotate(359deg); } }
-/* line 146, ../../../../general/res/sass/tree/_tree.scss */
-.tree-item mct-representation.s-status-pending .t-object-label .t-item-icon .t-item-icon-glyph {
+/* line 142, ../../../../general/res/sass/tree/_tree.scss */
+mct-representation.s-status-pending .t-object-label .t-item-icon .t-item-icon-glyph {
   display: none; }
-/* line 150, ../../../../general/res/sass/tree/_tree.scss */
-.tree-item mct-representation.s-status-pending .t-object-label .t-title-label {
+/* line 146, ../../../../general/res/sass/tree/_tree.scss */
+mct-representation.s-status-pending .t-object-label .t-title-label {
   font-style: italic;
   opacity: 0.6; }
-/* line 157, ../../../../general/res/sass/tree/_tree.scss */
-.tree-item.selected mct-representation.s-status-pending .t-object-label .t-item-icon:before {
+
+/* line 153, ../../../../general/res/sass/tree/_tree.scss */
+.selected mct-representation.s-status-pending .t-object-label .t-item-icon:before {
+  border-color: rgba(252, 252, 252, 0.25);
+  border-top-color: #fcfcfc; }
+
+/*****************************************************************************
+ * Open MCT Web, Copyright (c) 2014-2015, United States Government
+ * as represented by the Administrator of the National Aeronautics and Space
+ * Administration. All rights reserved.
+ *
+ * Open MCT Web is licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * Open MCT Web includes source code licensed under additional open source
+ * licenses. See the Open Source Licenses file (LICENSES.md) included with
+ * this source code distribution or the Licensing information page available
+ * at runtime from the About dialog for additional information.
+ *****************************************************************************/
+/* line 24, ../../../../general/res/sass/_object-label.scss */
+.rep-object-label {
+  -webkit-flex-direction: row;
+  flex-direction: row;
+  -webkit-flex: 1 1 auto;
+  flex: 1 1 auto;
+  height: inherit;
+  line-height: inherit;
+  min-width: 0; }
+
+/* line 33, ../../../../general/res/sass/_object-label.scss */
+.t-object-label .t-item-icon {
+  margin-right: 5px; }
+/* line 36, ../../../../general/res/sass/_object-label.scss */
+.t-object-label .t-title-label {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap; }
+
+/* line 45, ../../../../general/res/sass/_object-label.scss */
+mct-representation.s-status-pending .t-object-label .t-item-icon:before {
+  -moz-animation-name: rotateCentered;
+  -webkit-animation-name: rotateCentered;
+  animation-name: rotateCentered;
+  -moz-animation-duration: 0.5s;
+  -webkit-animation-duration: 0.5s;
+  animation-duration: 0.5s;
+  -moz-animation-iteration-count: infinite;
+  -webkit-animation-iteration-count: infinite;
+  animation-iteration-count: infinite;
+  -moz-animation-timing-function: linear;
+  -webkit-animation-timing-function: linear;
+  animation-timing-function: linear;
+  border-style: solid;
+  border-width: 4px;
+  -moz-border-radius: 100%;
+  -webkit-border-radius: 100%;
+  border-radius: 100%;
+  content: "";
+  display: block;
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  padding: 35%;
+  width: 0;
+  height: 0; }
+@-moz-keyframes rotateCentered {
+  0% {
+    -moz-transform: translateX(-50%) translateY(-50%) rotate(0deg);
+    transform: translateX(-50%) translateY(-50%) rotate(0deg); }
+  100% {
+    -moz-transform: translateX(-50%) translateY(-50%) rotate(359deg);
+    transform: translateX(-50%) translateY(-50%) rotate(359deg); } }
+@-webkit-keyframes rotateCentered {
+  0% {
+    -webkit-transform: translateX(-50%) translateY(-50%) rotate(0deg);
+    transform: translateX(-50%) translateY(-50%) rotate(0deg); }
+  100% {
+    -webkit-transform: translateX(-50%) translateY(-50%) rotate(359deg);
+    transform: translateX(-50%) translateY(-50%) rotate(359deg); } }
+@keyframes rotateCentered {
+  0% {
+    -moz-transform: translateX(-50%) translateY(-50%) rotate(0deg);
+    -ms-transform: translateX(-50%) translateY(-50%) rotate(0deg);
+    -webkit-transform: translateX(-50%) translateY(-50%) rotate(0deg);
+    transform: translateX(-50%) translateY(-50%) rotate(0deg); }
+  100% {
+    -moz-transform: translateX(-50%) translateY(-50%) rotate(359deg);
+    -ms-transform: translateX(-50%) translateY(-50%) rotate(359deg);
+    -webkit-transform: translateX(-50%) translateY(-50%) rotate(359deg);
+    transform: translateX(-50%) translateY(-50%) rotate(359deg); } }
+/* line 58, ../../../../general/res/sass/_object-label.scss */
+mct-representation.s-status-pending .t-object-label .t-item-icon .t-item-icon-glyph {
+  display: none; }
+/* line 62, ../../../../general/res/sass/_object-label.scss */
+mct-representation.s-status-pending .t-object-label .t-title-label {
+  font-style: italic;
+  opacity: 0.6; }
+
+/* line 69, ../../../../general/res/sass/_object-label.scss */
+.selected mct-representation.s-status-pending .t-object-label .t-item-icon:before {
   border-color: rgba(252, 252, 252, 0.25);
   border-top-color: #fcfcfc; }
 

--- a/platform/commonUI/themes/snow/res/css/theme-snow.css
+++ b/platform/commonUI/themes/snow/res/css/theme-snow.css
@@ -5621,47 +5621,53 @@ ul.tree {
       font-size: 1.4em;
       color: #0099cc;
       width: 18px; }
-  /* line 84, ../../../../general/res/sass/tree/_tree.scss */
+    /* line 82, ../../../../general/res/sass/tree/_tree.scss */
+    .tree-item .t-object-label .t-title-label,
+    .search-result-item .t-object-label .t-title-label {
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap; }
+  /* line 87, ../../../../general/res/sass/tree/_tree.scss */
   .tree-item.selected,
   .search-result-item.selected {
     background: #1ac6ff;
     color: #fcfcfc; }
-    /* line 87, ../../../../general/res/sass/tree/_tree.scss */
+    /* line 90, ../../../../general/res/sass/tree/_tree.scss */
     .tree-item.selected .view-control,
     .search-result-item.selected .view-control {
       color: #fcfcfc; }
-    /* line 90, ../../../../general/res/sass/tree/_tree.scss */
+    /* line 93, ../../../../general/res/sass/tree/_tree.scss */
     .tree-item.selected .t-object-label .t-item-icon,
     .search-result-item.selected .t-object-label .t-item-icon {
       color: #fcfcfc; }
   @media only screen and (min-device-width: 1025px) and (-webkit-min-device-pixel-ratio: 1) {
-    /* line 97, ../../../../general/res/sass/tree/_tree.scss */
+    /* line 100, ../../../../general/res/sass/tree/_tree.scss */
     .tree-item:not(.selected):hover,
     .search-result-item:not(.selected):hover {
       background: rgba(102, 102, 102, 0.1);
       color: #333333; }
-      /* line 100, ../../../../general/res/sass/tree/_tree.scss */
+      /* line 103, ../../../../general/res/sass/tree/_tree.scss */
       .tree-item:not(.selected):hover .t-item-icon,
       .search-result-item:not(.selected):hover .t-item-icon {
         color: #0099cc; } }
-  /* line 107, ../../../../general/res/sass/tree/_tree.scss */
+  /* line 110, ../../../../general/res/sass/tree/_tree.scss */
   .tree-item:not(.loading),
   .search-result-item:not(.loading) {
     cursor: pointer; }
-  /* line 111, ../../../../general/res/sass/tree/_tree.scss */
+  /* line 114, ../../../../general/res/sass/tree/_tree.scss */
   .tree-item .context-trigger,
   .search-result-item .context-trigger {
     top: -1px;
     position: absolute;
     right: 3px; }
-    /* line 116, ../../../../general/res/sass/tree/_tree.scss */
+    /* line 119, ../../../../general/res/sass/tree/_tree.scss */
     .tree-item .context-trigger .invoke-menu,
     .search-result-item .context-trigger .invoke-menu {
       font-size: 0.75em;
       height: 0.9rem;
       line-height: 0.9rem; }
 
-/* line 128, ../../../../general/res/sass/tree/_tree.scss */
+/* line 131, ../../../../general/res/sass/tree/_tree.scss */
 mct-representation.s-status-pending .t-object-label .t-item-icon:before {
   -moz-animation-name: rotateCentered;
   -webkit-animation-name: rotateCentered;
@@ -5709,15 +5715,15 @@ mct-representation.s-status-pending .t-object-label .t-item-icon:before {
     -ms-transform: translateX(-50%) translateY(-50%) rotate(359deg);
     -webkit-transform: translateX(-50%) translateY(-50%) rotate(359deg);
     transform: translateX(-50%) translateY(-50%) rotate(359deg); } }
-/* line 142, ../../../../general/res/sass/tree/_tree.scss */
+/* line 145, ../../../../general/res/sass/tree/_tree.scss */
 mct-representation.s-status-pending .t-object-label .t-item-icon .t-item-icon-glyph {
   display: none; }
-/* line 146, ../../../../general/res/sass/tree/_tree.scss */
+/* line 149, ../../../../general/res/sass/tree/_tree.scss */
 mct-representation.s-status-pending .t-object-label .t-title-label {
   font-style: italic;
   opacity: 0.6; }
 
-/* line 153, ../../../../general/res/sass/tree/_tree.scss */
+/* line 156, ../../../../general/res/sass/tree/_tree.scss */
 .selected mct-representation.s-status-pending .t-object-label .t-item-icon:before {
   border-color: rgba(252, 252, 252, 0.25);
   border-top-color: #fcfcfc; }
@@ -5756,13 +5762,8 @@ mct-representation.s-status-pending .t-object-label .t-title-label {
 /* line 33, ../../../../general/res/sass/_object-label.scss */
 .t-object-label .t-item-icon {
   margin-right: 5px; }
-/* line 36, ../../../../general/res/sass/_object-label.scss */
-.t-object-label .t-title-label {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap; }
 
-/* line 45, ../../../../general/res/sass/_object-label.scss */
+/* line 42, ../../../../general/res/sass/_object-label.scss */
 mct-representation.s-status-pending .t-object-label .t-item-icon:before {
   -moz-animation-name: rotateCentered;
   -webkit-animation-name: rotateCentered;
@@ -5814,15 +5815,15 @@ mct-representation.s-status-pending .t-object-label .t-item-icon:before {
     -ms-transform: translateX(-50%) translateY(-50%) rotate(359deg);
     -webkit-transform: translateX(-50%) translateY(-50%) rotate(359deg);
     transform: translateX(-50%) translateY(-50%) rotate(359deg); } }
-/* line 58, ../../../../general/res/sass/_object-label.scss */
+/* line 55, ../../../../general/res/sass/_object-label.scss */
 mct-representation.s-status-pending .t-object-label .t-item-icon .t-item-icon-glyph {
   display: none; }
-/* line 62, ../../../../general/res/sass/_object-label.scss */
+/* line 59, ../../../../general/res/sass/_object-label.scss */
 mct-representation.s-status-pending .t-object-label .t-title-label {
   font-style: italic;
   opacity: 0.6; }
 
-/* line 69, ../../../../general/res/sass/_object-label.scss */
+/* line 66, ../../../../general/res/sass/_object-label.scss */
 .selected mct-representation.s-status-pending .t-object-label .t-item-icon:before {
   border-color: rgba(252, 252, 252, 0.25);
   border-top-color: #fcfcfc; }

--- a/platform/commonUI/themes/snow/res/css/theme-snow.css
+++ b/platform/commonUI/themes/snow/res/css/theme-snow.css
@@ -20,7 +20,7 @@
  * this source code distribution or the Licensing information page available
  * at runtime from the About dialog for additional information.
  *****************************************************************************/
-/* line 5, ../../../../../../../../../../Library/Ruby/Gems/2.0.0/gems/compass-core-1.0.3/stylesheets/compass/reset/_utilities.scss */
+/* line 5, ../../../../../../../../../../../Library/Ruby/Gems/2.0.0/gems/compass-core-1.0.3/stylesheets/compass/reset/_utilities.scss */
 html, body, div, span, applet, object, iframe,
 h1, h2, h3, h4, h5, h6, p, blockquote, pre,
 a, abbr, acronym, address, big, cite, code,
@@ -41,38 +41,38 @@ time, mark, audio, video {
   font-size: 100%;
   vertical-align: baseline; }
 
-/* line 22, ../../../../../../../../../../Library/Ruby/Gems/2.0.0/gems/compass-core-1.0.3/stylesheets/compass/reset/_utilities.scss */
+/* line 22, ../../../../../../../../../../../Library/Ruby/Gems/2.0.0/gems/compass-core-1.0.3/stylesheets/compass/reset/_utilities.scss */
 html {
   line-height: 1; }
 
-/* line 24, ../../../../../../../../../../Library/Ruby/Gems/2.0.0/gems/compass-core-1.0.3/stylesheets/compass/reset/_utilities.scss */
+/* line 24, ../../../../../../../../../../../Library/Ruby/Gems/2.0.0/gems/compass-core-1.0.3/stylesheets/compass/reset/_utilities.scss */
 ol, ul {
   list-style: none; }
 
-/* line 26, ../../../../../../../../../../Library/Ruby/Gems/2.0.0/gems/compass-core-1.0.3/stylesheets/compass/reset/_utilities.scss */
+/* line 26, ../../../../../../../../../../../Library/Ruby/Gems/2.0.0/gems/compass-core-1.0.3/stylesheets/compass/reset/_utilities.scss */
 table {
   border-collapse: collapse;
   border-spacing: 0; }
 
-/* line 28, ../../../../../../../../../../Library/Ruby/Gems/2.0.0/gems/compass-core-1.0.3/stylesheets/compass/reset/_utilities.scss */
+/* line 28, ../../../../../../../../../../../Library/Ruby/Gems/2.0.0/gems/compass-core-1.0.3/stylesheets/compass/reset/_utilities.scss */
 caption, th, td {
   text-align: left;
   font-weight: normal;
   vertical-align: middle; }
 
-/* line 30, ../../../../../../../../../../Library/Ruby/Gems/2.0.0/gems/compass-core-1.0.3/stylesheets/compass/reset/_utilities.scss */
+/* line 30, ../../../../../../../../../../../Library/Ruby/Gems/2.0.0/gems/compass-core-1.0.3/stylesheets/compass/reset/_utilities.scss */
 q, blockquote {
   quotes: none; }
-  /* line 103, ../../../../../../../../../../Library/Ruby/Gems/2.0.0/gems/compass-core-1.0.3/stylesheets/compass/reset/_utilities.scss */
+  /* line 103, ../../../../../../../../../../../Library/Ruby/Gems/2.0.0/gems/compass-core-1.0.3/stylesheets/compass/reset/_utilities.scss */
   q:before, q:after, blockquote:before, blockquote:after {
     content: "";
     content: none; }
 
-/* line 32, ../../../../../../../../../../Library/Ruby/Gems/2.0.0/gems/compass-core-1.0.3/stylesheets/compass/reset/_utilities.scss */
+/* line 32, ../../../../../../../../../../../Library/Ruby/Gems/2.0.0/gems/compass-core-1.0.3/stylesheets/compass/reset/_utilities.scss */
 a img {
   border: none; }
 
-/* line 116, ../../../../../../../../../../Library/Ruby/Gems/2.0.0/gems/compass-core-1.0.3/stylesheets/compass/reset/_utilities.scss */
+/* line 116, ../../../../../../../../../../../Library/Ruby/Gems/2.0.0/gems/compass-core-1.0.3/stylesheets/compass/reset/_utilities.scss */
 article, aside, details, figcaption, figure, footer, header, hgroup, main, menu, nav, section, summary {
   display: block; }
 
@@ -5632,33 +5632,33 @@ ul.tree {
     .search-result-item.selected .t-object-label .t-item-icon {
       color: #fcfcfc; }
   @media only screen and (min-device-width: 1025px) and (-webkit-min-device-pixel-ratio: 1) {
-    /* line 103, ../../../../general/res/sass/tree/_tree.scss */
+    /* line 102, ../../../../general/res/sass/tree/_tree.scss */
     .tree-item:not(.selected):hover,
     .search-result-item:not(.selected):hover {
       background: rgba(102, 102, 102, 0.1);
       color: #333333; }
-      /* line 106, ../../../../general/res/sass/tree/_tree.scss */
+      /* line 105, ../../../../general/res/sass/tree/_tree.scss */
       .tree-item:not(.selected):hover .t-item-icon,
       .search-result-item:not(.selected):hover .t-item-icon {
         color: #0099cc; } }
-  /* line 113, ../../../../general/res/sass/tree/_tree.scss */
+  /* line 112, ../../../../general/res/sass/tree/_tree.scss */
   .tree-item:not(.loading),
   .search-result-item:not(.loading) {
     cursor: pointer; }
-  /* line 117, ../../../../general/res/sass/tree/_tree.scss */
+  /* line 116, ../../../../general/res/sass/tree/_tree.scss */
   .tree-item .context-trigger,
   .search-result-item .context-trigger {
     top: -1px;
     position: absolute;
     right: 3px; }
-    /* line 122, ../../../../general/res/sass/tree/_tree.scss */
+    /* line 121, ../../../../general/res/sass/tree/_tree.scss */
     .tree-item .context-trigger .invoke-menu,
     .search-result-item .context-trigger .invoke-menu {
       font-size: 0.75em;
       height: 0.9rem;
       line-height: 0.9rem; }
 
-/* line 135, ../../../../general/res/sass/tree/_tree.scss */
+/* line 134, ../../../../general/res/sass/tree/_tree.scss */
 .tree-item mct-representation.s-status-pending .t-object-label .t-item-icon:before {
   -moz-animation-name: rotateCentered;
   -webkit-animation-name: rotateCentered;
@@ -5711,9 +5711,17 @@ ul.tree {
     -ms-transform: translateX(-50%) translateY(-50%) rotate(359deg);
     -webkit-transform: translateX(-50%) translateY(-50%) rotate(359deg);
     transform: translateX(-50%) translateY(-50%) rotate(359deg); } }
-/* line 147, ../../../../general/res/sass/tree/_tree.scss */
+/* line 146, ../../../../general/res/sass/tree/_tree.scss */
 .tree-item mct-representation.s-status-pending .t-object-label .t-item-icon .t-item-icon-glyph {
   display: none; }
+/* line 150, ../../../../general/res/sass/tree/_tree.scss */
+.tree-item mct-representation.s-status-pending .t-object-label .t-title-label {
+  font-style: italic;
+  opacity: 0.6; }
+/* line 157, ../../../../general/res/sass/tree/_tree.scss */
+.tree-item.selected mct-representation.s-status-pending .t-object-label .t-item-icon:before {
+  border-color: rgba(252, 252, 252, 0.25);
+  border-top-color: #fcfcfc; }
 
 /*****************************************************************************
  * Open MCT Web, Copyright (c) 2014-2015, United States Government

--- a/platform/commonUI/themes/snow/res/css/theme-snow.css
+++ b/platform/commonUI/themes/snow/res/css/theme-snow.css
@@ -1232,7 +1232,7 @@ tr[class*="s-limit"].s-limit-lwr td:first-child:before {
     transform: rotate(0deg); }
   100% {
     transform: rotate(359deg); } }
-/* line 63, ../../../../general/res/sass/helpers/_wait-spinner.scss */
+/* line 68, ../../../../general/res/sass/helpers/_wait-spinner.scss */
 .t-wait-spinner,
 .wait-spinner {
   display: block;
@@ -1257,7 +1257,7 @@ tr[class*="s-limit"].s-limit-lwr td:first-child:before {
   margin-top: -5%;
   margin-left: -5%;
   z-index: 2; }
-  /* line 74, ../../../../general/res/sass/helpers/_wait-spinner.scss */
+  /* line 79, ../../../../general/res/sass/helpers/_wait-spinner.scss */
   .t-wait-spinner.inline,
   .wait-spinner.inline {
     display: inline-block !important;
@@ -1265,26 +1265,26 @@ tr[class*="s-limit"].s-limit-lwr td:first-child:before {
     position: relative !important;
     vertical-align: middle; }
 
-/* line 82, ../../../../general/res/sass/helpers/_wait-spinner.scss */
+/* line 87, ../../../../general/res/sass/helpers/_wait-spinner.scss */
 .l-wait-spinner-holder {
   pointer-events: none;
   position: absolute; }
-  /* line 86, ../../../../general/res/sass/helpers/_wait-spinner.scss */
+  /* line 91, ../../../../general/res/sass/helpers/_wait-spinner.scss */
   .l-wait-spinner-holder.align-left .t-wait-spinner {
     left: 0;
     margin-left: 0; }
-  /* line 91, ../../../../general/res/sass/helpers/_wait-spinner.scss */
+  /* line 96, ../../../../general/res/sass/helpers/_wait-spinner.scss */
   .l-wait-spinner-holder.full-size {
     display: inline-block;
     height: 100%;
     width: 100%; }
-    /* line 94, ../../../../general/res/sass/helpers/_wait-spinner.scss */
+    /* line 99, ../../../../general/res/sass/helpers/_wait-spinner.scss */
     .l-wait-spinner-holder.full-size .t-wait-spinner {
       top: 0;
       margin-top: 0;
       padding: 30%; }
 
-/* line 103, ../../../../general/res/sass/helpers/_wait-spinner.scss */
+/* line 108, ../../../../general/res/sass/helpers/_wait-spinner.scss */
 .treeview .wait-spinner {
   display: block;
   position: absolute;
@@ -1306,7 +1306,7 @@ tr[class*="s-limit"].s-limit-lwr td:first-child:before {
   top: 2px;
   left: 0; }
 
-/* line 112, ../../../../general/res/sass/helpers/_wait-spinner.scss */
+/* line 117, ../../../../general/res/sass/helpers/_wait-spinner.scss */
 .wait-spinner.sm {
   display: block;
   position: absolute;
@@ -1329,13 +1329,13 @@ tr[class*="s-limit"].s-limit-lwr td:first-child:before {
   top: 0;
   left: 0; }
 
-/* line 122, ../../../../general/res/sass/helpers/_wait-spinner.scss */
+/* line 127, ../../../../general/res/sass/helpers/_wait-spinner.scss */
 .loading {
   pointer-events: none; }
-  /* line 125, ../../../../general/res/sass/helpers/_wait-spinner.scss */
+  /* line 130, ../../../../general/res/sass/helpers/_wait-spinner.scss */
   .loading:before, .loading:after {
     content: ''; }
-  /* line 129, ../../../../general/res/sass/helpers/_wait-spinner.scss */
+  /* line 134, ../../../../general/res/sass/helpers/_wait-spinner.scss */
   .loading:before {
     -moz-animation-name: rotateCentered;
     -webkit-animation-name: rotateCentered;
@@ -1382,7 +1382,7 @@ tr[class*="s-limit"].s-limit-lwr td:first-child:before {
     transform: translateX(-50%) translateY(-50%) rotate(0deg); }
   100% {
     transform: translateX(-50%) translateY(-50%) rotate(359deg); } }
-  /* line 133, ../../../../general/res/sass/helpers/_wait-spinner.scss */
+  /* line 138, ../../../../general/res/sass/helpers/_wait-spinner.scss */
   .loading:after {
     overflow: hidden;
     position: absolute;
@@ -1395,7 +1395,7 @@ tr[class*="s-limit"].s-limit-lwr td:first-child:before {
     background: rgba(119, 107, 162, 0.1);
     display: block;
     z-index: 9; }
-  /* line 139, ../../../../general/res/sass/helpers/_wait-spinner.scss */
+  /* line 144, ../../../../general/res/sass/helpers/_wait-spinner.scss */
   .loading.tree-item:before {
     padding: 0.375rem;
     border-width: 2px; }
@@ -5503,7 +5503,7 @@ span.req {
  * this source code distribution or the Licensing information page available
  * at runtime from the About dialog for additional information.
  *****************************************************************************/
-/* line 23, ../../../../general/res/sass/tree/_tree.scss */
+/* line 35, ../../../../general/res/sass/tree/_tree.scss */
 ul.tree {
   margin: 0;
   padding: 0;
@@ -5516,15 +5516,15 @@ ul.tree {
     list-style-type: none;
     margin: 0;
     padding: 0; }
-  /* line 26, ../../../../general/res/sass/tree/_tree.scss */
+  /* line 38, ../../../../general/res/sass/tree/_tree.scss */
   ul.tree li {
     display: block;
     position: relative; }
-  /* line 30, ../../../../general/res/sass/tree/_tree.scss */
+  /* line 42, ../../../../general/res/sass/tree/_tree.scss */
   ul.tree ul.tree {
     margin-left: 15px; }
 
-/* line 35, ../../../../general/res/sass/tree/_tree.scss */
+/* line 47, ../../../../general/res/sass/tree/_tree.scss */
 .tree-item,
 .search-result-item {
   -moz-box-sizing: border-box;
@@ -5543,7 +5543,7 @@ ul.tree {
   line-height: 1.5rem;
   margin-bottom: 3px;
   position: relative; }
-  /* line 48, ../../../../general/res/sass/tree/_tree.scss */
+  /* line 60, ../../../../general/res/sass/tree/_tree.scss */
   .tree-item .view-control,
   .search-result-item .view-control {
     color: #666;
@@ -5552,14 +5552,12 @@ ul.tree {
     font-size: 0.75em;
     width: 10px; }
     @media only screen and (min-device-width: 1025px) and (-webkit-min-device-pixel-ratio: 1) {
-      /* line 56, ../../../../general/res/sass/tree/_tree.scss */
+      /* line 68, ../../../../general/res/sass/tree/_tree.scss */
       .tree-item .view-control:hover,
       .search-result-item .view-control:hover {
         color: #0099cc !important; } }
-  /* line 62, ../../../../general/res/sass/tree/_tree.scss */
-  .tree-item .label,
+  /* line 74, ../../../../general/res/sass/tree/_tree.scss */
   .tree-item .t-object-label,
-  .search-result-item .label,
   .search-result-item .t-object-label {
     display: block;
     overflow: hidden;
@@ -5571,10 +5569,8 @@ ul.tree {
     width: auto;
     height: auto;
     line-height: 1.5rem; }
-    /* line 68, ../../../../general/res/sass/tree/_tree.scss */
-    .tree-item .label .t-item-icon,
+    /* line 79, ../../../../general/res/sass/tree/_tree.scss */
     .tree-item .t-object-label .t-item-icon,
-    .search-result-item .label .t-item-icon,
     .search-result-item .t-object-label .t-item-icon {
       font-size: 1.4em;
       color: #0099cc;
@@ -5586,74 +5582,9 @@ ul.tree {
       -ms-transform: translateY(-50%);
       -webkit-transform: translateY(-50%);
       transform: translateY(-50%); }
-    /* line 79, ../../../../general/res/sass/tree/_tree.scss */
-    .tree-item .label .type-icon,
-    .tree-item .t-object-label .type-icon,
-    .search-result-item .label .type-icon,
-    .search-result-item .t-object-label .type-icon {
-      font-size: 1.4em;
-      color: #0099cc;
-      left: 5px;
-      position: absolute;
-      top: 4px;
-      bottom: auto;
-      height: 16px;
-      line-height: 100%;
-      right: auto;
-      width: 1.4em; }
-      /* line 92, ../../../../general/res/sass/tree/_tree.scss */
-      .tree-item .label .type-icon .icon.l-icon-link, .tree-item .label .type-icon .l-icon-link.t-item-icon, .tree-item .label .type-icon .icon.l-icon-alert, .tree-item .label .type-icon .l-icon-alert.t-item-icon,
-      .tree-item .t-object-label .type-icon .icon.l-icon-link,
-      .tree-item .t-object-label .type-icon .l-icon-link.t-item-icon,
-      .tree-item .t-object-label .type-icon .icon.l-icon-alert,
-      .tree-item .t-object-label .type-icon .l-icon-alert.t-item-icon,
-      .search-result-item .label .type-icon .icon.l-icon-link,
-      .search-result-item .label .type-icon .l-icon-link.t-item-icon,
-      .search-result-item .label .type-icon .icon.l-icon-alert,
-      .search-result-item .label .type-icon .l-icon-alert.t-item-icon,
-      .search-result-item .t-object-label .type-icon .icon.l-icon-link,
-      .search-result-item .t-object-label .type-icon .l-icon-link.t-item-icon,
-      .search-result-item .t-object-label .type-icon .icon.l-icon-alert,
-      .search-result-item .t-object-label .type-icon .l-icon-alert.t-item-icon {
-        position: absolute;
-        z-index: 2; }
-      /* line 97, ../../../../general/res/sass/tree/_tree.scss */
-      .tree-item .label .type-icon .icon.l-icon-alert, .tree-item .label .type-icon .l-icon-alert.t-item-icon,
-      .tree-item .t-object-label .type-icon .icon.l-icon-alert,
-      .tree-item .t-object-label .type-icon .l-icon-alert.t-item-icon,
-      .search-result-item .label .type-icon .icon.l-icon-alert,
-      .search-result-item .label .type-icon .l-icon-alert.t-item-icon,
-      .search-result-item .t-object-label .type-icon .icon.l-icon-alert,
-      .search-result-item .t-object-label .type-icon .l-icon-alert.t-item-icon {
-        color: #ff3c00;
-        font-size: 8px;
-        line-height: 8px;
-        height: 8px;
-        width: 8px;
-        top: 1px;
-        right: -2px; }
-      /* line 103, ../../../../general/res/sass/tree/_tree.scss */
-      .tree-item .label .type-icon .icon.l-icon-link, .tree-item .label .type-icon .l-icon-link.t-item-icon,
-      .tree-item .t-object-label .type-icon .icon.l-icon-link,
-      .tree-item .t-object-label .type-icon .l-icon-link.t-item-icon,
-      .search-result-item .label .type-icon .icon.l-icon-link,
-      .search-result-item .label .type-icon .l-icon-link.t-item-icon,
-      .search-result-item .t-object-label .type-icon .icon.l-icon-link,
-      .search-result-item .t-object-label .type-icon .l-icon-link.t-item-icon {
-        color: #49dedb;
-        font-size: 8px;
-        line-height: 8px;
-        height: 8px;
-        width: 8px;
-        left: -3px;
-        bottom: 0px; }
-    /* line 111, ../../../../general/res/sass/tree/_tree.scss */
-    .tree-item .label .title-label,
-    .tree-item .label .t-title-label,
+    /* line 83, ../../../../general/res/sass/tree/_tree.scss */
     .tree-item .t-object-label .title-label,
     .tree-item .t-object-label .t-title-label,
-    .search-result-item .label .title-label,
-    .search-result-item .label .t-title-label,
     .search-result-item .t-object-label .title-label,
     .search-result-item .t-object-label .t-title-label {
       overflow: hidden;
@@ -5669,49 +5600,99 @@ ul.tree {
       overflow: hidden;
       text-overflow: ellipsis;
       white-space: nowrap; }
-  /* line 122, ../../../../general/res/sass/tree/_tree.scss */
+  /* line 94, ../../../../general/res/sass/tree/_tree.scss */
   .tree-item.selected,
   .search-result-item.selected {
     background: #1ac6ff;
     color: #fcfcfc; }
-    /* line 125, ../../../../general/res/sass/tree/_tree.scss */
+    /* line 97, ../../../../general/res/sass/tree/_tree.scss */
     .tree-item.selected .view-control,
     .search-result-item.selected .view-control {
       color: #fcfcfc; }
-    /* line 128, ../../../../general/res/sass/tree/_tree.scss */
+    /* line 100, ../../../../general/res/sass/tree/_tree.scss */
     .tree-item.selected .t-object-label .t-item-icon,
     .search-result-item.selected .t-object-label .t-item-icon {
       color: #fcfcfc; }
   @media only screen and (min-device-width: 1025px) and (-webkit-min-device-pixel-ratio: 1) {
-    /* line 136, ../../../../general/res/sass/tree/_tree.scss */
+    /* line 108, ../../../../general/res/sass/tree/_tree.scss */
     .tree-item:not(.selected):hover,
     .search-result-item:not(.selected):hover {
       background: rgba(102, 102, 102, 0.1);
       color: #333333; }
-      /* line 139, ../../../../general/res/sass/tree/_tree.scss */
+      /* line 111, ../../../../general/res/sass/tree/_tree.scss */
       .tree-item:not(.selected):hover .t-item-icon,
       .search-result-item:not(.selected):hover .t-item-icon {
         color: #0099cc; } }
-  /* line 146, ../../../../general/res/sass/tree/_tree.scss */
+  /* line 118, ../../../../general/res/sass/tree/_tree.scss */
   .tree-item:not(.loading),
   .search-result-item:not(.loading) {
     cursor: pointer; }
-  /* line 150, ../../../../general/res/sass/tree/_tree.scss */
+  /* line 122, ../../../../general/res/sass/tree/_tree.scss */
   .tree-item .context-trigger,
   .search-result-item .context-trigger {
     top: -1px;
     position: absolute;
     right: 3px; }
-    /* line 155, ../../../../general/res/sass/tree/_tree.scss */
+    /* line 127, ../../../../general/res/sass/tree/_tree.scss */
     .tree-item .context-trigger .invoke-menu,
     .search-result-item .context-trigger .invoke-menu {
       font-size: 0.75em;
       height: 0.9rem;
       line-height: 0.9rem; }
 
-/* line 164, ../../../../general/res/sass/tree/_tree.scss */
-.tree-item .t-object-label {
+/* line 137, ../../../../general/res/sass/tree/_tree.scss */
+.tree-item mct-representation .t-object-label {
   left: 15px; }
+/* line 142, ../../../../general/res/sass/tree/_tree.scss */
+.tree-item mct-representation.s-status-pending .t-object-label:before {
+  font-size: 1.4em;
+  color: #0099cc;
+  position: absolute;
+  left: 5px;
+  top: 50%;
+  width: 1.4em;
+  -moz-transform: translateY(-50%);
+  -ms-transform: translateY(-50%);
+  -webkit-transform: translateY(-50%);
+  transform: translateY(-50%);
+  -moz-animation-name: rotateCentered;
+  -webkit-animation-name: rotateCentered;
+  animation-name: rotateCentered;
+  -moz-animation-duration: 0.5s;
+  -webkit-animation-duration: 0.5s;
+  animation-duration: 0.5s;
+  -moz-animation-iteration-count: infinite;
+  -webkit-animation-iteration-count: infinite;
+  animation-iteration-count: infinite;
+  -moz-animation-timing-function: linear;
+  -webkit-animation-timing-function: linear;
+  animation-timing-function: linear;
+  border-color: rgba(0, 0, 255, 0.25);
+  border-top-color: blue;
+  border-style: solid;
+  border-width: 2px;
+  -moz-border-radius: 100%;
+  -webkit-border-radius: 100%;
+  border-radius: 100%;
+  content: ""; }
+@-moz-keyframes rotateCentered {
+  0% {
+    transform: translateX(-50%) translateY(-50%) rotate(0deg); }
+  100% {
+    transform: translateX(-50%) translateY(-50%) rotate(359deg); } }
+@-webkit-keyframes rotateCentered {
+  0% {
+    transform: translateX(-50%) translateY(-50%) rotate(0deg); }
+  100% {
+    transform: translateX(-50%) translateY(-50%) rotate(359deg); } }
+@keyframes rotateCentered {
+  0% {
+    transform: translateX(-50%) translateY(-50%) rotate(0deg); }
+  100% {
+    transform: translateX(-50%) translateY(-50%) rotate(359deg); } }
+/* line 147, ../../../../general/res/sass/tree/_tree.scss */
+.tree-item mct-representation.s-status-pending .t-object-label .t-item-icon .t-item-icon-glyph {
+  display: none; }
 
 /*****************************************************************************
  * Open MCT Web, Copyright (c) 2014-2015, United States Government

--- a/platform/commonUI/themes/snow/res/css/theme-snow.css
+++ b/platform/commonUI/themes/snow/res/css/theme-snow.css
@@ -20,7 +20,7 @@
  * this source code distribution or the Licensing information page available
  * at runtime from the About dialog for additional information.
  *****************************************************************************/
-/* line 5, ../../../../../../../../../../../Library/Ruby/Gems/2.0.0/gems/compass-core-1.0.3/stylesheets/compass/reset/_utilities.scss */
+/* line 5, ../../../../../../../../../../Library/Ruby/Gems/2.0.0/gems/compass-core-1.0.3/stylesheets/compass/reset/_utilities.scss */
 html, body, div, span, applet, object, iframe,
 h1, h2, h3, h4, h5, h6, p, blockquote, pre,
 a, abbr, acronym, address, big, cite, code,
@@ -41,38 +41,38 @@ time, mark, audio, video {
   font-size: 100%;
   vertical-align: baseline; }
 
-/* line 22, ../../../../../../../../../../../Library/Ruby/Gems/2.0.0/gems/compass-core-1.0.3/stylesheets/compass/reset/_utilities.scss */
+/* line 22, ../../../../../../../../../../Library/Ruby/Gems/2.0.0/gems/compass-core-1.0.3/stylesheets/compass/reset/_utilities.scss */
 html {
   line-height: 1; }
 
-/* line 24, ../../../../../../../../../../../Library/Ruby/Gems/2.0.0/gems/compass-core-1.0.3/stylesheets/compass/reset/_utilities.scss */
+/* line 24, ../../../../../../../../../../Library/Ruby/Gems/2.0.0/gems/compass-core-1.0.3/stylesheets/compass/reset/_utilities.scss */
 ol, ul {
   list-style: none; }
 
-/* line 26, ../../../../../../../../../../../Library/Ruby/Gems/2.0.0/gems/compass-core-1.0.3/stylesheets/compass/reset/_utilities.scss */
+/* line 26, ../../../../../../../../../../Library/Ruby/Gems/2.0.0/gems/compass-core-1.0.3/stylesheets/compass/reset/_utilities.scss */
 table {
   border-collapse: collapse;
   border-spacing: 0; }
 
-/* line 28, ../../../../../../../../../../../Library/Ruby/Gems/2.0.0/gems/compass-core-1.0.3/stylesheets/compass/reset/_utilities.scss */
+/* line 28, ../../../../../../../../../../Library/Ruby/Gems/2.0.0/gems/compass-core-1.0.3/stylesheets/compass/reset/_utilities.scss */
 caption, th, td {
   text-align: left;
   font-weight: normal;
   vertical-align: middle; }
 
-/* line 30, ../../../../../../../../../../../Library/Ruby/Gems/2.0.0/gems/compass-core-1.0.3/stylesheets/compass/reset/_utilities.scss */
+/* line 30, ../../../../../../../../../../Library/Ruby/Gems/2.0.0/gems/compass-core-1.0.3/stylesheets/compass/reset/_utilities.scss */
 q, blockquote {
   quotes: none; }
-  /* line 103, ../../../../../../../../../../../Library/Ruby/Gems/2.0.0/gems/compass-core-1.0.3/stylesheets/compass/reset/_utilities.scss */
+  /* line 103, ../../../../../../../../../../Library/Ruby/Gems/2.0.0/gems/compass-core-1.0.3/stylesheets/compass/reset/_utilities.scss */
   q:before, q:after, blockquote:before, blockquote:after {
     content: "";
     content: none; }
 
-/* line 32, ../../../../../../../../../../../Library/Ruby/Gems/2.0.0/gems/compass-core-1.0.3/stylesheets/compass/reset/_utilities.scss */
+/* line 32, ../../../../../../../../../../Library/Ruby/Gems/2.0.0/gems/compass-core-1.0.3/stylesheets/compass/reset/_utilities.scss */
 a img {
   border: none; }
 
-/* line 116, ../../../../../../../../../../../Library/Ruby/Gems/2.0.0/gems/compass-core-1.0.3/stylesheets/compass/reset/_utilities.scss */
+/* line 116, ../../../../../../../../../../Library/Ruby/Gems/2.0.0/gems/compass-core-1.0.3/stylesheets/compass/reset/_utilities.scss */
 article, aside, details, figcaption, figure, footer, header, hgroup, main, menu, nav, section, summary {
   display: block; }
 
@@ -5127,41 +5127,42 @@ span.req {
     -o-transition-delay: 0;
     -webkit-transition-delay: 0;
     transition-delay: 0;
-    pointer-events: none; }
-  /* line 88, ../../../../general/res/sass/search/_search.scss */
+    pointer-events: none;
+    z-index: 1; }
+  /* line 89, ../../../../general/res/sass/search/_search.scss */
   .holder-search .search-bar:hover:before {
     color: #8c8c8c; }
-  /* line 92, ../../../../general/res/sass/search/_search.scss */
+  /* line 93, ../../../../general/res/sass/search/_search.scss */
   .holder-search .search-bar .clear-icon {
     right: 22px;
     visibility: hidden;
     opacity: 0; }
-    /* line 98, ../../../../general/res/sass/search/_search.scss */
+    /* line 99, ../../../../general/res/sass/search/_search.scss */
     .holder-search .search-bar .clear-icon.show {
       visibility: visible;
       opacity: 1; }
-    /* line 103, ../../../../general/res/sass/search/_search.scss */
+    /* line 104, ../../../../general/res/sass/search/_search.scss */
     .holder-search .search-bar .clear-icon:hover {
       color: #8c8c8c; }
-  /* line 108, ../../../../general/res/sass/search/_search.scss */
+  /* line 109, ../../../../general/res/sass/search/_search.scss */
   .holder-search .search-bar .menu-icon {
     font-size: 0.8em;
     padding-right: 4px;
     right: 4px;
     text-align: right; }
-    /* line 110, ../../../../general/res/sass/search/_search.scss */
+    /* line 111, ../../../../general/res/sass/search/_search.scss */
     .holder-search .search-bar .menu-icon:before {
       content: '\76'; }
-    /* line 116, ../../../../general/res/sass/search/_search.scss */
+    /* line 117, ../../../../general/res/sass/search/_search.scss */
     .holder-search .search-bar .menu-icon:hover {
       color: #8c8c8c; }
-  /* line 121, ../../../../general/res/sass/search/_search.scss */
+  /* line 122, ../../../../general/res/sass/search/_search.scss */
   .holder-search .search-bar .search-menu-holder {
     float: right;
     left: -20px;
     z-index: 70;
     transition: visibility .05s, opacity .05s; }
-/* line 129, ../../../../general/res/sass/search/_search.scss */
+/* line 130, ../../../../general/res/sass/search/_search.scss */
 .holder-search .active-filter-display {
   -moz-box-sizing: border-box;
   -webkit-box-sizing: border-box;
@@ -5169,7 +5170,7 @@ span.req {
   line-height: 130%;
   padding-left: 1.4625em;
   font-size: 0.65em; }
-  /* line 137, ../../../../general/res/sass/search/_search.scss */
+  /* line 138, ../../../../general/res/sass/search/_search.scss */
   .holder-search .active-filter-display .clear-filters-icon {
     color: #a6a6a6;
     opacity: 1;
@@ -5177,7 +5178,7 @@ span.req {
     position: absolute;
     left: 1px;
     cursor: pointer; }
-/* line 147, ../../../../general/res/sass/search/_search.scss */
+/* line 148, ../../../../general/res/sass/search/_search.scss */
 .holder-search .search-results {
   -moz-transition-property: opacity, visibility;
   -o-transition-property: opacity, visibility;
@@ -5197,16 +5198,16 @@ span.req {
   transition-delay: 0;
   margin-top: 10px;
   padding-right: 5px; }
-  /* line 151, ../../../../general/res/sass/search/_search.scss */
+  /* line 152, ../../../../general/res/sass/search/_search.scss */
   .holder-search .search-results .hint {
     margin-bottom: 10px;
     font-size: 0.65em;
     opacity: 0.6; }
-  /* line 156, ../../../../general/res/sass/search/_search.scss */
+  /* line 157, ../../../../general/res/sass/search/_search.scss */
   .holder-search .search-results.active {
     visibility: visible;
     opacity: 1; }
-  /* line 160, ../../../../general/res/sass/search/_search.scss */
+  /* line 161, ../../../../general/res/sass/search/_search.scss */
   .holder-search .search-results .load-more-button {
     -moz-transform: translateX(-50%);
     -ms-transform: translateX(-50%);
@@ -5221,10 +5222,10 @@ span.req {
 
 @media only screen and (orientation: portrait) and (max-device-width: 767px), only screen and (orientation: landscape) and (max-device-width: 767px) {
   /* line 5, ../../../../general/res/sass/mobile/search/_search.scss */
-  .search .search-bar .menu-icon {
+  .search-holder .search-bar .menu-icon {
     display: none; }
   /* line 8, ../../../../general/res/sass/mobile/search/_search.scss */
-  .search .search-bar .clear-icon {
+  .search-holder .search-bar .clear-icon {
     right: 5px; } }
 /*****************************************************************************
  * Open MCT Web, Copyright (c) 2014-2015, United States Government
@@ -5857,9 +5858,9 @@ mct-representation.s-status-pending .t-object-label .t-title-label {
   /* line 31, ../../../../general/res/sass/mobile/_tree.scss */
   .tree-item,
   .search-result-item {
-    height: 35px;
-    line-height: 35px;
-    margin-bottom: 0px; }
+    height: 35px !important;
+    line-height: 35px !important;
+    margin-bottom: 0px !important; }
     /* line 36, ../../../../general/res/sass/mobile/_tree.scss */
     .tree-item .view-control,
     .search-result-item .view-control {

--- a/platform/commonUI/themes/snow/res/css/theme-snow.css
+++ b/platform/commonUI/themes/snow/res/css/theme-snow.css
@@ -5168,8 +5168,8 @@ span.req {
   -webkit-box-sizing: border-box;
   box-sizing: border-box;
   line-height: 130%;
-  padding-left: 1.4625em;
-  font-size: 0.65em; }
+  padding-left: 1.575em;
+  font-size: 0.7em; }
   /* line 138, ../../../../general/res/sass/search/_search.scss */
   .holder-search .active-filter-display .clear-filters-icon {
     color: #a6a6a6;
@@ -5196,18 +5196,17 @@ span.req {
   -o-transition-delay: 0;
   -webkit-transition-delay: 0;
   transition-delay: 0;
-  margin-top: 10px;
   padding-right: 5px; }
-  /* line 152, ../../../../general/res/sass/search/_search.scss */
+  /* line 151, ../../../../general/res/sass/search/_search.scss */
   .holder-search .search-results .hint {
     margin-bottom: 10px;
     font-size: 0.65em;
     opacity: 0.6; }
-  /* line 157, ../../../../general/res/sass/search/_search.scss */
+  /* line 156, ../../../../general/res/sass/search/_search.scss */
   .holder-search .search-results.active {
     visibility: visible;
     opacity: 1; }
-  /* line 161, ../../../../general/res/sass/search/_search.scss */
+  /* line 160, ../../../../general/res/sass/search/_search.scss */
   .holder-search .search-results .load-more-button {
     -moz-transform: translateX(-50%);
     -ms-transform: translateX(-50%);

--- a/platform/commonUI/themes/snow/res/css/theme-snow.css
+++ b/platform/commonUI/themes/snow/res/css/theme-snow.css
@@ -527,23 +527,47 @@ mct-container {
   -webkit-flex-wrap: nowrap;
   flex-wrap: nowrap; }
   /* line 99, ../../../../general/res/sass/_archetypes.scss */
-  .l-flex-row .flex-elem,
-  .l-flex-col .flex-elem {
+  .l-flex-row .flex-elem, .l-flex-row .tree-item .view-control, .tree-item .l-flex-row .view-control,
+  .l-flex-row .search-result-item .view-control,
+  .search-result-item .l-flex-row .view-control,
+  .l-flex-col .flex-elem,
+  .l-flex-col .tree-item .view-control,
+  .tree-item .l-flex-col .view-control,
+  .l-flex-col .search-result-item .view-control,
+  .search-result-item .l-flex-col .view-control {
     min-height: 0;
     position: relative; }
     /* line 102, ../../../../general/res/sass/_archetypes.scss */
-    .l-flex-row .flex-elem:not(.grows),
-    .l-flex-col .flex-elem:not(.grows) {
+    .l-flex-row .flex-elem:not(.grows), .l-flex-row .tree-item .view-control:not(.grows), .tree-item .l-flex-row .view-control:not(.grows),
+    .l-flex-row .search-result-item .view-control:not(.grows),
+    .search-result-item .l-flex-row .view-control:not(.grows),
+    .l-flex-col .flex-elem:not(.grows),
+    .l-flex-col .tree-item .view-control:not(.grows),
+    .tree-item .l-flex-col .view-control:not(.grows),
+    .l-flex-col .search-result-item .view-control:not(.grows),
+    .search-result-item .l-flex-col .view-control:not(.grows) {
       -webkit-flex: 0 0 auto;
       flex: 0 0 auto; }
       /* line 104, ../../../../general/res/sass/_archetypes.scss */
-      .l-flex-row .flex-elem:not(.grows).flex-can-shrink,
-      .l-flex-col .flex-elem:not(.grows).flex-can-shrink {
+      .l-flex-row .flex-elem:not(.grows).flex-can-shrink, .l-flex-row .tree-item .view-control:not(.grows).flex-can-shrink, .tree-item .l-flex-row .view-control:not(.grows).flex-can-shrink,
+      .l-flex-row .search-result-item .view-control:not(.grows).flex-can-shrink,
+      .search-result-item .l-flex-row .view-control:not(.grows).flex-can-shrink,
+      .l-flex-col .flex-elem:not(.grows).flex-can-shrink,
+      .l-flex-col .tree-item .view-control:not(.grows).flex-can-shrink,
+      .tree-item .l-flex-col .view-control:not(.grows).flex-can-shrink,
+      .l-flex-col .search-result-item .view-control:not(.grows).flex-can-shrink,
+      .search-result-item .l-flex-col .view-control:not(.grows).flex-can-shrink {
         -webkit-flex: 0 1 auto;
         flex: 0 1 auto; }
     /* line 108, ../../../../general/res/sass/_archetypes.scss */
-    .l-flex-row .flex-elem.grows,
-    .l-flex-col .flex-elem.grows {
+    .l-flex-row .flex-elem.grows, .l-flex-row .tree-item .grows.view-control, .tree-item .l-flex-row .grows.view-control,
+    .l-flex-row .search-result-item .grows.view-control,
+    .search-result-item .l-flex-row .grows.view-control,
+    .l-flex-col .flex-elem.grows,
+    .l-flex-col .tree-item .grows.view-control,
+    .tree-item .l-flex-col .grows.view-control,
+    .l-flex-col .search-result-item .grows.view-control,
+    .search-result-item .l-flex-col .grows.view-control {
       -webkit-flex: 1 1 auto;
       flex: 1 1 auto; }
   /* line 112, ../../../../general/res/sass/_archetypes.scss */
@@ -562,11 +586,14 @@ mct-container {
   -webkit-flex-direction: row;
   flex-direction: row; }
   /* line 123, ../../../../general/res/sass/_archetypes.scss */
-  .l-flex-row.flex-elem {
+  .l-flex-row.flex-elem, .tree-item .l-flex-row.view-control,
+  .search-result-item .l-flex-row.view-control {
     -webkit-flex: 1 1 auto;
     flex: 1 1 auto; }
   /* line 124, ../../../../general/res/sass/_archetypes.scss */
-  .l-flex-row .flex-elem {
+  .l-flex-row .flex-elem, .l-flex-row .tree-item .view-control, .tree-item .l-flex-row .view-control,
+  .l-flex-row .search-result-item .view-control,
+  .search-result-item .l-flex-row .view-control {
     height: inherit;
     line-height: inherit;
     min-width: 0; }
@@ -580,10 +607,14 @@ mct-container {
   -webkit-flex-direction: column;
   flex-direction: column; }
   /* line 134, ../../../../general/res/sass/_archetypes.scss */
-  .l-flex-col .flex-elem {
+  .l-flex-col .flex-elem, .l-flex-col .tree-item .view-control, .tree-item .l-flex-col .view-control,
+  .l-flex-col .search-result-item .view-control,
+  .search-result-item .l-flex-col .view-control {
     min-height: 0; }
     /* line 136, ../../../../general/res/sass/_archetypes.scss */
-    .l-flex-col .flex-elem.holder:not(:last-child) {
+    .l-flex-col .flex-elem.holder:not(:last-child), .l-flex-col .tree-item .holder.view-control:not(:last-child), .tree-item .l-flex-col .holder.view-control:not(:last-child),
+    .l-flex-col .search-result-item .holder.view-control:not(:last-child),
+    .search-result-item .l-flex-col .holder.view-control:not(:last-child) {
       margin-bottom: 10px; }
   /* line 138, ../../../../general/res/sass/_archetypes.scss */
   .l-flex-col .flex-container {
@@ -1369,18 +1400,28 @@ tr[class*="s-limit"].s-limit-lwr td:first-child:before {
     z-index: 10; }
 @-moz-keyframes rotateCentered {
   0% {
+    -moz-transform: translateX(-50%) translateY(-50%) rotate(0deg);
     transform: translateX(-50%) translateY(-50%) rotate(0deg); }
   100% {
+    -moz-transform: translateX(-50%) translateY(-50%) rotate(359deg);
     transform: translateX(-50%) translateY(-50%) rotate(359deg); } }
 @-webkit-keyframes rotateCentered {
   0% {
+    -webkit-transform: translateX(-50%) translateY(-50%) rotate(0deg);
     transform: translateX(-50%) translateY(-50%) rotate(0deg); }
   100% {
+    -webkit-transform: translateX(-50%) translateY(-50%) rotate(359deg);
     transform: translateX(-50%) translateY(-50%) rotate(359deg); } }
 @keyframes rotateCentered {
   0% {
+    -moz-transform: translateX(-50%) translateY(-50%) rotate(0deg);
+    -ms-transform: translateX(-50%) translateY(-50%) rotate(0deg);
+    -webkit-transform: translateX(-50%) translateY(-50%) rotate(0deg);
     transform: translateX(-50%) translateY(-50%) rotate(0deg); }
   100% {
+    -moz-transform: translateX(-50%) translateY(-50%) rotate(359deg);
+    -ms-transform: translateX(-50%) translateY(-50%) rotate(359deg);
+    -webkit-transform: translateX(-50%) translateY(-50%) rotate(359deg);
     transform: translateX(-50%) translateY(-50%) rotate(359deg); } }
   /* line 138, ../../../../general/res/sass/helpers/_wait-spinner.scss */
   .loading:after {
@@ -5503,7 +5544,7 @@ span.req {
  * this source code distribution or the Licensing information page available
  * at runtime from the About dialog for additional information.
  *****************************************************************************/
-/* line 35, ../../../../general/res/sass/tree/_tree.scss */
+/* line 23, ../../../../general/res/sass/tree/_tree.scss */
 ul.tree {
   margin: 0;
   padding: 0;
@@ -5516,15 +5557,15 @@ ul.tree {
     list-style-type: none;
     margin: 0;
     padding: 0; }
-  /* line 38, ../../../../general/res/sass/tree/_tree.scss */
+  /* line 26, ../../../../general/res/sass/tree/_tree.scss */
   ul.tree li {
     display: block;
     position: relative; }
-  /* line 42, ../../../../general/res/sass/tree/_tree.scss */
+  /* line 30, ../../../../general/res/sass/tree/_tree.scss */
   ul.tree ul.tree {
     margin-left: 15px; }
 
-/* line 47, ../../../../general/res/sass/tree/_tree.scss */
+/* line 35, ../../../../general/res/sass/tree/_tree.scss */
 .tree-item,
 .search-result-item {
   -moz-box-sizing: border-box;
@@ -5537,124 +5578,92 @@ ul.tree {
   -o-transition: background-color 0.25s;
   -webkit-transition: background-color 0.25s;
   transition: background-color 0.25s;
-  display: block;
   font-size: 0.8rem;
   height: 1.5rem;
   line-height: 1.5rem;
   margin-bottom: 3px;
+  padding: 0 3px;
   position: relative; }
-  /* line 60, ../../../../general/res/sass/tree/_tree.scss */
+  /* line 48, ../../../../general/res/sass/tree/_tree.scss */
   .tree-item .view-control,
   .search-result-item .view-control {
     color: #666;
-    display: inline-block;
-    margin-left: 5px;
+    margin-right: 5px;
     font-size: 0.75em;
     width: 10px; }
+    /* line 56, ../../../../general/res/sass/tree/_tree.scss */
+    .tree-item .view-control.has-children:before,
+    .search-result-item .view-control.has-children:before {
+      content: ">"; }
+    /* line 63, ../../../../general/res/sass/tree/_tree.scss */
+    .tree-item .view-control.has-children.expanded:before,
+    .search-result-item .view-control.has-children.expanded:before {
+      content: "v"; }
     @media only screen and (min-device-width: 1025px) and (-webkit-min-device-pixel-ratio: 1) {
-      /* line 68, ../../../../general/res/sass/tree/_tree.scss */
+      /* line 69, ../../../../general/res/sass/tree/_tree.scss */
       .tree-item .view-control:hover,
       .search-result-item .view-control:hover {
         color: #0099cc !important; } }
-  /* line 74, ../../../../general/res/sass/tree/_tree.scss */
+  /* line 75, ../../../../general/res/sass/tree/_tree.scss */
   .tree-item .t-object-label,
   .search-result-item .t-object-label {
-    display: block;
-    overflow: hidden;
-    position: absolute;
-    top: 0px;
-    right: 0px;
-    bottom: 0px;
-    left: 0px;
-    width: auto;
-    height: auto;
     line-height: 1.5rem; }
-    /* line 79, ../../../../general/res/sass/tree/_tree.scss */
+    /* line 80, ../../../../general/res/sass/tree/_tree.scss */
     .tree-item .t-object-label .t-item-icon,
     .search-result-item .t-object-label .t-item-icon {
       font-size: 1.4em;
       color: #0099cc;
-      position: absolute;
-      left: 5px;
-      top: 50%;
-      width: 1.4em;
-      -moz-transform: translateY(-50%);
-      -ms-transform: translateY(-50%);
-      -webkit-transform: translateY(-50%);
-      transform: translateY(-50%); }
-    /* line 83, ../../../../general/res/sass/tree/_tree.scss */
+      width: 1.4em; }
+    /* line 91, ../../../../general/res/sass/tree/_tree.scss */
     .tree-item .t-object-label .title-label,
     .tree-item .t-object-label .t-title-label,
     .search-result-item .t-object-label .title-label,
     .search-result-item .t-object-label .t-title-label {
       overflow: hidden;
-      position: absolute;
-      top: 0px;
-      right: 0px;
-      bottom: 0px;
-      left: 0px;
-      width: auto;
-      height: auto;
-      display: block;
-      left: 30px;
-      overflow: hidden;
       text-overflow: ellipsis;
       white-space: nowrap; }
-  /* line 94, ../../../../general/res/sass/tree/_tree.scss */
+  /* line 100, ../../../../general/res/sass/tree/_tree.scss */
   .tree-item.selected,
   .search-result-item.selected {
     background: #1ac6ff;
     color: #fcfcfc; }
-    /* line 97, ../../../../general/res/sass/tree/_tree.scss */
+    /* line 103, ../../../../general/res/sass/tree/_tree.scss */
     .tree-item.selected .view-control,
     .search-result-item.selected .view-control {
       color: #fcfcfc; }
-    /* line 100, ../../../../general/res/sass/tree/_tree.scss */
+    /* line 106, ../../../../general/res/sass/tree/_tree.scss */
     .tree-item.selected .t-object-label .t-item-icon,
     .search-result-item.selected .t-object-label .t-item-icon {
       color: #fcfcfc; }
   @media only screen and (min-device-width: 1025px) and (-webkit-min-device-pixel-ratio: 1) {
-    /* line 108, ../../../../general/res/sass/tree/_tree.scss */
+    /* line 114, ../../../../general/res/sass/tree/_tree.scss */
     .tree-item:not(.selected):hover,
     .search-result-item:not(.selected):hover {
       background: rgba(102, 102, 102, 0.1);
       color: #333333; }
-      /* line 111, ../../../../general/res/sass/tree/_tree.scss */
+      /* line 117, ../../../../general/res/sass/tree/_tree.scss */
       .tree-item:not(.selected):hover .t-item-icon,
       .search-result-item:not(.selected):hover .t-item-icon {
         color: #0099cc; } }
-  /* line 118, ../../../../general/res/sass/tree/_tree.scss */
+  /* line 124, ../../../../general/res/sass/tree/_tree.scss */
   .tree-item:not(.loading),
   .search-result-item:not(.loading) {
     cursor: pointer; }
-  /* line 122, ../../../../general/res/sass/tree/_tree.scss */
+  /* line 128, ../../../../general/res/sass/tree/_tree.scss */
   .tree-item .context-trigger,
   .search-result-item .context-trigger {
     top: -1px;
     position: absolute;
     right: 3px; }
-    /* line 127, ../../../../general/res/sass/tree/_tree.scss */
+    /* line 133, ../../../../general/res/sass/tree/_tree.scss */
     .tree-item .context-trigger .invoke-menu,
     .search-result-item .context-trigger .invoke-menu {
       font-size: 0.75em;
       height: 0.9rem;
       line-height: 0.9rem; }
 
-/* line 137, ../../../../general/res/sass/tree/_tree.scss */
-.tree-item mct-representation .t-object-label {
-  left: 15px; }
-/* line 142, ../../../../general/res/sass/tree/_tree.scss */
+/* line 148, ../../../../general/res/sass/tree/_tree.scss */
 .tree-item mct-representation.s-status-pending .t-object-label:before {
-  font-size: 1.4em;
-  color: #0099cc;
-  position: absolute;
-  left: 5px;
-  top: 50%;
-  width: 1.4em;
-  -moz-transform: translateY(-50%);
-  -ms-transform: translateY(-50%);
-  -webkit-transform: translateY(-50%);
-  transform: translateY(-50%);
   -moz-animation-name: rotateCentered;
   -webkit-animation-name: rotateCentered;
   animation-name: rotateCentered;
@@ -5667,30 +5676,40 @@ ul.tree {
   -moz-animation-timing-function: linear;
   -webkit-animation-timing-function: linear;
   animation-timing-function: linear;
-  border-color: rgba(0, 0, 255, 0.25);
-  border-top-color: blue;
+  border-color: rgba(0, 153, 204, 0.25);
+  border-top-color: #0099cc;
   border-style: solid;
-  border-width: 2px;
+  border-width: 0.25em;
   -moz-border-radius: 100%;
   -webkit-border-radius: 100%;
   border-radius: 100%;
   content: ""; }
 @-moz-keyframes rotateCentered {
   0% {
+    -moz-transform: translateX(-50%) translateY(-50%) rotate(0deg);
     transform: translateX(-50%) translateY(-50%) rotate(0deg); }
   100% {
+    -moz-transform: translateX(-50%) translateY(-50%) rotate(359deg);
     transform: translateX(-50%) translateY(-50%) rotate(359deg); } }
 @-webkit-keyframes rotateCentered {
   0% {
+    -webkit-transform: translateX(-50%) translateY(-50%) rotate(0deg);
     transform: translateX(-50%) translateY(-50%) rotate(0deg); }
   100% {
+    -webkit-transform: translateX(-50%) translateY(-50%) rotate(359deg);
     transform: translateX(-50%) translateY(-50%) rotate(359deg); } }
 @keyframes rotateCentered {
   0% {
+    -moz-transform: translateX(-50%) translateY(-50%) rotate(0deg);
+    -ms-transform: translateX(-50%) translateY(-50%) rotate(0deg);
+    -webkit-transform: translateX(-50%) translateY(-50%) rotate(0deg);
     transform: translateX(-50%) translateY(-50%) rotate(0deg); }
   100% {
+    -moz-transform: translateX(-50%) translateY(-50%) rotate(359deg);
+    -ms-transform: translateX(-50%) translateY(-50%) rotate(359deg);
+    -webkit-transform: translateX(-50%) translateY(-50%) rotate(359deg);
     transform: translateX(-50%) translateY(-50%) rotate(359deg); } }
-/* line 147, ../../../../general/res/sass/tree/_tree.scss */
+/* line 152, ../../../../general/res/sass/tree/_tree.scss */
 .tree-item mct-representation.s-status-pending .t-object-label .t-item-icon .t-item-icon-glyph {
   display: none; }
 

--- a/platform/commonUI/themes/snow/res/css/theme-snow.css
+++ b/platform/commonUI/themes/snow/res/css/theme-snow.css
@@ -838,14 +838,14 @@ mct-container {
     color: #ff3c00;
     content: "!"; }
 
-/* line 84, ../../../../general/res/sass/_icons.scss */
+/* line 83, ../../../../general/res/sass/_icons.scss */
 .t-item-icon {
   line-height: normal;
   position: relative; }
-  /* line 91, ../../../../general/res/sass/_icons.scss */
+  /* line 89, ../../../../general/res/sass/_icons.scss */
   .t-item-icon .t-item-icon-glyph {
-    position: relative; }
-  /* line 96, ../../../../general/res/sass/_icons.scss */
+    position: absolute; }
+  /* line 94, ../../../../general/res/sass/_icons.scss */
   .t-item-icon.l-icon-link .t-item-icon-glyph:before {
     color: #49dedb;
     content: "\f4";
@@ -1244,7 +1244,7 @@ tr[class*="s-limit"].s-limit-lwr td:first-child:before {
     transform: rotate(0deg); }
   100% {
     transform: rotate(359deg); } }
-/* line 68, ../../../../general/res/sass/helpers/_wait-spinner.scss */
+/* line 69, ../../../../general/res/sass/helpers/_wait-spinner.scss */
 .t-wait-spinner,
 .wait-spinner {
   display: block;
@@ -1269,7 +1269,7 @@ tr[class*="s-limit"].s-limit-lwr td:first-child:before {
   margin-top: -5%;
   margin-left: -5%;
   z-index: 2; }
-  /* line 79, ../../../../general/res/sass/helpers/_wait-spinner.scss */
+  /* line 80, ../../../../general/res/sass/helpers/_wait-spinner.scss */
   .t-wait-spinner.inline,
   .wait-spinner.inline {
     display: inline-block !important;
@@ -1277,26 +1277,26 @@ tr[class*="s-limit"].s-limit-lwr td:first-child:before {
     position: relative !important;
     vertical-align: middle; }
 
-/* line 87, ../../../../general/res/sass/helpers/_wait-spinner.scss */
+/* line 88, ../../../../general/res/sass/helpers/_wait-spinner.scss */
 .l-wait-spinner-holder {
   pointer-events: none;
   position: absolute; }
-  /* line 91, ../../../../general/res/sass/helpers/_wait-spinner.scss */
+  /* line 92, ../../../../general/res/sass/helpers/_wait-spinner.scss */
   .l-wait-spinner-holder.align-left .t-wait-spinner {
     left: 0;
     margin-left: 0; }
-  /* line 96, ../../../../general/res/sass/helpers/_wait-spinner.scss */
+  /* line 97, ../../../../general/res/sass/helpers/_wait-spinner.scss */
   .l-wait-spinner-holder.full-size {
     display: inline-block;
     height: 100%;
     width: 100%; }
-    /* line 99, ../../../../general/res/sass/helpers/_wait-spinner.scss */
+    /* line 100, ../../../../general/res/sass/helpers/_wait-spinner.scss */
     .l-wait-spinner-holder.full-size .t-wait-spinner {
       top: 0;
       margin-top: 0;
       padding: 30%; }
 
-/* line 108, ../../../../general/res/sass/helpers/_wait-spinner.scss */
+/* line 109, ../../../../general/res/sass/helpers/_wait-spinner.scss */
 .treeview .wait-spinner {
   display: block;
   position: absolute;
@@ -1318,7 +1318,7 @@ tr[class*="s-limit"].s-limit-lwr td:first-child:before {
   top: 2px;
   left: 0; }
 
-/* line 117, ../../../../general/res/sass/helpers/_wait-spinner.scss */
+/* line 118, ../../../../general/res/sass/helpers/_wait-spinner.scss */
 .wait-spinner.sm {
   display: block;
   position: absolute;
@@ -1341,13 +1341,13 @@ tr[class*="s-limit"].s-limit-lwr td:first-child:before {
   top: 0;
   left: 0; }
 
-/* line 127, ../../../../general/res/sass/helpers/_wait-spinner.scss */
+/* line 128, ../../../../general/res/sass/helpers/_wait-spinner.scss */
 .loading {
   pointer-events: none; }
-  /* line 130, ../../../../general/res/sass/helpers/_wait-spinner.scss */
+  /* line 131, ../../../../general/res/sass/helpers/_wait-spinner.scss */
   .loading:before, .loading:after {
     content: ''; }
-  /* line 134, ../../../../general/res/sass/helpers/_wait-spinner.scss */
+  /* line 135, ../../../../general/res/sass/helpers/_wait-spinner.scss */
   .loading:before {
     -moz-animation-name: rotateCentered;
     -webkit-animation-name: rotateCentered;
@@ -1361,6 +1361,10 @@ tr[class*="s-limit"].s-limit-lwr td:first-child:before {
     -moz-animation-timing-function: linear;
     -webkit-animation-timing-function: linear;
     animation-timing-function: linear;
+    -moz-transform-origin: center 50%;
+    -ms-transform-origin: center 50%;
+    -webkit-transform-origin: center 50%;
+    transform-origin: center 50%;
     border-style: solid;
     border-width: 5px;
     -moz-border-radius: 100%;
@@ -1404,7 +1408,7 @@ tr[class*="s-limit"].s-limit-lwr td:first-child:before {
     -ms-transform: translateX(-50%) translateY(-50%) rotate(359deg);
     -webkit-transform: translateX(-50%) translateY(-50%) rotate(359deg);
     transform: translateX(-50%) translateY(-50%) rotate(359deg); } }
-  /* line 138, ../../../../general/res/sass/helpers/_wait-spinner.scss */
+  /* line 139, ../../../../general/res/sass/helpers/_wait-spinner.scss */
   .loading:after {
     overflow: hidden;
     position: absolute;
@@ -1417,7 +1421,7 @@ tr[class*="s-limit"].s-limit-lwr td:first-child:before {
     background: rgba(119, 107, 162, 0.1);
     display: block;
     z-index: 9; }
-  /* line 144, ../../../../general/res/sass/helpers/_wait-spinner.scss */
+  /* line 145, ../../../../general/res/sass/helpers/_wait-spinner.scss */
   .loading.tree-item:before {
     padding: 0.375rem;
     border-width: 2px; }
@@ -1504,26 +1508,35 @@ tr[class*="s-limit"].s-limit-lwr td:first-child:before {
     .l-inspect .inspector-properties .value {
       color: #404040;
       word-break: break-all; }
-  /* line 88, ../../../../general/res/sass/_inspector.scss */
+  /* line 87, ../../../../general/res/sass/_inspector.scss */
   .l-inspect .inspector-location .location-item {
+    -moz-box-sizing: border-box;
+    -webkit-box-sizing: border-box;
+    box-sizing: border-box;
     cursor: pointer;
     display: inline-block;
+    line-height: 1.2em;
     position: relative;
     padding: 2px 4px; }
-    /* line 93, ../../../../general/res/sass/_inspector.scss */
+    /* line 96, ../../../../general/res/sass/_inspector.scss */
+    .l-inspect .inspector-location .location-item .t-object-label .t-item-icon {
+      height: 1.2em;
+      width: 0.7rem; }
+    /* line 101, ../../../../general/res/sass/_inspector.scss */
     .l-inspect .inspector-location .location-item:hover {
       background: rgba(102, 102, 102, 0.1);
       color: #333333; }
-      /* line 96, ../../../../general/res/sass/_inspector.scss */
+      /* line 104, ../../../../general/res/sass/_inspector.scss */
       .l-inspect .inspector-location .location-item:hover .icon, .l-inspect .inspector-location .location-item:hover .t-item-icon {
         color: #0099cc; }
-  /* line 101, ../../../../general/res/sass/_inspector.scss */
+  /* line 109, ../../../../general/res/sass/_inspector.scss */
   .l-inspect .inspector-location:not(.last) .t-object-label .t-title-label:after {
     color: #8c8c8c;
     content: '\3e';
     display: inline-block;
     font-family: symbolsfont;
     font-size: 8px;
+    font-style: normal !important;
     line-height: inherit;
     margin-left: 3px;
     width: 4px; }
@@ -1644,7 +1657,7 @@ tr[class*="s-limit"].s-limit-lwr td:first-child:before {
     @media only screen and (min-device-width: 1025px) and (-webkit-min-device-pixel-ratio: 1) {
       /* line 302, ../../../../general/res/sass/_mixins.scss */
       .s-btn.major:not(.disabled):hover, .major.s-menu-btn:not(.disabled):hover {
-        background: deepskyblue; }
+        background-image: deepskyblue; }
         /* line 304, ../../../../general/res/sass/_mixins.scss */
         .s-btn.major:not(.disabled):hover > .icon, .major.s-menu-btn:not(.disabled):hover > .icon, .s-btn.major:not(.disabled):hover > .t-item-icon, .major.s-menu-btn:not(.disabled):hover > .t-item-icon {
           color: white; } }
@@ -1674,7 +1687,7 @@ tr[class*="s-limit"].s-limit-lwr td:first-child:before {
     @media only screen and (min-device-width: 1025px) and (-webkit-min-device-pixel-ratio: 1) {
       /* line 302, ../../../../general/res/sass/_mixins.scss */
       .s-btn:not(.major):not(.disabled):hover, .s-menu-btn:not(.major):not(.disabled):hover {
-        background: #0099cc; }
+        background-image: #0099cc; }
         /* line 304, ../../../../general/res/sass/_mixins.scss */
         .s-btn:not(.major):not(.disabled):hover > .icon, .s-menu-btn:not(.major):not(.disabled):hover > .icon, .s-btn:not(.major):not(.disabled):hover > .t-item-icon, .s-menu-btn:not(.major):not(.disabled):hover > .t-item-icon {
           color: white; } }
@@ -1707,7 +1720,7 @@ tr[class*="s-limit"].s-limit-lwr td:first-child:before {
     @media only screen and (min-device-width: 1025px) and (-webkit-min-device-pixel-ratio: 1) {
       /* line 302, ../../../../general/res/sass/_mixins.scss */
       .s-btn.pause-play.paused:not(.disabled):hover, .pause-play.paused.s-menu-btn:not(.disabled):hover {
-        background: #ffad33; }
+        background-image: #ffad33; }
         /* line 304, ../../../../general/res/sass/_mixins.scss */
         .s-btn.pause-play.paused:not(.disabled):hover > .icon, .pause-play.paused.s-menu-btn:not(.disabled):hover > .icon, .s-btn.pause-play.paused:not(.disabled):hover > .t-item-icon, .pause-play.paused.s-menu-btn:not(.disabled):hover > .t-item-icon {
           color: white; } }
@@ -1799,7 +1812,7 @@ tr[class*="s-limit"].s-limit-lwr td:first-child:before {
     @media only screen and (min-device-width: 1025px) and (-webkit-min-device-pixel-ratio: 1) and (min-device-width: 1025px) and (-webkit-min-device-pixel-ratio: 1) {
       /* line 302, ../../../../general/res/sass/_mixins.scss */
       .mini-tab.collapsed:not(.disabled):hover {
-        background: #0099cc; }
+        background-image: #0099cc; }
         /* line 304, ../../../../general/res/sass/_mixins.scss */
         .mini-tab.collapsed:not(.disabled):hover > .icon, .mini-tab.collapsed:not(.disabled):hover > .t-item-icon {
           color: white; } }
@@ -5381,7 +5394,7 @@ span.req {
         @media only screen and (min-device-width: 1025px) and (-webkit-min-device-pixel-ratio: 1) {
           /* line 302, ../../../../general/res/sass/_mixins.scss */
           .overlay .bottom-bar .s-btn:not(.major):not(.disabled):hover, .overlay .bottom-bar .s-menu-btn:not(.major):not(.disabled):hover {
-            background: #7d7d7d; }
+            background-image: #7d7d7d; }
             /* line 304, ../../../../general/res/sass/_mixins.scss */
             .overlay .bottom-bar .s-btn:not(.major):not(.disabled):hover > .icon, .overlay .bottom-bar .s-menu-btn:not(.major):not(.disabled):hover > .icon, .overlay .bottom-bar .s-btn:not(.major):not(.disabled):hover > .t-item-icon, .overlay .bottom-bar .s-menu-btn:not(.major):not(.disabled):hover > .t-item-icon {
               color: white; } }
@@ -5681,15 +5694,17 @@ mct-representation.s-status-pending .t-object-label .t-item-icon:before {
   -moz-animation-timing-function: linear;
   -webkit-animation-timing-function: linear;
   animation-timing-function: linear;
+  -moz-transform-origin: center 50%;
+  -ms-transform-origin: center 50%;
+  -webkit-transform-origin: center 50%;
+  transform-origin: center 50%;
   border-style: solid;
   border-width: 4px;
   -moz-border-radius: 100%;
   -webkit-border-radius: 100%;
   border-radius: 100%;
   border-color: rgba(0, 153, 204, 0.25);
-  border-top-color: #0099cc;
-  width: 10px;
-  height: 10px; }
+  border-top-color: #0099cc; }
 @-moz-keyframes rotateCentered {
   0% {
     -moz-transform: translateX(-50%) translateY(-50%) rotate(0deg);
@@ -5715,15 +5730,15 @@ mct-representation.s-status-pending .t-object-label .t-item-icon:before {
     -ms-transform: translateX(-50%) translateY(-50%) rotate(359deg);
     -webkit-transform: translateX(-50%) translateY(-50%) rotate(359deg);
     transform: translateX(-50%) translateY(-50%) rotate(359deg); } }
-/* line 145, ../../../../general/res/sass/tree/_tree.scss */
+/* line 137, ../../../../general/res/sass/tree/_tree.scss */
 mct-representation.s-status-pending .t-object-label .t-item-icon .t-item-icon-glyph {
   display: none; }
-/* line 149, ../../../../general/res/sass/tree/_tree.scss */
+/* line 141, ../../../../general/res/sass/tree/_tree.scss */
 mct-representation.s-status-pending .t-object-label .t-title-label {
   font-style: italic;
   opacity: 0.6; }
 
-/* line 156, ../../../../general/res/sass/tree/_tree.scss */
+/* line 148, ../../../../general/res/sass/tree/_tree.scss */
 .selected mct-representation.s-status-pending .t-object-label .t-item-icon:before {
   border-color: rgba(252, 252, 252, 0.25);
   border-top-color: #fcfcfc; }
@@ -5777,6 +5792,10 @@ mct-representation.s-status-pending .t-object-label .t-item-icon:before {
   -moz-animation-timing-function: linear;
   -webkit-animation-timing-function: linear;
   animation-timing-function: linear;
+  -moz-transform-origin: center 50%;
+  -ms-transform-origin: center 50%;
+  -webkit-transform-origin: center 50%;
+  transform-origin: center 50%;
   border-style: solid;
   border-width: 4px;
   -moz-border-radius: 100%;
@@ -5787,7 +5806,7 @@ mct-representation.s-status-pending .t-object-label .t-item-icon:before {
   position: absolute;
   left: 50%;
   top: 50%;
-  padding: 35%;
+  padding: 30%;
   width: 0;
   height: 0; }
 @-moz-keyframes rotateCentered {
@@ -6847,7 +6866,7 @@ table {
     @media only screen and (min-device-width: 1025px) and (-webkit-min-device-pixel-ratio: 1) {
       /* line 302, ../../../../general/res/sass/_mixins.scss */
       .items-holder .item.grid-item:not(.disabled):hover {
-        background: #d0d0d0; }
+        background-image: #d0d0d0; }
         /* line 304, ../../../../general/res/sass/_mixins.scss */
         .items-holder .item.grid-item:not(.disabled):hover > .icon, .items-holder .item.grid-item:not(.disabled):hover > .t-item-icon {
           color: #33ccff; } }

--- a/platform/commonUI/themes/snow/res/css/theme-snow.css
+++ b/platform/commonUI/themes/snow/res/css/theme-snow.css
@@ -527,47 +527,23 @@ mct-container {
   -webkit-flex-wrap: nowrap;
   flex-wrap: nowrap; }
   /* line 99, ../../../../general/res/sass/_archetypes.scss */
-  .l-flex-row .flex-elem, .l-flex-row .tree-item .view-control, .tree-item .l-flex-row .view-control,
-  .l-flex-row .search-result-item .view-control,
-  .search-result-item .l-flex-row .view-control,
-  .l-flex-col .flex-elem,
-  .l-flex-col .tree-item .view-control,
-  .tree-item .l-flex-col .view-control,
-  .l-flex-col .search-result-item .view-control,
-  .search-result-item .l-flex-col .view-control {
+  .l-flex-row .flex-elem,
+  .l-flex-col .flex-elem {
     min-height: 0;
     position: relative; }
     /* line 102, ../../../../general/res/sass/_archetypes.scss */
-    .l-flex-row .flex-elem:not(.grows), .l-flex-row .tree-item .view-control:not(.grows), .tree-item .l-flex-row .view-control:not(.grows),
-    .l-flex-row .search-result-item .view-control:not(.grows),
-    .search-result-item .l-flex-row .view-control:not(.grows),
-    .l-flex-col .flex-elem:not(.grows),
-    .l-flex-col .tree-item .view-control:not(.grows),
-    .tree-item .l-flex-col .view-control:not(.grows),
-    .l-flex-col .search-result-item .view-control:not(.grows),
-    .search-result-item .l-flex-col .view-control:not(.grows) {
+    .l-flex-row .flex-elem:not(.grows),
+    .l-flex-col .flex-elem:not(.grows) {
       -webkit-flex: 0 0 auto;
       flex: 0 0 auto; }
       /* line 104, ../../../../general/res/sass/_archetypes.scss */
-      .l-flex-row .flex-elem:not(.grows).flex-can-shrink, .l-flex-row .tree-item .view-control:not(.grows).flex-can-shrink, .tree-item .l-flex-row .view-control:not(.grows).flex-can-shrink,
-      .l-flex-row .search-result-item .view-control:not(.grows).flex-can-shrink,
-      .search-result-item .l-flex-row .view-control:not(.grows).flex-can-shrink,
-      .l-flex-col .flex-elem:not(.grows).flex-can-shrink,
-      .l-flex-col .tree-item .view-control:not(.grows).flex-can-shrink,
-      .tree-item .l-flex-col .view-control:not(.grows).flex-can-shrink,
-      .l-flex-col .search-result-item .view-control:not(.grows).flex-can-shrink,
-      .search-result-item .l-flex-col .view-control:not(.grows).flex-can-shrink {
+      .l-flex-row .flex-elem:not(.grows).flex-can-shrink,
+      .l-flex-col .flex-elem:not(.grows).flex-can-shrink {
         -webkit-flex: 0 1 auto;
         flex: 0 1 auto; }
     /* line 108, ../../../../general/res/sass/_archetypes.scss */
-    .l-flex-row .flex-elem.grows, .l-flex-row .tree-item .grows.view-control, .tree-item .l-flex-row .grows.view-control,
-    .l-flex-row .search-result-item .grows.view-control,
-    .search-result-item .l-flex-row .grows.view-control,
-    .l-flex-col .flex-elem.grows,
-    .l-flex-col .tree-item .grows.view-control,
-    .tree-item .l-flex-col .grows.view-control,
-    .l-flex-col .search-result-item .grows.view-control,
-    .search-result-item .l-flex-col .grows.view-control {
+    .l-flex-row .flex-elem.grows,
+    .l-flex-col .flex-elem.grows {
       -webkit-flex: 1 1 auto;
       flex: 1 1 auto; }
   /* line 112, ../../../../general/res/sass/_archetypes.scss */
@@ -586,14 +562,11 @@ mct-container {
   -webkit-flex-direction: row;
   flex-direction: row; }
   /* line 123, ../../../../general/res/sass/_archetypes.scss */
-  .l-flex-row.flex-elem, .tree-item .l-flex-row.view-control,
-  .search-result-item .l-flex-row.view-control {
+  .l-flex-row.flex-elem {
     -webkit-flex: 1 1 auto;
     flex: 1 1 auto; }
   /* line 124, ../../../../general/res/sass/_archetypes.scss */
-  .l-flex-row .flex-elem, .l-flex-row .tree-item .view-control, .tree-item .l-flex-row .view-control,
-  .l-flex-row .search-result-item .view-control,
-  .search-result-item .l-flex-row .view-control {
+  .l-flex-row .flex-elem {
     height: inherit;
     line-height: inherit;
     min-width: 0; }
@@ -607,14 +580,10 @@ mct-container {
   -webkit-flex-direction: column;
   flex-direction: column; }
   /* line 134, ../../../../general/res/sass/_archetypes.scss */
-  .l-flex-col .flex-elem, .l-flex-col .tree-item .view-control, .tree-item .l-flex-col .view-control,
-  .l-flex-col .search-result-item .view-control,
-  .search-result-item .l-flex-col .view-control {
+  .l-flex-col .flex-elem {
     min-height: 0; }
     /* line 136, ../../../../general/res/sass/_archetypes.scss */
-    .l-flex-col .flex-elem.holder:not(:last-child), .l-flex-col .tree-item .holder.view-control:not(:last-child), .tree-item .l-flex-col .holder.view-control:not(:last-child),
-    .l-flex-col .search-result-item .holder.view-control:not(:last-child),
-    .search-result-item .l-flex-col .holder.view-control:not(:last-child) {
+    .l-flex-col .flex-elem.holder:not(:last-child) {
       margin-bottom: 10px; }
   /* line 138, ../../../../general/res/sass/_archetypes.scss */
   .l-flex-col .flex-container {
@@ -5588,33 +5557,59 @@ ul.tree {
   .tree-item .view-control,
   .search-result-item .view-control {
     color: #666;
-    margin-right: 5px;
     font-size: 0.75em;
+    margin-right: 5px;
+    height: 100%;
+    line-height: inherit;
     width: 10px; }
     /* line 56, ../../../../general/res/sass/tree/_tree.scss */
     .tree-item .view-control.has-children:before,
     .search-result-item .view-control.has-children:before {
-      content: ">"; }
-    /* line 63, ../../../../general/res/sass/tree/_tree.scss */
+      position: absolute;
+      -moz-transition-property: -moz-transform;
+      -o-transition-property: -o-transform;
+      -webkit-transition-property: -webkit-transform;
+      transition-property: transform;
+      -moz-transition-duration: 100ms;
+      -o-transition-duration: 100ms;
+      -webkit-transition-duration: 100ms;
+      transition-duration: 100ms;
+      -moz-transition-timing-function: ease-in-out;
+      -o-transition-timing-function: ease-in-out;
+      -webkit-transition-timing-function: ease-in-out;
+      transition-timing-function: ease-in-out;
+      -moz-transition-delay: 0;
+      -o-transition-delay: 0;
+      -webkit-transition-delay: 0;
+      transition-delay: 0;
+      content: "\3e";
+      -moz-transform-origin: center 50%;
+      -ms-transform-origin: center 50%;
+      -webkit-transform-origin: center 50%;
+      transform-origin: center 50%; }
+    /* line 62, ../../../../general/res/sass/tree/_tree.scss */
     .tree-item .view-control.has-children.expanded:before,
     .search-result-item .view-control.has-children.expanded:before {
-      content: "v"; }
+      -moz-transform: rotate(90deg);
+      -ms-transform: rotate(90deg);
+      -webkit-transform: rotate(90deg);
+      transform: rotate(90deg); }
     @media only screen and (min-device-width: 1025px) and (-webkit-min-device-pixel-ratio: 1) {
-      /* line 69, ../../../../general/res/sass/tree/_tree.scss */
+      /* line 67, ../../../../general/res/sass/tree/_tree.scss */
       .tree-item .view-control:hover,
       .search-result-item .view-control:hover {
         color: #0099cc !important; } }
-  /* line 75, ../../../../general/res/sass/tree/_tree.scss */
+  /* line 73, ../../../../general/res/sass/tree/_tree.scss */
   .tree-item .t-object-label,
   .search-result-item .t-object-label {
     line-height: 1.5rem; }
-    /* line 80, ../../../../general/res/sass/tree/_tree.scss */
+    /* line 76, ../../../../general/res/sass/tree/_tree.scss */
     .tree-item .t-object-label .t-item-icon,
     .search-result-item .t-object-label .t-item-icon {
       font-size: 1.4em;
       color: #0099cc;
       width: 1.4em; }
-    /* line 91, ../../../../general/res/sass/tree/_tree.scss */
+    /* line 82, ../../../../general/res/sass/tree/_tree.scss */
     .tree-item .t-object-label .title-label,
     .tree-item .t-object-label .t-title-label,
     .search-result-item .t-object-label .title-label,
@@ -5622,47 +5617,47 @@ ul.tree {
       overflow: hidden;
       text-overflow: ellipsis;
       white-space: nowrap; }
-  /* line 100, ../../../../general/res/sass/tree/_tree.scss */
+  /* line 88, ../../../../general/res/sass/tree/_tree.scss */
   .tree-item.selected,
   .search-result-item.selected {
     background: #1ac6ff;
     color: #fcfcfc; }
-    /* line 103, ../../../../general/res/sass/tree/_tree.scss */
+    /* line 91, ../../../../general/res/sass/tree/_tree.scss */
     .tree-item.selected .view-control,
     .search-result-item.selected .view-control {
       color: #fcfcfc; }
-    /* line 106, ../../../../general/res/sass/tree/_tree.scss */
+    /* line 94, ../../../../general/res/sass/tree/_tree.scss */
     .tree-item.selected .t-object-label .t-item-icon,
     .search-result-item.selected .t-object-label .t-item-icon {
       color: #fcfcfc; }
   @media only screen and (min-device-width: 1025px) and (-webkit-min-device-pixel-ratio: 1) {
-    /* line 114, ../../../../general/res/sass/tree/_tree.scss */
+    /* line 102, ../../../../general/res/sass/tree/_tree.scss */
     .tree-item:not(.selected):hover,
     .search-result-item:not(.selected):hover {
       background: rgba(102, 102, 102, 0.1);
       color: #333333; }
-      /* line 117, ../../../../general/res/sass/tree/_tree.scss */
+      /* line 105, ../../../../general/res/sass/tree/_tree.scss */
       .tree-item:not(.selected):hover .t-item-icon,
       .search-result-item:not(.selected):hover .t-item-icon {
         color: #0099cc; } }
-  /* line 124, ../../../../general/res/sass/tree/_tree.scss */
+  /* line 112, ../../../../general/res/sass/tree/_tree.scss */
   .tree-item:not(.loading),
   .search-result-item:not(.loading) {
     cursor: pointer; }
-  /* line 128, ../../../../general/res/sass/tree/_tree.scss */
+  /* line 116, ../../../../general/res/sass/tree/_tree.scss */
   .tree-item .context-trigger,
   .search-result-item .context-trigger {
     top: -1px;
     position: absolute;
     right: 3px; }
-    /* line 133, ../../../../general/res/sass/tree/_tree.scss */
+    /* line 121, ../../../../general/res/sass/tree/_tree.scss */
     .tree-item .context-trigger .invoke-menu,
     .search-result-item .context-trigger .invoke-menu {
       font-size: 0.75em;
       height: 0.9rem;
       line-height: 0.9rem; }
 
-/* line 148, ../../../../general/res/sass/tree/_tree.scss */
+/* line 136, ../../../../general/res/sass/tree/_tree.scss */
 .tree-item mct-representation.s-status-pending .t-object-label:before {
   -moz-animation-name: rotateCentered;
   -webkit-animation-name: rotateCentered;
@@ -5709,7 +5704,7 @@ ul.tree {
     -ms-transform: translateX(-50%) translateY(-50%) rotate(359deg);
     -webkit-transform: translateX(-50%) translateY(-50%) rotate(359deg);
     transform: translateX(-50%) translateY(-50%) rotate(359deg); } }
-/* line 152, ../../../../general/res/sass/tree/_tree.scss */
+/* line 140, ../../../../general/res/sass/tree/_tree.scss */
 .tree-item mct-representation.s-status-pending .t-object-label .t-item-icon .t-item-icon-glyph {
   display: none; }
 
@@ -5737,7 +5732,7 @@ ul.tree {
 @media only screen and (orientation: portrait) and (max-device-width: 767px), only screen and (orientation: landscape) and (max-device-width: 767px), only screen and (orientation: portrait) and (min-device-width: 768px) and (max-device-width: 1024px), only screen and (orientation: landscape) and (min-device-width: 768px) and (max-device-width: 1024px) {
   /* line 27, ../../../../general/res/sass/mobile/_tree.scss */
   ul.tree ul.tree {
-    margin-left: 20px; }
+    margin-left: 15px; }
 
   /* line 31, ../../../../general/res/sass/mobile/_tree.scss */
   .tree-item,
@@ -5748,20 +5743,27 @@ ul.tree {
     /* line 36, ../../../../general/res/sass/mobile/_tree.scss */
     .tree-item .view-control,
     .search-result-item .view-control {
-      position: absolute;
-      font-size: 1.1em;
-      height: 35px;
-      line-height: inherit;
-      right: 0px;
-      width: 30px;
-      text-align: center; }
-    /* line 47, ../../../../general/res/sass/mobile/_tree.scss */
-    .tree-item .label,
+      order: 2;
+      width: 35px; }
+      /* line 40, ../../../../general/res/sass/mobile/_tree.scss */
+      .tree-item .view-control.has-children:before,
+      .search-result-item .view-control.has-children:before {
+        content: "\7d";
+        left: 50%;
+        -moz-transform: translateX(-50%) rotate(90deg);
+        -ms-transform: translateX(-50%) rotate(90deg);
+        -webkit-transform: translateX(-50%) rotate(90deg);
+        transform: translateX(-50%) rotate(90deg); }
+      /* line 45, ../../../../general/res/sass/mobile/_tree.scss */
+      .tree-item .view-control.has-children.expanded:before,
+      .search-result-item .view-control.has-children.expanded:before {
+        -moz-transform: translateX(-50%) rotate(270deg);
+        -ms-transform: translateX(-50%) rotate(270deg);
+        -webkit-transform: translateX(-50%) rotate(270deg);
+        transform: translateX(-50%) rotate(270deg); }
+    /* line 50, ../../../../general/res/sass/mobile/_tree.scss */
     .tree-item .t-object-label,
-    .search-result-item .label,
     .search-result-item .t-object-label {
-      left: 0;
-      right: 35px;
       line-height: inherit; } }
 /*****************************************************************************
  * Open MCT Web, Copyright (c) 2014-2015, United States Government

--- a/platform/commonUI/themes/snow/res/css/theme-snow.css
+++ b/platform/commonUI/themes/snow/res/css/theme-snow.css
@@ -830,10 +830,12 @@ mct-container {
 
 /* line 84, ../../../../general/res/sass/_icons.scss */
 .t-item-icon {
-  display: inline-block;
   line-height: normal;
   position: relative; }
-  /* line 93, ../../../../general/res/sass/_icons.scss */
+  /* line 91, ../../../../general/res/sass/_icons.scss */
+  .t-item-icon .t-item-icon-glyph {
+    position: relative; }
+  /* line 96, ../../../../general/res/sass/_icons.scss */
   .t-item-icon.l-icon-link .t-item-icon-glyph:before {
     color: #49dedb;
     content: "\f4";

--- a/platform/search/res/templates/search-item.html
+++ b/platform/search/res/templates/search-item.html
@@ -20,11 +20,12 @@
  at runtime from the About dialog for additional information.
 --> 
 
-<div class="search-result-item"
+<div class="search-result-item l-flex-row flex-elem grows"
      ng-class="{selected: ngModel.selectedObject.getId() === domainObject.getId()}">
     <mct-representation key="'label'"
                         mct-object="domainObject"
                         ng-model="ngModel"
-                        ng-click="ngModel.selectedObject = domainObject">
+                        ng-click="ngModel.selectedObject = domainObject"
+                        class="l-flex-row flex-elem grows">
     </mct-representation>
 </div>

--- a/platform/search/res/templates/search.html
+++ b/platform/search/res/templates/search.html
@@ -48,7 +48,8 @@
         <mct-representation key="'search-item'"
                             ng-repeat="result in results"
                             mct-object="result.object"
-                            ng-model="ngModel">
+                            ng-model="ngModel"
+                            class="l-flex-row flex-elem grows">
         </mct-representation>
         <a class="load-more-button s-btn vsm" ng-if="controller.areMore()" ng-click="controller.loadMore()">More Results</a>
     </div>

--- a/platform/search/res/templates/search.html
+++ b/platform/search/res/templates/search.html
@@ -20,11 +20,13 @@
  at runtime from the About dialog for additional information.
 -->
 <div class="l-flex-col flex-elem grows holder holder-search"  ng-controller="SearchController as controller">
-    <div class="search-bar flex-elem" ng-controller="ClickAwayController as toggle">
+    <div class="search-bar flex-elem"
+         ng-controller="ClickAwayController as toggle"
+         ng-class="{ holder: !(ngModel.input === '' || ngModel.input === undefined) }">
         <input class="search-input"
                type="text"
                ng-model="ngModel.input"
-               ng-keyup="controller.search()" />
+               ng-keyup="controller.search()"/>
         <a class="clear-icon"
            ng-class="{show: !(ngModel.input === '' || ngModel.input === undefined)}"
            ng-click="ngModel.input = ''; controller.search()"></a>
@@ -37,13 +39,13 @@
                      ng-click="toggle.setState(true)">
         </mct-include>
     </div>
-    <div class="active-filter-display flex-elem"
+    <div class="active-filter-display flex-elem holder"
          ng-class="{off: ngModel.filtersString === '' || ngModel.filtersString === undefined || !ngModel.search}"
          ng-controller="SearchMenuController as menuController">
         <a class="clear-icon clear-filters-icon"
            ng-click="ngModel.checkAll = true; menuController.checkAll()"></a>Filtered by: {{ ngModel.filtersString }}
     </div>
-    <div class="search-results flex-elem grows vscroll"
+    <div class="search-results flex-elem holder grows vscroll"
          ng-class="{ off: !(loading || results.length > 0), loading: loading }">
         <mct-representation key="'search-item'"
                             ng-repeat="result in results"


### PR DESCRIPTION
#431 
**Pending status**: Adds solid `s-status-pending` support for object labels anywhere they are used, in tree, search results, Inspector location objects, edit mode's "Elements" pool. Add `s-status-pending` to the label's `mct-representation` class attribute.
**Markup mods**: As part of making pending status implementation a clean one, the label template, and tree items, were converted to use flex-box layout. Markup and styles have been extensively unit tested in the browser's mobile emulation mode.
**Changes to mobile navigation in the tree**: As part of the markup mods previously noted, markup in tree-node.html was greatly simplified. Multiple elements using `mct-device` have been eliminated. Mobile navigation is now more consistent with the desktop: tapping a tree item navigates, while the `view-control` element functions, though laid out differently, the same as it does in the desktop. 

**Author checklist:**
- Changes address original issue? Y
- Unit tests included and/or updated with changes? N/A (no code changed)
- Command line build passes? Y
- Expect to pass code review? Y