### PR TITLE
[Edit Mode] Added ability to clear all dirty cache

### DIFF
--- a/platform/commonUI/edit/src/capabilities/EditorCapability.js
+++ b/platform/commonUI/edit/src/capabilities/EditorCapability.js
@@ -125,7 +125,7 @@ define(
         EditorCapability.prototype.cancel = function () {
             this.editableObject.getCapability("status").set("editing", false);
             //TODO: Reset the cache as well here.
-            this.cache.markClean(this.editableObject);
+            this.cache.markClean();
             return resolvePromise(undefined);
         };
 

--- a/platform/commonUI/edit/src/objects/EditableDomainObjectCache.js
+++ b/platform/commonUI/edit/src/objects/EditableDomainObjectCache.js
@@ -126,7 +126,14 @@ define(
          * @param {DomainObject} domainObject the domain object
          */
         EditableDomainObjectCache.prototype.markClean = function (domainObject) {
-            delete this.dirtyObjects[domainObject.getId()];
+            var self = this;
+            if (!domainObject) {
+                Object.keys(this.dirtyObjects).forEach(function(key) {
+                    delete self.dirtyObjects[key];
+                });
+            } else {
+                delete this.dirtyObjects[domainObject.getId()];
+            }
         };
 
         /**


### PR DESCRIPTION
Addresses #660 

Problem manifested with sub-object editing in timelines as an unload warning on cancel followed by unexpected behavior. This was due to the fact that in current NEM the cancel action clears the dirty cache, however previously it was only removing the currently editing object from the cache. This caused problems in timelines which support a degree of sub-object editing, resulting in potentially multiple dirty objects in the cache. 

This modification allows clearing of the entire dirty cache in one go.

This problem does not manifest in #627 due to changes that support slightly more elegant handling of navigation change events. Clearing of the dirty cache was introduced in NEM, but subsequent refactoring should remove the need for it.


### Author Checklist

1. Changes address original issue? __Y__
2. Unit tests included and/or updated with changes? __N__ * Errant code was introduced as part of NEM and should be refactored out
3. Command line build passes? __Y__
4. Changes have been smoke-tested? __Y__

