### PR TITLE
[Timelines] #677 Applied fix to prevent editing of timelines in browse

### DIFF
--- a/platform/commonUI/browse/res/templates/browse-object.html
+++ b/platform/commonUI/browse/res/templates/browse-object.html
@@ -44,7 +44,7 @@
         </div>
     </div>
     <div class="holder l-flex-col flex-elem grows l-object-wrapper">
-        <div class="holder l-flex-col flex-elem grows l-object-wrapper-inner">
+        <div ng-if="isEditable" class="holder l-flex-col flex-elem grows l-object-wrapper-inner">
             <!-- Toolbar and Save/Cancel buttons -->
             <div class="l-edit-controls flex-elem l-flex-row flex-align-end">
                 <mct-toolbar name="mctToolbar"
@@ -63,6 +63,20 @@
                                 class="abs flex-elem grows object-holder-main scroll"
                                 toolbar="toolbar">
             </mct-representation>
-        </div><!--/ l-object-wrapper-inner -->
+        </div>
+        <div ng-if="!isEditable" class="holder l-flex-col flex-elem grows l-object-wrapper-inner">
+            <!-- Toolbar and Save/Cancel buttons -->
+            <div class="l-edit-controls flex-elem l-flex-row flex-align-end">
+                <mct-representation key="'edit-action-buttons'"
+                                    mct-object="domainObject"
+                                    class='flex-elem conclude-editing'>
+                </mct-representation>
+
+            </div>
+            <mct-representation key="representation.selected.key"
+                                mct-object="representation.selected.key && domainObject"
+                                class="abs flex-elem grows object-holder-main scroll">
+            </mct-representation>
+        </div>
     </div>
 </div>

--- a/platform/commonUI/edit/src/representers/EditRepresenter.js
+++ b/platform/commonUI/edit/src/representers/EditRepresenter.js
@@ -109,6 +109,8 @@ define(
             // Track the represented object
             this.domainObject = representedObject;
 
+            this.scope.isEditable = representedObject.getCapability('status').get('editing');
+
             // Ensure existing watches are released
             this.destroy();
         };

--- a/platform/commonUI/edit/test/representers/EditRepresenterSpec.js
+++ b/platform/commonUI/edit/test/representers/EditRepresenterSpec.js
@@ -33,6 +33,8 @@ define(
                 testRepresentation,
                 mockDomainObject,
                 mockPersistence,
+                mockCapabilities,
+                mockStatusCapability,
                 representer;
 
             function mockPromise(value) {
@@ -57,11 +59,20 @@ define(
                 ]);
                 mockPersistence =
                     jasmine.createSpyObj("persistence", ["persist"]);
+                mockStatusCapability =
+                    jasmine.createSpyObj("status", ["get"]);
+                mockStatusCapability.get.andReturn(false);
+                mockCapabilities = {
+                    'persistence': mockPersistence,
+                    'status': mockStatusCapability
+                };
 
                 mockDomainObject.getModel.andReturn({});
                 mockDomainObject.hasCapability.andReturn(true);
                 mockDomainObject.useCapability.andReturn(true);
-                mockDomainObject.getCapability.andReturn(mockPersistence);
+                mockDomainObject.getCapability.andCallFake(function(capability){
+                    return mockCapabilities[capability];
+                });
 
                 representer = new EditRepresenter(mockQ, mockLog, mockScope);
                 representer.represent(testRepresentation, mockDomainObject);


### PR DESCRIPTION
### Changes
* Added flag "isEditable" to edit representer. This is used for conditional inclusion of markup in browse-object.html
* Added temporary conditional markup block to browse-object.html to include or not include toolbar depending on edit state. This will no longer be necessary when the changes for #627 are merged.

### Author Checklist

1. Changes address original issue? Y
2. Unit tests included and/or updated with changes? N/A * 
3. Command line build passes? Y
4. Changes have been smoke-tested? Y