### PR TITLE
[Time Conductor] Update validation logic

### DIFF
--- a/platform/commonUI/general/res/templates/controls/datetime-field.html
+++ b/platform/commonUI/general/res/templates/controls/datetime-field.html
@@ -25,8 +25,7 @@
            ng-model="textValue"
            ng-blur="restoreTextValue(); ngBlur()"
            ng-class="{
-                     error: textInvalid,
-                     test: structure.validate && !structure.validate(ngModel[field])
+                     error: textInvalid || (structure.validate && !structure.validate(ngModel[field]))
                      }">
     </input>
     <a class="ui-symbol icon icon-calendar"

--- a/platform/commonUI/general/res/templates/controls/datetime-field.html
+++ b/platform/commonUI/general/res/templates/controls/datetime-field.html
@@ -24,7 +24,7 @@
     <input type="text"
            ng-model="textValue"
            ng-blur="restoreTextValue(); ngBlur()"
-           ng-class="{ error: textInvalid }">
+           ng-class="{ error: textInvalid, test: valueInvalid }">
     </input>
     <a class="ui-symbol icon icon-calendar"
        ng-if="structure.format === 'utc' || !structure.format"

--- a/platform/commonUI/general/res/templates/controls/datetime-field.html
+++ b/platform/commonUI/general/res/templates/controls/datetime-field.html
@@ -24,7 +24,7 @@
     <input type="text"
            ng-model="textValue"
            ng-blur="restoreTextValue(); ngBlur()"
-           ng-class="{ error: textInvalid, test: valueInvalid }">
+           ng-class="{ error: textInvalid }">
     </input>
     <a class="ui-symbol icon icon-calendar"
        ng-if="structure.format === 'utc' || !structure.format"

--- a/platform/commonUI/general/res/templates/controls/datetime-field.html
+++ b/platform/commonUI/general/res/templates/controls/datetime-field.html
@@ -24,7 +24,10 @@
     <input type="text"
            ng-model="textValue"
            ng-blur="restoreTextValue(); ngBlur()"
-           ng-class="{ error: textInvalid }">
+           ng-class="{
+                     error: textInvalid,
+                     test: structure.validate && !structure.validate(ngModel[field])
+                     }">
     </input>
     <a class="ui-symbol icon icon-calendar"
        ng-if="structure.format === 'utc' || !structure.format"

--- a/platform/commonUI/general/res/templates/controls/datetime-field.html
+++ b/platform/commonUI/general/res/templates/controls/datetime-field.html
@@ -25,7 +25,9 @@
            ng-model="textValue"
            ng-blur="restoreTextValue(); ngBlur()"
            ng-class="{
-                     error: textInvalid || (structure.validate && !structure.validate(ngModel[field]))
+                        error: textInvalid ||
+                            (structure.validate &&
+                                !structure.validate(ngModel[field]))
                      }">
     </input>
     <a class="ui-symbol icon icon-calendar"

--- a/platform/commonUI/general/res/templates/controls/time-controller.html
+++ b/platform/commonUI/general/res/templates/controls/time-controller.html
@@ -25,7 +25,7 @@
         <span class="l-time-range-inputs-elem ui-symbol type-icon">&#x43;</span>
         <span class="l-time-range-input">
             <mct-control key="'datetime-field'"
-                         structure="{ format: parameters.format }"
+                         structure="{ format: parameters.format, validate: validateStart }"
                          ng-model="formModel"
                          ng-blur="updateBoundsFromForm()"
                          field="'start'"
@@ -37,7 +37,7 @@
 
         <span class="l-time-range-input" ng-controller="ToggleController as t2">
             <mct-control key="'datetime-field'"
-                         structure="{ format: parameters.format }"
+                         structure="{ format: parameters.format, validate: validateEnd }"
                          ng-model="formModel"
                          ng-blur="updateBoundsFromForm()"
                          field="'end'"

