### PR TITLE
[New Edit Mode] #659 Fix to timelines

### DIFF
--- a/platform/containment/src/ComposeActionPolicy.js
+++ b/platform/containment/src/ComposeActionPolicy.js
@@ -55,11 +55,12 @@ define(
             this.policyService = this.policyService || this.getPolicyService();
 
             // ...and delegate to the composition policy
-            return this.policyService.allow(
-                'composition',
-                containerType,
-                selectedType
-            );
+            return containerObject.getId() !== selectedObject.getId() &&
+                this.policyService.allow(
+                    'composition',
+                    containerType,
+                    selectedType
+                );
         };
 
         /**

--- a/platform/features/timeline/src/directives/MCTSwimlaneDrop.js
+++ b/platform/features/timeline/src/directives/MCTSwimlaneDrop.js
@@ -85,6 +85,7 @@ define(
                     );
 
                 if (id) {
+                    event.stopPropagation();
                     // Delegate the drop to the swimlane itself
                     swimlane.drop(id, (draggedSwimlane || {}).domainObject);
                 }

--- a/platform/features/timeline/test/directives/MCTSwimlaneDropSpec.js
+++ b/platform/features/timeline/test/directives/MCTSwimlaneDropSpec.js
@@ -87,7 +87,8 @@ define(
                 testEvent = {
                     pageY: TEST_TOP + TEST_HEIGHT / 10,
                     dataTransfer: { getData: jasmine.createSpy() },
-                    preventDefault: jasmine.createSpy()
+                    preventDefault: jasmine.createSpy(),
+                    stopPropagation: jasmine.createSpy()
                 };
 
                 testEvent.dataTransfer.getData.andReturn('abc');


### PR DESCRIPTION
Addresses https://github.com/nasa/openmctweb/issues/659#issuecomment-182659801

### Changes
* Added a check to the ComposeActionPolicy to prevent composition of an object with itself. Suggest that in future this could be added as a separate composition policy, but might require some refactoring of Composition policies to pass in object instances rather than types, or alternatively a new policy type that accepts object instances.
* Prevented propagation of drop event from timeline up to `DropGesture`. Suggest refactor of TimelineSwimlaneDropHandler to use DropGesture + actions instead of a dedicated drop handler

### Author Checklist

1. Changes address original issue? __Y__
2. Unit tests included and/or updated with changes? __Y__
3. Command line build passes? __Y__
4. Changes have been smoke-tested? __Y__
