### PR TITLE
[Build] run JSHint on circleci, generate test reports

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -13,3 +13,6 @@ deployment:
     branch: mobile
     heroku:
       appname: openmctweb-staging-deux
+test:
+  post:
+    - npm run jshint --silent

--- a/example/export/ExportTelemetryAsCSVAction.js
+++ b/example/export/ExportTelemetryAsCSVAction.js
@@ -57,14 +57,23 @@ define([], function () {
                 rows = [],
                 row,
                 i;
+
+            function copyDomainsToRow(row, index) {
+                domains.forEach(function (domain) {
+                    row[domain.name] = series.getDomainValue(index, domain.key);
+                });
+            }
+
+            function copyRangesToRow(row, index) {
+                ranges.forEach(function (range) {
+                    row[range.name] = series.getRangeValue(index, range.key);
+                });
+            }
+
             for (i = 0; i < series.getPointCount(); i += 1) {
                 row = {};
-                domains.forEach(function (domain) {
-                    row[domain.name] = series.getDomainValue(i, domain.key);
-                });
-                ranges.forEach(function (range) {
-                    row[range.name] = series.getRangeValue(i, range.key);
-                });
+                copyDomainsToRow(row, i);
+                copyRangesToRow(row, i);
                 rows.push(row);
             }
             exportService.exportCSV(rows, { headers: headers });

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -20,7 +20,7 @@
  * at runtime from the About dialog for additional information.
  *****************************************************************************/
 
-/*global module*/
+/*global module,process*/
 module.exports = function(config) {
     config.set({
 
@@ -79,7 +79,9 @@ module.exports = function(config) {
 
         // Code coverage reporting.
         coverageReporter: {
-            dir: "dist/coverage"
+            dir: process.env.CIRCLE_ARTIFACTS ?
+                process.env.CIRCLE_ARTIFACTS + '/coverage' :
+                "dist/coverage"
         },
 
         // HTML test reporting.
@@ -90,7 +92,7 @@ module.exports = function(config) {
         },
 
         junitReporter: {
-            outputDir: process.env.CIRCLE_TEST_REPORTS || 'target/junit',
+            outputDir: process.env.CIRCLE_TEST_REPORTS || 'target/junit'
         },
 
         // Continuous Integration mode.

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -58,7 +58,7 @@ module.exports = function(config) {
         // Test results reporter to use
         // Possible values: 'dots', 'progress'
         // Available reporters: https://npmjs.org/browse/keyword/karma-reporter
-        reporters: ['progress', 'coverage', 'html'],
+        reporters: ['progress', 'coverage', 'html', 'junit'],
 
         // Web server port.
         port: 9876,
@@ -87,6 +87,10 @@ module.exports = function(config) {
             outputDir: "target/tests",
             preserveDescribeNesting: true,
             foldAll: false
+        },
+
+        junitReporter: {
+            outputDir: process.env.CIRCLE_TEST_REPORTS || 'target/junit',
         },
 
         // Continuous Integration mode.

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   "scripts": {
     "start": "node app.js",
     "test": "karma start --single-run",
-    "jshint": "jshint platform example || exit 0",
+    "jshint": "jshint platform example",
     "watch": "karma start",
     "jsdoc": "jsdoc -c jsdoc.json -r -d target/docs/api",
     "otherdoc": "node docs/gendocs.js --in docs/src --out target/docs --suppress-toc 'docs/src/index.md|docs/src/process/index.md'",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "karma-coverage": "^0.5.3",
     "karma-html-reporter": "^0.2.7",
     "karma-jasmine": "^0.1.5",
+    "karma-junit-reporter": "^0.3.8",
     "karma-phantomjs-launcher": "^1.0.0",
     "karma-requirejs": "^0.2.2",
     "lodash": "^3.10.1",


### PR DESCRIPTION
This wasn't directly inspired by an issue; I noticed that circleci wasn't running JSHint so it wouldn't catch style errors.  Added JSHint to the circle configuration and fixed some style issues that would result in a broken build.

Also added a junit test reporter which allows circleci to gather profiling information about our tests and improves the reporting capabilities of circleci.

# Author Checklist

1. Changes address original issue? N*
2. Unit tests included and/or updated with changes? N
3. Command line build passes? Y
4. Changes have been smoke-tested? Y

* Did not have an original issue.