--- a/platform/commonUI/general/src/controllers/DateTimeFieldController.js
+++ b/platform/commonUI/general/src/controllers/DateTimeFieldController.js
@@ -26,6 +26,10 @@ define(
     function () {
         'use strict';
 
+        function ACCEPT() {
+            return true;
+        }
+
         /**
          * Controller to support the date-time entry field.
          *
@@ -44,7 +48,8 @@ define(
          *        format has been otherwise specified
          */
         function DateTimeFieldController($scope, formatService, defaultFormat) {
-            var formatter = formatService.getFormat(defaultFormat);
+            var formatter = formatService.getFormat(defaultFormat),
+                validate = ACCEPT;
 
             function updateFromModel(value) {
                 // Only reformat if the value is different from user
@@ -59,10 +64,12 @@ define(
             }
 
             function updateFromView(textValue) {
+                var newValue;
                 $scope.textInvalid = !formatter.validate(textValue);
                 if (!$scope.textInvalid) {
-                    $scope.ngModel[$scope.field] =
-                        formatter.parse(textValue);
+                    newValue = formatter.parse(textValue);
+                    $scope.valueInvalid = !validate(newValue);
+                    $scope.ngModel[$scope.field] = newValue;
                     $scope.lastValidValue = $scope.textValue;
                 }
             }
@@ -82,6 +89,10 @@ define(
                 updateFromModel($scope.ngModel[$scope.field]);
             }
 
+            function setValidator(newValidator) {
+                validate = newValidator || ACCEPT;
+            }
+
             function restoreTextValue() {
                 $scope.textValue = $scope.lastValidValue;
                 updateFromView($scope.textValue);
@@ -95,7 +106,7 @@ define(
             $scope.$watch('ngModel[field]', updateFromModel);
             $scope.$watch('pickerModel.value', updateFromPicker);
             $scope.$watch('textValue', updateFromView);
-
+            $scope.$watch('structure.validate', setValidator);
         }
 
         return DateTimeFieldController;

--- a/platform/commonUI/general/src/controllers/DateTimeFieldController.js
+++ b/platform/commonUI/general/src/controllers/DateTimeFieldController.js
@@ -26,10 +26,6 @@ define(
     function () {
         'use strict';
 
-        function ACCEPT() {
-            return true;
-        }
-
         /**
          * Controller to support the date-time entry field.
          *
@@ -48,8 +44,7 @@ define(
          *        format has been otherwise specified
          */
         function DateTimeFieldController($scope, formatService, defaultFormat) {
-            var formatter = formatService.getFormat(defaultFormat),
-                validate = ACCEPT;
+            var formatter = formatService.getFormat(defaultFormat);
 
             function updateFromModel(value) {
                 // Only reformat if the value is different from user
@@ -64,12 +59,10 @@ define(
             }
 
             function updateFromView(textValue) {
-                var newValue;
                 $scope.textInvalid = !formatter.validate(textValue);
                 if (!$scope.textInvalid) {
-                    newValue = formatter.parse(textValue);
-                    $scope.valueInvalid = !validate(newValue);
-                    $scope.ngModel[$scope.field] = newValue;
+                    $scope.ngModel[$scope.field] =
+                        formatter.parse(textValue);
                     $scope.lastValidValue = $scope.textValue;
                 }
             }
@@ -89,10 +82,6 @@ define(
                 updateFromModel($scope.ngModel[$scope.field]);
             }
 
-            function setValidator(newValidator) {
-                validate = newValidator || ACCEPT;
-            }
-
             function restoreTextValue() {
                 $scope.textValue = $scope.lastValidValue;
                 updateFromView($scope.textValue);
@@ -106,7 +95,7 @@ define(
             $scope.$watch('ngModel[field]', updateFromModel);
             $scope.$watch('pickerModel.value', updateFromPicker);
             $scope.$watch('textValue', updateFromView);
-            $scope.$watch('structure.validate', setValidator);
+
         }
 
         return DateTimeFieldController;

--- a/platform/commonUI/general/src/controllers/TimeRangeController.js
+++ b/platform/commonUI/general/src/controllers/TimeRangeController.js
@@ -43,7 +43,7 @@ define(
         function TimeRangeController($scope, formatService, defaultFormat, now) {
             var tickCount = 2,
                 innerMinimumSpan = 1000, // 1 second
-                outerMinimumSpan = 1000 * 60 * 60, // 1 hour
+                outerMinimumSpan = 1000, // 1 hour
                 initialDragValue,
                 formatter = formatService.getFormat(defaultFormat);
 

--- a/platform/commonUI/general/src/controllers/TimeRangeController.js
+++ b/platform/commonUI/general/src/controllers/TimeRangeController.js
@@ -240,6 +240,14 @@ define(
                 };
             }
 
+            function validateStart(startValue) {
+                return startValue <= $scope.ngModel.outer.end - outerMinimumSpan;
+            }
+
+            function validateEnd(endValue) {
+                return endValue >= $scope.ngModel.outer.start + outerMinimumSpan;
+            }
+
             $scope.startLeftDrag = startLeftDrag;
             $scope.startRightDrag = startRightDrag;
             $scope.startMiddleDrag = startMiddleDrag;
@@ -248,6 +256,9 @@ define(
             $scope.middleDrag = middleDrag;
 
             $scope.updateBoundsFromForm = updateBoundsFromForm;
+
+            $scope.validateStart = validateStart;
+            $scope.validateEnd = validateEnd;
 
             $scope.ticks = [];
 

--- a/platform/commonUI/general/src/controllers/TimeRangeController.js
+++ b/platform/commonUI/general/src/controllers/TimeRangeController.js
@@ -185,13 +185,6 @@ define(
             function updateOuterStart(t) {
                 var ngModel = $scope.ngModel;
 
-                ngModel.outer.start = t;
-
-                ngModel.outer.end = Math.max(
-                    ngModel.outer.start + outerMinimumSpan,
-                    ngModel.outer.end
-                );
-
                 ngModel.inner.start =
                     Math.max(ngModel.outer.start, ngModel.inner.start);
                 ngModel.inner.end = Math.max(
@@ -206,13 +199,6 @@ define(
 
             function updateOuterEnd(t) {
                 var ngModel = $scope.ngModel;
-
-                ngModel.outer.end = t;
-
-                ngModel.outer.start = Math.min(
-                    ngModel.outer.end - outerMinimumSpan,
-                    ngModel.outer.start
-                );
 
                 ngModel.inner.end =
                     Math.min(ngModel.outer.end, ngModel.inner.end);
@@ -233,19 +219,20 @@ define(
             }
 
             function updateBoundsFromForm() {
-                $scope.ngModel = $scope.ngModel || {};
-                $scope.ngModel.outer = {
-                    start: $scope.formModel.start,
-                    end: $scope.formModel.end
-                };
+                var start = $scope.formModel.start,
+                    end = $scope.formModel.end;
+                if (end >= start + outerMinimumSpan) {
+                    $scope.ngModel = $scope.ngModel || {};
+                    $scope.ngModel.outer = { start: start, end: end };
+                }
             }
 
             function validateStart(startValue) {
-                return startValue <= $scope.ngModel.outer.end - outerMinimumSpan;
+                return startValue <= $scope.formModel.end - outerMinimumSpan;
             }
 
             function validateEnd(endValue) {
-                return endValue >= $scope.ngModel.outer.start + outerMinimumSpan;
+                return endValue >= $scope.formModel.start + outerMinimumSpan;
             }
 
             $scope.startLeftDrag = startLeftDrag;

--- a/platform/commonUI/general/src/controllers/TimeRangeController.js
+++ b/platform/commonUI/general/src/controllers/TimeRangeController.js
@@ -43,7 +43,7 @@ define(
         function TimeRangeController($scope, formatService, defaultFormat, now) {
             var tickCount = 2,
                 innerMinimumSpan = 1000, // 1 second
-                outerMinimumSpan = 1000, // 1 hour
+                outerMinimumSpan = 1000, // 1 second
                 initialDragValue,
                 formatter = formatService.getFormat(defaultFormat);
 

--- a/platform/commonUI/general/test/controllers/TimeRangeControllerSpec.js
+++ b/platform/commonUI/general/test/controllers/TimeRangeControllerSpec.js
@@ -91,6 +91,24 @@ define(
                     .toHaveBeenCalledWith("ngModel", jasmine.any(Function));
             });
 
+            it("exposes start time validator", function () {
+                var testValue = 42000000;
+                mockScope.ngModel.outer = { end: testValue };
+                expect(mockScope.validateStart(testValue + 1))
+                    .toBe(false);
+                expect(mockScope.validateStart(testValue - 60 * 60 * 1000 - 1))
+                    .toBe(true);
+            });
+
+            it("exposes end time validator", function () {
+                var testValue = 42000000;
+                mockScope.ngModel.outer = { start:  testValue };
+                expect(mockScope.validateEnd(testValue - 1))
+                    .toBe(false);
+                expect(mockScope.validateEnd(testValue + 60 * 60 * 1000 + 1))
+                    .toBe(true);
+            });
+
             describe("when changes are made via form entry", function () {
                 beforeEach(function () {
                     mockScope.ngModel = {

--- a/platform/commonUI/general/test/controllers/TimeRangeControllerSpec.js
+++ b/platform/commonUI/general/test/controllers/TimeRangeControllerSpec.js
@@ -93,7 +93,7 @@ define(
 
             it("exposes start time validator", function () {
                 var testValue = 42000000;
-                mockScope.ngModel.outer = { end: testValue };
+                mockScope.formModel = { end: testValue };
                 expect(mockScope.validateStart(testValue + 1))
                     .toBe(false);
                 expect(mockScope.validateStart(testValue - 60 * 60 * 1000 - 1))
@@ -102,7 +102,7 @@ define(
 
             it("exposes end time validator", function () {
                 var testValue = 42000000;
-                mockScope.ngModel.outer = { start:  testValue };
+                mockScope.formModel = { start:  testValue };
                 expect(mockScope.validateEnd(testValue - 1))
                     .toBe(false);
                 expect(mockScope.validateEnd(testValue + 60 * 60 * 1000 + 1))
@@ -210,26 +210,6 @@ define(
                     mockScope.spanWidth = 1000;
                     fireWatch("spanWidth", mockScope.spanWidth);
                     fireWatchCollection("ngModel", mockScope.ngModel);
-                });
-
-                it("enforces a minimum outer span", function () {
-                    mockScope.ngModel.outer.end =
-                        mockScope.ngModel.outer.start - DAY * 100;
-                    fireWatch(
-                        "ngModel.outer.end",
-                        mockScope.ngModel.outer.end
-                    );
-                    expect(mockScope.ngModel.outer.end)
-                        .toBeGreaterThan(mockScope.ngModel.outer.start);
-
-                    mockScope.ngModel.outer.start =
-                        mockScope.ngModel.outer.end + DAY * 100;
-                    fireWatch(
-                        "ngModel.outer.start",
-                        mockScope.ngModel.outer.start
-                    );
-                    expect(mockScope.ngModel.outer.end)
-                        .toBeGreaterThan(mockScope.ngModel.outer.start);
                 });
 
                 it("enforces a minimum inner span when outer span changes", function () {


### PR DESCRIPTION
Addresses #325, updating validation approach in cases where user-entered start time exceeds user-entered end time.

* Display start/end violations as validity violations (with `error` class)
  * Utilize `validate` function passed into date-time fields as part of their form structure (consistent with other `mct-control`s)
  * Pass in such `validate` functions from the time range control
* Don't "fix" start/end violations when user tabs/submits; instead, simply don't update the outer bounds until form input is valid
* Reduce minimum outer bounds span to 1 second

### Author Checklist

1. Changes address original issue? Y
2. Unit tests included and/or updated with changes? Y
3. Command line build passes? Y
4. Changes have been smoke-tested? Y