### PR TITLE
[Mobile] Add classes for device characteristics to body

### DIFF
--- a/platform/commonUI/mobile/bundle.json
+++ b/platform/commonUI/mobile/bundle.json
@@ -13,6 +13,12 @@
                 "implementation": "AgentService.js",
                 "depends": [ "$window" ]
             }
+        ],
+        "runs": [
+            {
+                "implementation": "DeviceClassifier.js",
+                "depends": [ "agentService", "$document" ]
+            }
         ]
     }
 }

--- a/platform/commonUI/mobile/src/AgentService.js
+++ b/platform/commonUI/mobile/src/AgentService.js
@@ -46,6 +46,7 @@ define(
             this.userAgent = userAgent;
             this.mobileName = matches[0];
             this.$window = $window;
+            this.touchEnabled = ($window.ontouchstart !== undefined);
         }
 
         /**
@@ -90,6 +91,14 @@ define(
          */
         AgentService.prototype.isLandscape = function () {
             return !this.isPortrait();
+        };
+
+        /**
+         * Check if the user's device supports a touch interface.
+         * @returns {boolean} true if touch is supported
+         */
+        AgentService.prototype.isTouch = function () {
+            return this.touchEnabled;
         };
 
         /**

--- a/platform/commonUI/mobile/src/DeviceClassifier.js
+++ b/platform/commonUI/mobile/src/DeviceClassifier.js
@@ -1,0 +1,58 @@
+/*****************************************************************************
+ * Open MCT Web, Copyright (c) 2014-2015, United States Government
+ * as represented by the Administrator of the National Aeronautics and Space
+ * Administration. All rights reserved.
+ *
+ * Open MCT Web is licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * Open MCT Web includes source code licensed under additional open source
+ * licenses. See the Open Source Licenses file (LICENSES.md) included with
+ * this source code distribution or the Licensing information page available
+ * at runtime from the About dialog for additional information.
+ *****************************************************************************/
+/*global define,Promise*/
+
+define(
+    ['./DeviceMatchers'],
+    function (DeviceMatchers) {
+        'use strict';
+
+        /**
+         * Runs at application startup and adds a subset of the following
+         * CSS classes to the body of the document, depending on device
+         * attributes:
+         *
+         * * `mobile`: Phones or tablets.
+         * * `phone`: Phones specifically.
+         * * `tablet`: Tablets specifically.
+         * * `desktop`: Non-mobile devices.
+         * * `portrait`: Devices in a portrait-style orientation.
+         * * `landscape`: Devices in a landscape-style orientation.
+         *
+         * @param {platform/commonUI/mobile.AgentService} agentService
+         *        the service used to examine the user agent
+         * @param $document Angular's jqLite-wrapped document element
+         * @constructor
+         */
+        function MobileClassifier(agentService, $document) {
+            var body = $document.find('body');
+            Object.keys(DeviceMatchers).forEach(function (key) {
+                if (DeviceMatchers[key](agentService)) {
+                    body.addClass(key);
+                }
+            });
+        }
+
+        return MobileClassifier;
+
+    }
+);

