### PR TITLE
[Duplicate] Avoid error when rewriting IDs in single-element arrays

### DIFF
--- a/platform/entanglement/src/services/CopyTask.js
+++ b/platform/entanglement/src/services/CopyTask.js
@@ -114,15 +114,19 @@ define(
          * @private
          */
         CopyTask.prototype.rewriteIdentifiers = function (obj, idMap) {
+            function lookupValue(value) {
+                return (typeof value === 'string' && idMap[value]) || value;
+            }
+
             if (Array.isArray(obj)) {
                 obj.forEach(function (value, index) {
-                    obj[index] = idMap[value] || value;
+                    obj[index] = lookupValue(value);
                     this.rewriteIdentifiers(obj[index], idMap);
                 }, this);
             } else if (obj && typeof obj === 'object') {
                 Object.keys(obj).forEach(function (key) {
                     var value = obj[key];
-                    obj[key] = idMap[value] || value;
+                    obj[key] = lookupValue(value);
                     if (idMap[key]) {
                         delete obj[key];
                         obj[idMap[key]] = value;

--- a/platform/entanglement/test/services/CopyTaskSpec.js
+++ b/platform/entanglement/test/services/CopyTaskSpec.js
@@ -106,7 +106,8 @@ define(
                     composition: [ ID_A, ID_B ],
                     someObj: {},
                     someArr: [ ID_A, ID_B ],
-                    objArr: [{"id": ID_A}, {"id": ID_B}]
+                    objArr: [{"id": ID_A}, {"id": ID_B}],
+                    singleElementArr: [ ID_A ]
                 };
                 testModel.someObj[ID_A] = "some value";
                 testModel.someObj.someProperty = ID_B;
@@ -180,6 +181,13 @@ define(
                 it("contain rewritten identifiers in property names", function () {
                     expect(model.someObj[cloneIds[ID_A]])
                         .toEqual(testModel.someObj[ID_A]);
+                });
+
+                it("contain rewritten identifiers in single-element arrays", function () {
+                    expect(model.singleElementArr)
+                        .toEqual(testModel.singleElementArr.map(function (id) {
+                            return cloneIds[id];
+                        }));
                 });
             });
 


### PR DESCRIPTION
Addresses #444 
