### PR TITLE
[Examples] #703 Changed imagery telemetry metadata to use 'utc' format

### DIFF
--- a/example/imagery/bundle.js
+++ b/example/imagery/bundle.js
@@ -60,7 +60,7 @@ define([
                             {
                                 "name": "Time",
                                 "key": "time",
-                                "format": "timestamp"
+                                "format": "utc"
                             }
                         ],
                         "ranges": [


### PR DESCRIPTION
This is to address #703 where errors are shown in scrolling lists for imagery data.

### Author Checklist

1. Changes address original issue? __Y__
2. Unit tests included and/or updated with changes? __N/A__
3. Command line build passes? __Y__
4. Changes have been smoke-tested? __Y__