--- a/platform/commonUI/mobile/src/DeviceClassifier.js
+++ b/platform/commonUI/mobile/src/DeviceClassifier.js
@@ -37,6 +37,7 @@ define(
          * * `desktop`: Non-mobile devices.
          * * `portrait`: Devices in a portrait-style orientation.
          * * `landscape`: Devices in a landscape-style orientation.
+         * * `touch`: Device supports touch events.
          *
          * @param {platform/commonUI/mobile.AgentService} agentService
          *        the service used to examine the user agent

--- a/platform/commonUI/mobile/src/DeviceMatchers.js
+++ b/platform/commonUI/mobile/src/DeviceMatchers.js
@@ -1,0 +1,57 @@
+/*****************************************************************************
+ * Open MCT Web, Copyright (c) 2014-2015, United States Government
+ * as represented by the Administrator of the National Aeronautics and Space
+ * Administration. All rights reserved.
+ *
+ * Open MCT Web is licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * Open MCT Web includes source code licensed under additional open source
+ * licenses. See the Open Source Licenses file (LICENSES.md) included with
+ * this source code distribution or the Licensing information page available
+ * at runtime from the About dialog for additional information.
+ *****************************************************************************/
+/*global define*/
+define(function () {
+    "use strict";
+
+    /**
+     * An object containing key-value pairs, where keys are symbolic of
+     * device attributes, and values are functions that take the
+     * `agentService` as inputs and return boolean values indicating
+     * whether or not the current device has these attributes.
+     *
+     * For internal use by the mobile support bundle.
+     *
+     * @memberof platform/commonUI/mobile
+     * @private
+     */
+    return {
+        mobile: function (agentService) {
+            return agentService.isMobile();
+        },
+        phone: function (agentService) {
+            return agentService.isPhone();
+        },
+        tablet: function (agentService) {
+            return agentService.isTablet();
+        },
+        desktop: function (agentService) {
+            return !agentService.isMobile();
+        },
+        portrait: function (agentService) {
+            return agentService.isPortrait();
+        },
+        landscape: function (agentService) {
+            return agentService.isLandscape();
+        }
+    };
+});

--- a/platform/commonUI/mobile/src/DeviceMatchers.js
+++ b/platform/commonUI/mobile/src/DeviceMatchers.js
@@ -52,6 +52,9 @@ define(function () {
         },
         landscape: function (agentService) {
             return agentService.isLandscape();
+        },
+        touch: function (agentService) {
+            return agentService.isTouch();
         }
     };
 });

