### PR TITLE
[Search] Index directly on mutation

### DIFF
--- a/platform/search/src/services/GenericSearchProvider.js
+++ b/platform/search/src/services/GenericSearchProvider.js
@@ -121,9 +121,13 @@ define([
             provider = this;
 
         mutationTopic.listen(function (mutatedObject) {
-            var id = mutatedObject.getId(),
-                model = mutatedObject.getModel();
-            provider.index(id, model);
+            var status = mutatedObject.getCapability('status');
+            if (!status || !status.get('editing')) {
+                provider.index(
+                    mutatedObject.getId(),
+                    mutatedObject.getModel()
+                );
+            }
         });
     };
 

--- a/platform/search/src/services/GenericSearchProvider.js
+++ b/platform/search/src/services/GenericSearchProvider.js
@@ -121,9 +121,9 @@ define([
             provider = this;
 
         mutationTopic.listen(function (mutatedObject) {
-            var id = mutatedObject.getId();
-            provider.indexedIds[id] = false;
-            provider.scheduleForIndexing(id);
+            var id = mutatedObject.getId(),
+                model = mutatedObject.getModel();
+            provider.index(id, model);
         });
     };
 

--- a/platform/search/test/services/GenericSearchProviderSpec.js
+++ b/platform/search/test/services/GenericSearchProviderSpec.js
@@ -101,7 +101,11 @@ define([
 
         it('re-indexes when mutation occurs', function () {
             var mockDomainObject =
-                    jasmine.createSpyObj('domainObj', ['getId', 'getModel']),
+                    jasmine.createSpyObj('domainObj', [
+                        'getId',
+                        'getModel',
+                        'getCapability'
+                    ]),
                 testModel = { some: 'model' };
             mockDomainObject.getId.andReturn("some-id");
             mockDomainObject.getModel.andReturn(testModel);

--- a/platform/search/test/services/GenericSearchProviderSpec.js
+++ b/platform/search/test/services/GenericSearchProviderSpec.js
@@ -99,12 +99,15 @@ define([
                 .toHaveBeenCalledWith(jasmine.any(Function));
         });
 
-        it('reschedules indexing when mutation occurs', function () {
+        it('re-indexes when mutation occurs', function () {
             var mockDomainObject =
-                jasmine.createSpyObj('domainObj', ['getId']);
+                    jasmine.createSpyObj('domainObj', ['getId', 'getModel']),
+                testModel = { some: 'model' };
             mockDomainObject.getId.andReturn("some-id");
+            mockDomainObject.getModel.andReturn(testModel);
+            spyOn(provider, 'index').andCallThrough();
             mutationTopic.listen.mostRecentCall.args[0](mockDomainObject);
-            expect(provider.scheduleForIndexing).toHaveBeenCalledWith('some-id');
+            expect(provider.index).toHaveBeenCalledWith('some-id', testModel);
         });
 
         it('starts indexing roots', function () {


### PR DESCRIPTION
Pass model directly when indexing is triggered via object mutation,
to avoid issuing an extra, unnecessary request to the server.

Additionally supports indexing of objects which have been created
but not yet persisted.

Addresses #377.