### PR TITLE
[Create] Utilize copyService during Save As

### DIFF
--- a/platform/commonUI/edit/bundle.js
+++ b/platform/commonUI/edit/bundle.js
@@ -156,11 +156,7 @@ define([
                     "name": "Save",
                     "description": "Save changes made to these objects.",
                     "depends": [
-                        "$q",
-                        "$location",
                         "$injector",
-                        "urlService",
-                        "navigationService",
                         "policyService",
                         "dialogService",
                         "creationService",

--- a/platform/commonUI/edit/bundle.js
+++ b/platform/commonUI/edit/bundle.js
@@ -163,7 +163,8 @@ define([
                         "navigationService",
                         "policyService",
                         "dialogService",
-                        "creationService"
+                        "creationService",
+                        "copyService"
                     ],
                     "priority": "mandatory"
                 },

--- a/platform/commonUI/edit/src/actions/SaveAction.js
+++ b/platform/commonUI/edit/src/actions/SaveAction.js
@@ -106,12 +106,13 @@ define(
                 return fetchObject(object.getModel().location);
             }
 
-            function isOriginal(domainObject) {
-                return domainObject.getCapability('location').isOriginal();
+            function allowClone(objectToClone) {
+                return (objectToClone.getId() === domainObject.getId()) ||
+                    objectToClone.getCapability('location').isOriginal();
             }
 
             function cloneIntoParent(parent) {
-                return copyService.perform(domainObject, parent, isOriginal);
+                return copyService.perform(domainObject, parent, allowClone);
             }
 
             function cancelEditingAfterClone(clonedObject) {

--- a/platform/commonUI/edit/src/actions/SaveAction.js
+++ b/platform/commonUI/edit/src/actions/SaveAction.js
@@ -118,7 +118,7 @@ define(
             function doSave() {
                 //This is a new 'virtual object' that has not been persisted
                 // yet.
-                if (!domainObject.getModel().persisted){
+                if (domainObject.getModel().persisted === undefined){
                     return getParent(domainObject)
                         .then(doWizardSave)
                         .then(getParent)

--- a/platform/commonUI/edit/src/actions/SaveAction.js
+++ b/platform/commonUI/edit/src/actions/SaveAction.js
@@ -132,6 +132,11 @@ define(
                 return false;
             }
 
+            function cancelEditingAfterClone(clonedObject) {
+                return domainObject.getCapability("editor").cancel()
+                    .then(resolveWith(clonedObject));
+            }
+
             // Invoke any save behavior introduced by the editor capability;
             // this is introduced by EditableDomainObject which is
             // used to insulate underlying objects from changes made
@@ -142,10 +147,9 @@ define(
                 if (!domainObject.getModel().persisted){
                     return getParent(domainObject)
                         .then(doWizardSave)
-                        .then(copyService.perform.bind(
-                            copyService,
-                            [ domainObject ]
-                        ))
+                        .then(getParent)
+                        .then(copyService.perform.bind(copyService, domainObject))
+                        .then(cancelEditingAfterClone)
                         .catch(doNothing);
                 } else {
                     return domainObject.getCapability("editor").save()

--- a/platform/commonUI/edit/src/actions/SaveAction.js
+++ b/platform/commonUI/edit/src/actions/SaveAction.js
@@ -106,6 +106,14 @@ define(
                 return fetchObject(object.getModel().location);
             }
 
+            function isOriginal(domainObject) {
+                return domainObject.getCapability('location').isOriginal();
+            }
+
+            function cloneIntoParent(parent) {
+                return copyService.perform(domainObject, parent, isOriginal);
+            }
+
             function cancelEditingAfterClone(clonedObject) {
                 return domainObject.getCapability("editor").cancel()
                     .then(resolveWith(clonedObject));
@@ -122,7 +130,7 @@ define(
                     return getParent(domainObject)
                         .then(doWizardSave)
                         .then(getParent)
-                        .then(copyService.perform.bind(copyService, domainObject))
+                        .then(cloneIntoParent)
                         .then(cancelEditingAfterClone)
                         .catch(resolveWith(false));
                 } else {

--- a/platform/entanglement/src/services/CopyService.js
+++ b/platform/entanglement/src/services/CopyService.js
@@ -55,15 +55,32 @@ define(
         };
 
         /**
+         * A function used to check if a domain object should be cloned
+         * or not.
+         * @callback platform/entanglement.CopyService~filter
+         * @param {DomainObject} domainObject the object to be cloned
+         * @returns {boolean} true if the object should be cloned; false
+         *          if it should be linked
+         */
+
+        /**
          * Creates a duplicate of the object tree starting at domainObject to
          * the new parent specified.
-         * @param domainObject
-         * @param parent
-         * @param progress
+         *
+         * Any domain objects which cannot be created will not be cloned;
+         * instead, these will appear as links. If a filtering function
+         * is provided, any objects which fail that check will also be
+         * linked instead of cloned
+         *
+         * @param {DomainObject} domainObject the object to duplicate
+         * @param {DomainObject} parent the destination for the clone
+         * @param {platform/entanglement.CopyService~filter} [filter]
+         *        an optional function used to filter out objects from
+         *        the cloning process
          * @returns a promise that will be completed with the clone of
          * domainObject when the duplication is successful.
          */
-        CopyService.prototype.perform = function (domainObject, parent) {
+        CopyService.prototype.perform = function (domainObject, parent, filter) {
             var $q = this.$q,
                 copyTask = new CopyTask(domainObject, parent, this.policyService, this.$q);
             if (this.validate(domainObject, parent)) {

--- a/platform/entanglement/src/services/CopyService.js
+++ b/platform/entanglement/src/services/CopyService.js
@@ -83,7 +83,9 @@ define(
         CopyService.prototype.perform = function (domainObject, parent, filter) {
             var policyService = this.policyService;
 
-            function completeFilter(domainObject) {
+            // Combines caller-provided filter (if any) with the
+            // baseline behavior of respecting creation policy.
+            function filterWithPolicy(domainObject) {
                 return (!filter || filter(domainObject)) &&
                     policyService.allow(
                         "creation",
@@ -95,7 +97,7 @@ define(
                 return new CopyTask(
                     domainObject,
                     parent,
-                    completeFilter,
+                    filterWithPolicy,
                     this.$q
                 ).perform();
             } else {

--- a/platform/entanglement/src/services/CopyService.js
+++ b/platform/entanglement/src/services/CopyService.js
@@ -81,10 +81,23 @@ define(
          * domainObject when the duplication is successful.
          */
         CopyService.prototype.perform = function (domainObject, parent, filter) {
-            var $q = this.$q,
-                copyTask = new CopyTask(domainObject, parent, this.policyService, this.$q);
+            var policyService = this.policyService;
+
+            function completeFilter(domainObject) {
+                return (!filter || filter(domainObject)) &&
+                    policyService.allow(
+                        "creation",
+                        domainObject.getCapability("type")
+                    );
+            }
+
             if (this.validate(domainObject, parent)) {
-                return copyTask.perform();
+                return new CopyTask(
+                    domainObject,
+                    parent,
+                    completeFilter,
+                    this.$q
+                ).perform();
             } else {
                 throw new Error(
                     "Tried to copy objects without validating first."

--- a/platform/entanglement/src/services/CopyTask.js
+++ b/platform/entanglement/src/services/CopyTask.js
@@ -31,18 +31,21 @@ define(
          * This class encapsulates the process of copying a domain object
          * and all of its children.
          *
-         * @param domainObject The object to copy
-         * @param parent The new location of the cloned object tree
-         * @param $q
+         * @param {DomainObject} domainObject The object to copy
+         * @param {DomainObject} parent The new location of the cloned object tree
+         * @param {platform/entanglement.CopyService~filter} filter
+         *        a function used to filter out objects from
+         *        the cloning process
+         * @param $q Angular's $q, for promises
          * @constructor
          */
-        function CopyTask (domainObject, parent, policyService, $q){
+        function CopyTask (domainObject, parent, filter, $q){
             this.domainObject = domainObject;
             this.parent = parent;
             this.firstClone = undefined;
             this.$q = $q;
             this.deferred = undefined;
-            this.policyService = policyService;
+            this.filter = filter;
             this.persisted = 0;
             this.clones = [];
             this.idMap = {};
@@ -198,7 +201,7 @@ define(
             //Check if the type of the object being copied allows for
             // creation of new instances. If it does not, then a link to the
             // original will be created instead.
-            if (this.policyService.allow("creation", originalObject.getCapability("type"))){
+            if (this.filter(originalObject)) {
                 //create a new clone of the original object. Use the
                 // creation capability of the targetParent to create the
                 // new clone. This will ensure that the correct persistence

--- a/platform/entanglement/src/services/CopyTask.js
+++ b/platform/entanglement/src/services/CopyTask.js
@@ -105,7 +105,7 @@ define(
          */
         function addClonesToParent(self) {
             return self.parent.getCapability("composition")
-                .add(self.firstClone.getId())
+                .add(self.firstClone)
                 .then(function (addedClone) {
                     return self.parent.getCapability("persistence").persist()
                         .then(function () {

--- a/platform/entanglement/src/services/CopyTask.js
+++ b/platform/entanglement/src/services/CopyTask.js
@@ -101,9 +101,14 @@ define(
          * Will add a list of clones to the specified parent's composition
          */
         function addClonesToParent(self) {
-            self.parent.getCapability("composition").add(self.firstClone.getId());
-            return self.parent.getCapability("persistence").persist()
-                .then(function(){return self.firstClone;});
+            return self.parent.getCapability("composition")
+                .add(self.firstClone.getId())
+                .then(function (addedClone) {
+                    return self.parent.getCapability("persistence").persist()
+                        .then(function () {
+                            return addedClone;
+                        });
+                });
         }
 
         /**

--- a/platform/entanglement/test/services/CopyServiceSpec.js
+++ b/platform/entanglement/test/services/CopyServiceSpec.js
@@ -162,6 +162,7 @@ define(
                         'compositionCapability',
                         ['invoke', 'add']
                     );
+                    compositionCapability.add.andCallFake(synchronousPromise);
 
                     locationCapability = jasmine.createSpyObj(
                         'locationCapability',
@@ -401,8 +402,8 @@ define(
                         it ("creates link instead of clone", function() {
                             var copiedObject = copyFinished.calls[0].args[0];
                             expect(copiedObject).toBe(object);
-                            expect(compositionCapability.add).toHaveBeenCalledWith(copiedObject.getId());
-                            //expect(newParent.getModel().composition).toContain(copiedObject.getId());
+                            expect(compositionCapability.add)
+                                .toHaveBeenCalledWith(copiedObject);
                         });
                     });
                 });

--- a/platform/entanglement/test/services/CopyServiceSpec.js
+++ b/platform/entanglement/test/services/CopyServiceSpec.js
@@ -388,6 +388,7 @@ define(
                             expect(childObjectClone.getModel().location).toEqual(objectClone.getId());
                         });
                     });
+
                     describe("when cloning non-creatable objects", function() {
                         beforeEach(function () {
                             policyService.allow.andCallFake(function(category){
@@ -404,6 +405,31 @@ define(
                             expect(copiedObject).toBe(object);
                             expect(compositionCapability.add)
                                 .toHaveBeenCalledWith(copiedObject);
+                        });
+                    });
+
+                    describe("when provided a filtering function", function () {
+                        function accept() {
+                            return true;
+                        }
+                        function reject() {
+                            return false;
+                        }
+
+                        it("does not create new instances of objects " +
+                            "rejected by the filter", function() {
+                            copyService.perform(object, newParent, reject)
+                                .then(copyFinished);
+                            expect(copyFinished.mostRecentCall.args[0])
+                                .toBe(object);
+                        });
+
+                        it("does create new instances of objects " +
+                            "accepted by the filter", function() {
+                            copyService.perform(object, newParent, accept)
+                                .then(copyFinished);
+                            expect(copyFinished.mostRecentCall.args[0])
+                                .not.toBe(object);
                         });
                     });
                 });

--- a/platform/entanglement/test/services/CopyTaskSpec.js
+++ b/platform/entanglement/test/services/CopyTaskSpec.js
@@ -44,11 +44,10 @@ define(
         describe("CopyTask", function () {
             var mockDomainObject,
                 mockParentObject,
-                mockPolicyService,
+                mockFilter,
                 mockQ,
                 mockDeferred,
                 testModel,
-                mockCallback,
                 counter,
                 cloneIds,
                 task;
@@ -119,17 +118,14 @@ define(
                 mockParentObject = domainObjectFactory({
                     capabilities: makeMockCapabilities()
                 });
-                mockPolicyService = jasmine.createSpyObj(
-                    'policyService',
-                    [ 'allow' ]
-                );
+                mockFilter = jasmine.createSpy('filter');
                 mockQ = jasmine.createSpyObj('$q', ['when', 'defer', 'all']);
                 mockDeferred = jasmine.createSpyObj(
                     'deferred',
                     [ 'notify', 'resolve', 'reject' ]
                 );
 
-                mockPolicyService.allow.andReturn(true);
+                mockFilter.andReturn(true);
 
                 mockQ.when.andCallFake(synchronousPromise);
                 mockQ.defer.andReturn(mockDeferred);
@@ -156,7 +152,7 @@ define(
                     task = new CopyTask(
                         mockDomainObject,
                         mockParentObject,
-                        mockPolicyService,
+                        mockFilter,
                         mockQ
                     );
 
@@ -218,7 +214,7 @@ define(
                     task = new CopyTask(
                         mockComposingObject,
                         mockParentObject,
-                        mockPolicyService,
+                        mockFilter,
                         mockQ
                     );
 


### PR DESCRIPTION
Utilize `copyService` during Save As; this allows the destination's persistence space to be used for newly-persisted objects.

Addresses #656, wherein an attempt to persist to a non-writable space results in persistence failure. (Also addresses a subtle corollary bug where objects are persisted to the _wrong_ persistence space; see [discussion](https://github.com/nasa/openmctweb/issues/656#issuecomment-182533470).)

Also removed some unused (or non-needed) dependencies and unused functions, partially addressing #630. (It was easier to follow the code for debugging purposes this way.) This is out of scope for the original issue, and I'd be happy to roll these back based on review.

Opening PR now for early review. Still to-do:

- [x] Add/update test cases
- [x] Try this out in a multi-persistence-space environment
- [x] Verify fix of originally reported issue
- [x] [Don't clone links](https://github.com/nasa/openmctweb/pull/666#discussion_r52525612)