--- a/platform/commonUI/mobile/src/MCTDevice.js
+++ b/platform/commonUI/mobile/src/MCTDevice.js
@@ -22,30 +22,9 @@
 /*global define,Promise*/
 
 define(
-    function () {
+    ['./DeviceMatchers'],
+    function (DeviceMatchers) {
         'use strict';
-
-        var DEVICE_MATCHERS = {
-            mobile: function (agentService) {
-                return agentService.isMobile();
-            },
-            phone: function (agentService) {
-                return agentService.isPhone();
-            },
-            tablet: function (agentService) {
-                return agentService.isTablet();
-            },
-            desktop: function (agentService) {
-                return !agentService.isMobile();
-            },
-            portrait: function (agentService) {
-                return agentService.isPortrait();
-            },
-            landscape: function (agentService) {
-                return agentService.isLandscape();
-            }
-        };
-
 
         /**
          * The `mct-device` directive, when applied as an attribute,
@@ -77,7 +56,7 @@ define(
             function deviceMatches(tokens) {
                 tokens = tokens || "";
                 return tokens.split(" ").every(function (token) {
-                    var fn = DEVICE_MATCHERS[token];
+                    var fn = DeviceMatchers[token];
                     return fn && fn(agentService);
                 });
             }

--- a/platform/commonUI/mobile/src/MCTDevice.js
+++ b/platform/commonUI/mobile/src/MCTDevice.js
@@ -47,6 +47,7 @@ define(
          * * `desktop`: Non-mobile devices.
          * * `portrait`: Devices in a portrait-style orientation.
          * * `landscape`: Devices in a landscape-style orientation.
+         * * `touch`: Device supports touch events.
          *
          * @param {AgentService} agentService used to detect device type
          *        based on information about the user agent

--- a/platform/commonUI/mobile/test/AgentServiceSpec.js
+++ b/platform/commonUI/mobile/test/AgentServiceSpec.js
@@ -82,6 +82,15 @@ define(
                 expect(agentService.isLandscape()).toBeFalsy();
             });
 
+            it("detects touch support", function () {
+                testWindow.ontouchstart = null;
+                expect(new AgentService(testWindow).isTouch())
+                    .toBe(true);
+                delete testWindow.ontouchstart;
+                expect(new AgentService(testWindow).isTouch())
+                    .toBe(false);
+            });
+
             it("allows for checking browser type", function () {
                 testWindow.navigator.userAgent = "Chromezilla Safarifox";
                 agentService = new AgentService(testWindow);

--- a/platform/commonUI/mobile/test/DeviceClassifierSpec.js
+++ b/platform/commonUI/mobile/test/DeviceClassifierSpec.js
@@ -1,0 +1,112 @@
+/*****************************************************************************
+ * Open MCT Web, Copyright (c) 2014-2015, United States Government
+ * as represented by the Administrator of the National Aeronautics and Space
+ * Administration. All rights reserved.
+ *
+ * Open MCT Web is licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * Open MCT Web includes source code licensed under additional open source
+ * licenses. See the Open Source Licenses file (LICENSES.md) included with
+ * this source code distribution or the Licensing information page available
+ * at runtime from the About dialog for additional information.
+ *****************************************************************************/
+/*global define,Promise,describe,it,expect,beforeEach,waitsFor,jasmine*/
+
+
+define(
+    ["../src/DeviceClassifier", "../src/DeviceMatchers"],
+    function (DeviceClassifier, DeviceMatchers) {
+        "use strict";
+
+        var AGENT_SERVICE_METHODS = [
+                'isMobile',
+                'isPhone',
+                'isTablet',
+                'isPortrait',
+                'isLandscape',
+                'isTouch'
+            ],
+            TEST_PERMUTATIONS = [
+                [ 'isMobile', 'isPhone', 'isTouch', 'isPortrait' ],
+                [ 'isMobile', 'isPhone', 'isTouch', 'isLandscape' ],
+                [ 'isMobile', 'isTablet', 'isTouch', 'isPortrait' ],
+                [ 'isMobile', 'isTablet', 'isTouch', 'isLandscape' ],
+                [ 'isTouch' ],
+                []
+            ];
+
+        describe("DeviceClassifier", function () {
+            var mockAgentService,
+                mockDocument,
+                mockBody;
+
+            beforeEach(function () {
+                mockAgentService = jasmine.createSpyObj(
+                    'agentService',
+                    AGENT_SERVICE_METHODS
+                );
+                mockDocument = jasmine.createSpyObj(
+                    '$document',
+                    [ 'find' ]
+                );
+                mockBody = jasmine.createSpyObj(
+                    'body',
+                    [ 'addClass' ]
+                );
+                mockDocument.find.andCallFake(function (sel) {
+                    return sel === 'body' && mockBody;
+                });
+                AGENT_SERVICE_METHODS.forEach(function (m) {
+                    mockAgentService[m].andReturn(false);
+                });
+            });
+
+            TEST_PERMUTATIONS.forEach(function (trueMethods) {
+                var summary = trueMethods.length === 0 ?
+                        "device has no detected characteristics" :
+                        "device " + (trueMethods.join(", "));
+
+                describe("when " + summary, function () {
+                    var classifier;
+
+                    beforeEach(function () {
+                        trueMethods.forEach(function (m) {
+                            mockAgentService[m].andReturn(true);
+                        });
+                        classifier = new DeviceClassifier(
+                            mockAgentService,
+                            mockDocument
+                        );
+                    });
+                    
+                    it("adds classes for matching, detected characteristics", function () {
+                        Object.keys(DeviceMatchers).filter(function (m) {
+                            return DeviceMatchers[m](mockAgentService);
+                        }).forEach(function (key) {
+                            expect(mockBody.addClass)
+                                .toHaveBeenCalledWith(key);
+                        });
+                    });
+
+                    it("does not add classes for non-matching characteristics", function () {
+                        Object.keys(DeviceMatchers).filter(function (m) {
+                            return !DeviceMatchers[m](mockAgentService);
+                        }).forEach(function (key) {
+                            expect(mockBody.addClass)
+                                .not.toHaveBeenCalledWith(key);
+                        });
+                    });
+                });
+            });
+        });
+    }
+);

--- a/platform/commonUI/mobile/test/DeviceClassifierSpec.js
+++ b/platform/commonUI/mobile/test/DeviceClassifierSpec.js
@@ -87,7 +87,7 @@ define(
                             mockDocument
                         );
                     });
-                    
+
                     it("adds classes for matching, detected characteristics", function () {
                         Object.keys(DeviceMatchers).filter(function (m) {
                             return DeviceMatchers[m](mockAgentService);

--- a/platform/commonUI/mobile/test/DeviceMatchersSpec.js
+++ b/platform/commonUI/mobile/test/DeviceMatchersSpec.js
@@ -1,0 +1,81 @@
+/*****************************************************************************
+ * Open MCT Web, Copyright (c) 2014-2015, United States Government
+ * as represented by the Administrator of the National Aeronautics and Space
+ * Administration. All rights reserved.
+ *
+ * Open MCT Web is licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * Open MCT Web includes source code licensed under additional open source
+ * licenses. See the Open Source Licenses file (LICENSES.md) included with
+ * this source code distribution or the Licensing information page available
+ * at runtime from the About dialog for additional information.
+ *****************************************************************************/
+/*global define,Promise,describe,it,expect,beforeEach,waitsFor,jasmine*/
+
+
+define(
+    ["../src/DeviceMatchers"],
+    function (DeviceMatchers) {
+        'use strict';
+
+        describe("DeviceMatchers", function () {
+            var mockAgentService;
+
+            beforeEach(function () {
+                mockAgentService = jasmine.createSpyObj(
+                    'agentService',
+                    [
+                        'isMobile',
+                        'isPhone',
+                        'isTablet',
+                        'isPortrait',
+                        'isLandscape',
+                        'isTouch'
+                    ]
+                );
+            });
+
+            it("detects when a device is a desktop device", function () {
+                mockAgentService.isMobile.andReturn(false);
+                expect(DeviceMatchers.desktop(mockAgentService))
+                    .toBe(true);
+                mockAgentService.isMobile.andReturn(true);
+                expect(DeviceMatchers.desktop(mockAgentService))
+                    .toBe(false);
+            });
+
+            function method(deviceType) {
+                return "is" + deviceType[0].toUpperCase() + deviceType.slice(1);
+            }
+
+            [
+                "mobile",
+                "phone",
+                "tablet",
+                "landscape",
+                "portrait",
+                "landscape",
+                "touch"
+            ].forEach(function (deviceType) {
+                it("detects when a device is a " + deviceType + " device", function () {
+                    mockAgentService[method(deviceType)].andReturn(true);
+                    expect(DeviceMatchers[deviceType](mockAgentService))
+                        .toBe(true);
+                    mockAgentService[method(deviceType)].andReturn(false);
+                    expect(DeviceMatchers[deviceType](mockAgentService))
+                        .toBe(false);
+                });
+            });
+
+        });
+    }
+);

--- a/platform/commonUI/mobile/test/suite.json
+++ b/platform/commonUI/mobile/test/suite.json
@@ -1,4 +1,5 @@
 [
     "AgentService",
+    "DeviceClassifier",
     "MCTDevice"
 ]

--- a/platform/commonUI/mobile/test/suite.json
+++ b/platform/commonUI/mobile/test/suite.json
@@ -1,5 +1,6 @@
 [
     "AgentService",
     "DeviceClassifier",
+    "DeviceMatchers",
     "MCTDevice"
 ]


### PR DESCRIPTION
Add a subset of the following CSS classes to body on application startup:

* `mobile`: Phones or tablets.
* `phone`: Phones specifically.
* `tablet`: Tablets specifically.
* `desktop`: Non-mobile devices.
* `portrait`: Devices in a portrait-style orientation.
* `landscape`: Devices in a landscape-style orientation.
* `touch`: Device supports touch events.

Class names are intentionally aligned with detectors supported by the `mct-device` directive.

Requested by @charlesh88 in the context of #169