### PR TITLE
[Notifications] #499 All notifications now dismissable by default.

### DIFF
--- a/platform/commonUI/dialog/res/templates/overlay-message-list.html
+++ b/platform/commonUI/dialog/res/templates/overlay-message-list.html
@@ -6,7 +6,9 @@
             </div>
         </div>
         <div class="abs message-body">
-            <mct-include ng-repeat="msg in ngModel.dialog.messages | orderBy: '-'" key="'message'" ng-model="msg"></mct-include>
+            <mct-include
+                    ng-repeat="msg in ngModel.dialog.messages | orderBy: '-'"
+                    key="'message'" ng-model="msg.model"></mct-include>
         </div>
         <div class="abs bottom-bar">
             <a ng-repeat="dialogAction in ngModel.dialog.actions"

--- a/platform/commonUI/general/src/controllers/BannerController.js
+++ b/platform/commonUI/general/src/controllers/BannerController.js
@@ -60,6 +60,12 @@ define(
                     notification.model.cancel = function(){
                         dialogService.dismiss();
                     };
+                    //If the notification is dismissed by the user, close
+                    // the dialog.
+                    notification.onDismiss(function(){
+                        dialogService.dismiss();
+                    });
+
                     dialogService.showBlockingMessage(notification.model);
                 }
             };

--- a/platform/commonUI/notification/bundle.js
+++ b/platform/commonUI/notification/bundle.js
@@ -79,6 +79,7 @@ define([
                     "implementation": NotificationService,
                     "depends": [
                         "$timeout",
+                        "topic",
                         "DEFAULT_AUTO_DISMISS",
                         "MINIMIZE_TIMEOUT"
                     ]

--- a/platform/commonUI/notification/src/NotificationIndicatorController.js
+++ b/platform/commonUI/notification/src/NotificationIndicatorController.js
@@ -50,9 +50,7 @@ define(
                         title: "Messages",
                         //Launch the message list dialog with the models
                         // from the notifications
-                        messages: notificationService.notifications && notificationService.notifications.map(function(notification){
-                            return notification.model;
-                        })
+                        messages: notificationService.notifications
                     },
                     cancel: function(){
                         dialogService.dismiss();

--- a/platform/commonUI/notification/src/NotificationService.js
+++ b/platform/commonUI/notification/src/NotificationService.js
@@ -67,7 +67,7 @@ define(
          * be automatically minimized or dismissed (depending on severity).
          * Additionally, if the provided value is a number, it will be used
          * as the delay period before being dismissed.
-         * @property {boolean} [dismissable=true] If truthy, notification will
+         * @property {boolean} [dismissable=true] If true, notification will
          * include an option to dismiss it completely.
          * @property {NotificationOption} [primaryOption] the default user
          * response to

--- a/platform/core/src/capabilities/PersistenceCapability.js
+++ b/platform/core/src/capabilities/PersistenceCapability.js
@@ -104,15 +104,14 @@ define(
          * persistence.
          */
         function notifyOnError(error, domainObject, notificationService, $q){
-            var errorMessage = "Unable to persist " + domainObject.getModel().name,
-                notification;
+            var errorMessage = "Unable to persist " + domainObject.getModel().name;
             if (error) {
                 errorMessage += ": " + formatError(error);
             }
 
-            notification = notificationService.error({
+            notificationService.error({
                 title: "Error persisting " + domainObject.getModel().name,
-                hint: errorMessage || "Unknown error",
+                hint: errorMessage,
                 dismissable: true
             });
 

--- a/platform/core/src/capabilities/PersistenceCapability.js
+++ b/platform/core/src/capabilities/PersistenceCapability.js
@@ -104,14 +104,16 @@ define(
          * persistence.
          */
         function notifyOnError(error, domainObject, notificationService, $q){
-            var errorMessage = "Unable to persist " + domainObject.getModel().name;
+            var errorMessage = "Unable to persist " + domainObject.getModel().name,
+                notification;
             if (error) {
                 errorMessage += ": " + formatError(error);
             }
 
-            notificationService.error({
+            notification = notificationService.error({
                 title: "Error persisting " + domainObject.getModel().name,
-                hint: errorMessage || "Unknown error"
+                hint: errorMessage || "Unknown error",
+                dismissable: true
             });
 
             return $q.reject(error);


### PR DESCRIPTION
Addresses #499

## Changes
* Added a new 'dismissable' attribute to notification
* All notifications now dismissable by default
* Notifications with dismassable !== false will have a dismiss action added to them automatically.
* Added new dismiss listener so that functions calling notifications can take some action if the notification is dismissed.

## Author checklist
1. Changes address original issue? __Y__
2. Unit tests included and/or updated with changes? __Y__
3. Command line build passes? __Y__
4. Changes have been smoke-tested? __Y__