### PR TITLE
[Build] Enforce code coverage threshold

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -81,7 +81,12 @@ module.exports = function(config) {
         coverageReporter: {
             dir: process.env.CIRCLE_ARTIFACTS ?
                 process.env.CIRCLE_ARTIFACTS + '/coverage' :
-                "dist/coverage"
+                "dist/coverage",
+            check: {
+                global: {
+                    lines: 80
+                }
+            }
         },
 
         // HTML test reporting.


### PR DESCRIPTION
Addresses #672 

Keeping it simple: Enforce 80% global coverage consistent with existing [test standards](https://github.com/nasa/openmctweb/blob/dd0f9ab74e1c9ba39136bc8c17805a866c2bcbe1/CONTRIBUTING.md#test-standards).

@larkin / @akhenry - this is also an opportunity to discuss coverage requirements, if there's any interest in adjusting these. (For my part, I don't think coverage is a hugely useful metric; I do like enforcing some standard as a barrier against under-testing, and to encourage qualities associated with testability, but beyond that the value is not clear to me.)

### Author Checklist

1. Changes address original issue? Y
2. Unit tests included and/or updated with changes? N/A (build-only change)
3. Command line build passes? Y
4. Changes have been smoke-tested? Y