### PR TITLE
[Create] #491 Apply default context root in Locator when none available from object

### DIFF
--- a/platform/commonUI/browse/bundle.js
+++ b/platform/commonUI/browse/bundle.js
@@ -117,7 +117,8 @@ define([
                     "implementation": LocatorController,
                     "depends": [
                         "$scope",
-                        "$timeout"
+                        "$timeout",
+                        "objectService"
                     ]
                 },
                 {

--- a/platform/commonUI/browse/src/creation/LocatorController.js
+++ b/platform/commonUI/browse/src/creation/LocatorController.js
@@ -33,7 +33,7 @@ define(
          * @memberof platform/commonUI/browse
          * @constructor
          */
-        function LocatorController($scope, $timeout) {
+        function LocatorController($scope, $timeout, objectService) {
             // Populate values needed by the locator control. These are:
             // * rootObject: The top-level object, since we want to show
             //               the full tree
@@ -52,6 +52,18 @@ define(
                         $scope.rootObject =
                             (context && context.getRoot()) || $scope.rootObject;
                     }, 0);
+                } else if (!contextRoot){
+                    //If no context root is available, default to the root
+                    // object
+                    $scope.rootObject = undefined;
+                    // Update the displayed tree on a timeout to avoid
+                    // an infinite digest exception.
+                    objectService.getObjects(['ROOT'])
+                        .then(function(objects){
+                            $timeout(function () {
+                                $scope.rootObject = objects.ROOT;
+                            }, 0);
+                        });
                 }
 
                 $scope.treeModel.selectedObject = domainObject;


### PR DESCRIPTION
## Summary of changes:
* Fetch default root (the ROOT object) if no context is available from the provided object. Allows user in the worst case complete control over location to persist new object. The changes in #500 that make Locator optional will prevent the default context from adversely affecting the case of activities added to timelines.
* New test for default context

## Author Checklist

1. Changes address original issue? __Y__
2. Unit tests included and/or updated with changes? __Y__
3. Command line build passes? __Y__
4. Changes have been smoke-tested? __Y__