### PR TITLE
Review and integrate open729

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -60,7 +60,8 @@ var gulp = require('gulp'),
             singleRun: true
         },
         sass: {
-            includePaths: bourbon.includePaths
+            includePaths: bourbon.includePaths,
+            sourceComments: true
         },
         replace: {
             variables: {

--- a/platform/commonUI/browse/res/templates/browse/object-properties.html
+++ b/platform/commonUI/browse/res/templates/browse/object-properties.html
@@ -32,6 +32,7 @@
         </li>
         <li ng-if="contextutalParents.length > 0">
             <em class="t-inspector-part-header" title="The location of this linked object.">Location</em>
+            <div ng-if="primaryParents.length > 0" class="section-header">This Object</div>
             <span class="inspector-location"
                   ng-repeat="parent in contextutalParents"
                   ng-class="{ last:($index + 1) === contextualParents.length }">
@@ -44,7 +45,7 @@
             </span>
         </li>
         <li ng-if="primaryParents.length > 0">
-            <em class="t-inspector-part-header" title="The location of the original object that this was linked from.">Original Location</em>
+            <div class="section-header">Object's Original</div>
             <span class="inspector-location"
                   ng-repeat="parent in primaryParents"
                   ng-class="{ last:($index + 1) === primaryParents.length }">

--- a/platform/commonUI/edit/res/templates/elements.html
+++ b/platform/commonUI/edit/res/templates/elements.html
@@ -19,16 +19,19 @@
  this source code distribution or the Licensing information page available
  at runtime from the About dialog for additional information.
 -->
-<div ng-controller="ElementsController">
+<div ng-controller="ElementsController" class="flex-elem l-flex-col holder grows">
     <mct-include key="'input-filter'"
                  class="flex-elem holder"
                  ng-model="filterBy">
     </mct-include>
-    <div class="current-elements abs" style="height: 100%;">
+    <div class="flex-elem grows vscroll">
         <ul class="tree">
             <li ng-repeat="containedObject in composition | filter:searchText">
                 <span class="tree-item">
-                    <mct-representation key="'label'" mct-object="containedObject">
+                    <mct-representation
+                            class="rep-object-label"
+                            key="'label'"
+                            mct-object="containedObject">
                     </mct-representation>
                 </span>
             </li>

--- a/platform/commonUI/general/res/sass/_inspector.scss
+++ b/platform/commonUI/general/res/sass/_inspector.scss
@@ -87,6 +87,9 @@
                     @include align-items(center);
                     border: none;
                     padding: $interiorMarginSm 0;
+                    .label {
+                        min-width: 80px;
+                    }
                     input[type='text'],
                     input[type='search'] {
                         width: 100%;

--- a/platform/commonUI/general/res/sass/_inspector.scss
+++ b/platform/commonUI/general/res/sass/_inspector.scss
@@ -61,9 +61,23 @@
     .l-inspector-part {
         box-sizing: border-box;
         padding-right: $interiorMargin;
-        .form {
+        .tree .form {
             margin-left: $treeVCW + $interiorMarginLg;
-            margin-bottom: $interiorMarginLg;
+        }
+        .section-header {
+            background: none;
+            color: $colorInspectorPropName;
+            border-radius: unset;
+            font-size: inherit;
+            padding: $interiorMarginSm 0;
+        }
+
+        mct-form:not(:last-child) .form {
+            border-bottom: 1px solid $colorInspectorSectionHeaderBg;
+        }
+
+        .form {
+            margin-bottom: $interiorMargin;
             .form-section {
                 margin-bottom: 0;
                 &:not(.first) {

--- a/platform/commonUI/general/res/sass/_inspector.scss
+++ b/platform/commonUI/general/res/sass/_inspector.scss
@@ -77,7 +77,8 @@
         }
 
         .form {
-            margin-bottom: $interiorMargin;
+            margin-bottom: $interiorMarginSm;
+            padding-bottom: $interiorMarginLg;
             .form-section {
                 margin-bottom: 0;
                 &:not(.first) {

--- a/platform/commonUI/general/res/sass/_inspector.scss
+++ b/platform/commonUI/general/res/sass/_inspector.scss
@@ -86,7 +86,11 @@
                 .form-row {
                     @include align-items(center);
                     border: none;
-                    padding: 0;
+                    padding: $interiorMarginSm 0;
+                    input[type='text'],
+                    input[type='search'] {
+                        width: 100%;
+                    }
                 }
             }
         }

--- a/platform/commonUI/general/res/sass/forms/_elems.scss
+++ b/platform/commonUI/general/res/sass/forms/_elems.scss
@@ -19,6 +19,10 @@
  * this source code distribution or the Licensing information page available
  * at runtime from the About dialog for additional information.
  *****************************************************************************/
+.section-header {
+    text-transform: uppercase;
+}
+
 .form {
 	color: $colorFormText;
     width: 100%;
@@ -34,7 +38,6 @@
         color: $c;
         font-size: 0.8em;
         padding: $formTBPad $formLRPad;
-        text-transform: uppercase;
     }
 
 	.form-row {

--- a/platform/commonUI/general/res/sass/forms/_elems.scss
+++ b/platform/commonUI/general/res/sass/forms/_elems.scss
@@ -42,7 +42,7 @@
 		box-sizing: border-box;
 		@include clearfix;
 		border-top: 1px solid $colorFormLines;
-		margin-top: $m;
+		//margin-top: $m;
 		padding: $formTBPad 0;
 		position: relative;
 		&.first {
@@ -83,19 +83,6 @@
 					margin-right: 5px;
 				}
 			}
-
-			.l-med input[type="text"] {
-				width: 200px;
-			}
-
-			.l-small input[type="text"] {
-				width: 50px;
-			}
-
-			.l-numeric input[type="text"] {
-				text-align: right;
-			}
-
 			.select {
 				margin-right: $interiorMargin;
 			}
@@ -124,25 +111,23 @@
 	}
 }
 
-.l-controls-first {
-    .form .form-row {
-        margin-top: $interiorMarginSm;
-        >.label,
-        >.controls {
-            line-height: inherit;
-            min-height: inherit;;
-        }
-        >.label {
-            @include flex(1 1 auto);
-            min-width: 0;
-            width: auto;
-            order: 2;
-        }
-        >.controls {
-            @include flex(0 0 auto);
-            margin-right: $interiorMargin;
-            order: 1;
-        }
+.l-controls-first .form .form-row,
+.form .form-row.l-controls-first {
+    >.label,
+    >.controls {
+        line-height: inherit;
+        min-height: inherit;;
+    }
+    >.label {
+        @include flex(1 1 auto);
+        min-width: 0;
+        width: auto;
+        order: 2;
+    }
+    >.controls {
+        @include flex(0 0 auto);
+        margin-right: $interiorMargin;
+        order: 1;
     }
 }
 
@@ -189,6 +174,18 @@ input[type="search"] {
 	&.numeric {
 		text-align: right;
 	}
+}
+
+.l-input-med input[type="text"] {
+    width: 200px !important;
+}
+
+.l-input-sm input[type="text"] {
+    width: 50px !important;
+}
+
+.l-numeric input[type="text"] {
+    text-align: right;
 }
 
 textarea {

--- a/platform/commonUI/general/res/sass/forms/_elems.scss
+++ b/platform/commonUI/general/res/sass/forms/_elems.scss
@@ -19,16 +19,6 @@
  * this source code distribution or the Licensing information page available
  * at runtime from the About dialog for additional information.
  *****************************************************************************/
-.section-header {
-	border-radius: $basicCr;
-	background: $colorFormSectionHeader;
-	$c: lighten($colorBodyFg, 20%);
-	color: $c;
-	font-size: 0.8em;
-	padding: $formTBPad $formLRPad;
-	text-transform: uppercase;
-}
-
 .form {
 	color: $colorFormText;
     width: 100%;
@@ -36,6 +26,16 @@
 		position: relative;
 		margin-bottom: $interiorMarginLg * 2;
 	}
+
+    .section-header {
+        border-radius: $basicCr;
+        background: $colorFormSectionHeader;
+        $c: lighten($colorBodyFg, 20%);
+        color: $c;
+        font-size: 0.8em;
+        padding: $formTBPad $formLRPad;
+        text-transform: uppercase;
+    }
 
 	.form-row {
 		$m: $interiorMargin;
@@ -52,9 +52,9 @@
 		>.label,
 		>.controls {
 			box-sizing: border-box;
-			@include clearfix;
+			//@include clearfix;
 			font-size: 0.8rem;
-			line-height: $formInputH;
+			//line-height: $formInputH;
             min-height: $formInputH;
 		}
 

--- a/platform/commonUI/general/res/sass/forms/_elems.scss
+++ b/platform/commonUI/general/res/sass/forms/_elems.scss
@@ -45,7 +45,6 @@
 		box-sizing: border-box;
 		@include clearfix;
 		border-top: 1px solid $colorFormLines;
-		//margin-top: $m;
 		padding: $formTBPad 0;
 		position: relative;
 		&.first {
@@ -55,9 +54,7 @@
 		>.label,
 		>.controls {
 			box-sizing: border-box;
-			//@include clearfix;
 			font-size: 0.8rem;
-			//line-height: $formInputH;
             min-height: $formInputH;
 		}
 

--- a/platform/commonUI/general/res/sass/overlay/_overlay.scss
+++ b/platform/commonUI/general/res/sass/overlay/_overlay.scss
@@ -88,7 +88,7 @@
         left: 0;
         right: 0;
         overflow: auto;
-        .field.l-med {
+        .field.l-input-med {
             input[type='text'] {
                 width: 100%;
             }

--- a/platform/commonUI/general/res/templates/object-inspector.html
+++ b/platform/commonUI/general/res/templates/object-inspector.html
@@ -40,7 +40,7 @@
                     <mct-representation
                             key="'edit-elements'"
                             mct-object="domainObject"
-                            class="flex-elem holder grows vscroll current-elements">
+                            class="flex-elem l-flex-col holder grows current-elements">
                     </mct-representation>
                 </div>
             </div>

--- a/platform/features/plot/res/templates/plot-options-browse.html
+++ b/platform/features/plot/res/templates/plot-options-browse.html
@@ -41,36 +41,38 @@
             name="yAxisFormState"
             class="flex-elem l-flex-row no-validate no-margin reduced-min-width">
     </mct-form>
-    <div class="section-header ng-binding ng-scope">
-        Plot Series
-    </div>
-    <ul class="first flex-elem grows vscroll">
-        <ul class="tree">
-            <li ng-repeat="child in children">
-                <span ng-controller="ToggleController as toggle">
-                    <span ng-controller="TreeNodeController as treeNode">
-                        <span class="tree-item menus-to-left">
-                            <span
-                                class='ui-symbol view-control flex-elem has-children'
-                                ng-class="{ expanded: toggle.isActive() }"
-                                ng-click="toggle.toggle(); treeNode.trackExpansion()">
+    <div class="form">
+        <div class="section-header ng-binding ng-scope">
+            Plot Series
+        </div>
+        <ul class="first flex-elem grows vscroll">
+            <ul class="tree">
+                <li ng-repeat="child in children">
+                    <span ng-controller="ToggleController as toggle">
+                        <span ng-controller="TreeNodeController as treeNode">
+                            <span class="tree-item menus-to-left">
+                                <span
+                                    class='ui-symbol view-control flex-elem has-children'
+                                    ng-class="{ expanded: toggle.isActive() }"
+                                    ng-click="toggle.toggle(); treeNode.trackExpansion()">
+                                </span>
+                                <mct-representation
+                                    class="rep-object-label"
+                                    key="'label'"
+                                    mct-object="child">
+                                </mct-representation>
                             </span>
-                            <mct-representation
-                                class="rep-object-label"
-                                key="'label'"
-                                mct-object="child">
-                            </mct-representation>
                         </span>
+                        <mct-form
+                            ng-class="{hidden: !toggle.isActive()}"
+                            ng-model="configuration.plot.series[$index]"
+                            structure="plotSeriesForm"
+                            name="plotOptionsState"
+                            class="flex-elem l-flex-row l-controls-first no-validate">
+                        </mct-form>
                     </span>
-                    <mct-form
-                        ng-class="{hidden: !toggle.isActive()}"
-                        ng-model="configuration.plot.series[$index]"
-                        structure="plotSeriesForm"
-                        name="plotOptionsState"
-                        class="flex-elem l-flex-row l-controls-first no-validate">
-                    </mct-form>
-                </span>
-            </li>
+                </li>
+            </ul>
         </ul>
-    </ul>
+    </div>
 </div>

--- a/platform/features/plot/res/templates/plot-options-browse.html
+++ b/platform/features/plot/res/templates/plot-options-browse.html
@@ -28,7 +28,7 @@
     }
 </style>
 <div ng-controller="PlotOptionsController" class="flex-elem grows l-inspector-part">
-    <em class="t-inspector-part-header" title="Display properties for this object">Display</em>
+    <em class="t-inspector-part-header" title="Display properties for this object">Plot Options</em>
     <mct-form
             ng-model="configuration.plot.xAxis"
             structure="xAxisForm"
@@ -68,7 +68,7 @@
                             ng-model="configuration.plot.series[$index]"
                             structure="plotSeriesForm"
                             name="plotOptionsState"
-                            class="flex-elem l-flex-row l-controls-first no-validate">
+                            class="flex-elem l-flex-row no-validate">
                         </mct-form>
                     </span>
                 </li>

--- a/platform/features/plot/res/templates/plot-options-browse.html
+++ b/platform/features/plot/res/templates/plot-options-browse.html
@@ -19,27 +19,19 @@
  this source code distribution or the Licensing information page available
  at runtime from the About dialog for additional information.
 -->
-<style>
-    .l-inspect .l-inspector-part .no-margin .form {
-        margin-left: 0;
-    }
-    .reduced-min-width .form .form-row > .label {
-        min-width: 80px;
-    }
-</style>
 <div ng-controller="PlotOptionsController" class="flex-elem grows l-inspector-part">
     <em class="t-inspector-part-header" title="Display properties for this object">Plot Options</em>
     <mct-form
             ng-model="configuration.plot.xAxis"
             structure="xAxisForm"
             name="xAxisFormState"
-            class="flex-elem l-flex-row no-validate no-margin reduced-min-width">
+            class="flex-elem l-flex-row no-validate no-margin">
     </mct-form>
     <mct-form
             ng-model="configuration.plot.yAxis"
             structure="yAxisForm"
             name="yAxisFormState"
-            class="flex-elem l-flex-row no-validate no-margin reduced-min-width">
+            class="flex-elem l-flex-row no-validate no-margin">
     </mct-form>
     <div class="form">
         <div class="section-header ng-binding ng-scope">

--- a/platform/features/plot/src/PlotOptionsForm.js
+++ b/platform/features/plot/src/PlotOptionsForm.js
@@ -77,8 +77,7 @@ define(
                     {
                         'name': 'Autoscale',
                         'control': 'checkbox',
-                        'key': 'autoscale',
-                        'layout': 'control-first'
+                        'key': 'autoscale'
                     },
                     {
                         'name': 'Min',

--- a/platform/features/plot/src/PlotOptionsForm.js
+++ b/platform/features/plot/src/PlotOptionsForm.js
@@ -48,9 +48,9 @@ define(
                             'control': 'select',
                             'key': 'key',
                             'options': [
-                                {'name':'scet', 'value': 'scet'},
-                                {'name':'sclk', 'value': 'sclk'},
-                                {'name':'lst', 'value': 'lst'}
+                                {'name':'SCET', 'value': 'scet'},
+                                {'name':'SCLK', 'value': 'sclk'},
+                                {'name':'LST', 'value': 'lst'}
                             ]
                         }
                     ]
@@ -65,31 +65,34 @@ define(
                 'name': 'y-axis',
                 'rows': [
                     {
+                        'name': 'Range',
+                        'control': 'select',
+                        'key': 'key',
+                        'options': [
+                            {'name':'EU', 'value': 'eu'},
+                            {'name':'DN', 'value': 'dn'},
+                            {'name':'Status', 'value': 'status'}
+                        ]
+                    },
+                    {
                         'name': 'Autoscale',
                         'control': 'checkbox',
-                        'key': 'autoscale'
+                        'key': 'autoscale',
+                        'layout': 'control-first'
                     },
                     {
                         'name': 'Min',
                         'control': 'textfield',
                         'key': 'min',
-                        'pattern': '[0-9]'
+                        'pattern': '[0-9]',
+                        'inputsize' : 'sm'
                     },
                     {
                         'name': 'Max',
                         'control': 'textfield',
                         'key': 'max',
-                        'pattern': '[0-9]'
-                    },
-                    {
-                        'name': 'Range',
-                        'control': 'select',
-                        'key': 'key',
-                        'options': [
-                            {'name':'eu', 'value': 'eu'},
-                            {'name':'dn', 'value': 'dn'},
-                            {'name':'status', 'value': 'status'}
-                        ]
+                        'pattern': '[0-9]',
+                        'inputsize' : 'sm'
                     }
                 ]
                 }]
@@ -110,7 +113,8 @@ define(
                             {
                                 'name': 'Markers',
                                 'control': 'checkbox',
-                                'key': 'markers'
+                                'key': 'markers',
+                                'layout': 'control-first'
                             }
                         ]
                     },
@@ -120,19 +124,22 @@ define(
                                 'name': 'No Line',
                                 'control': 'radio',
                                 'key': 'lineType',
-                                'value': 'noLine'
+                                'value': 'noLine',
+                                'layout': 'control-first'
                             },
                             {
                                 'name': 'Step Line',
                                 'control': 'radio',
                                 'key': 'lineType',
-                                'value': 'stepLine'
+                                'value': 'stepLine',
+                                'layout': 'control-first'
                             },
                             {
                                 'name': 'Linear Line',
                                 'control': 'radio',
                                 'key': 'lineType',
-                                'value': 'linearLine'
+                                'value': 'linearLine',
+                                'layout': 'control-first'
                             }
                         ]
                     }

--- a/platform/features/table/res/templates/table-options-edit.html
+++ b/platform/features/table/res/templates/table-options-edit.html
@@ -19,7 +19,7 @@
  this source code distribution or the Licensing information page available
  at runtime from the About dialog for additional information.
 -->
-<div ng-controller="TableOptionsController" class="flex-elem grows l-inspector-part">
+<div ng-controller="TableOptionsController" class="l-controls-first flex-elem grows l-inspector-part">
     <em class="t-inspector-part-header" title="Display properties for this object">Display</em>
     <mct-form
             ng-model="configuration.table.columns"

--- a/platform/features/table/res/templates/table-options-edit.html
+++ b/platform/features/table/res/templates/table-options-edit.html
@@ -25,6 +25,6 @@
             ng-model="configuration.table.columns"
             structure="columnsForm"
             name="columnsFormState"
-            class="flex-elem l-flex-row no-validate no-margin reduced-min-width">
+            class="flex-elem l-flex-row no-validate no-margin">
     </mct-form>
 </div>

--- a/platform/features/table/res/templates/table-options-edit.html
+++ b/platform/features/table/res/templates/table-options-edit.html
@@ -20,7 +20,7 @@
  at runtime from the About dialog for additional information.
 -->
 <div ng-controller="TableOptionsController" class="l-controls-first flex-elem grows l-inspector-part">
-    <em class="t-inspector-part-header" title="Display properties for this object">Display</em>
+    <em class="t-inspector-part-header" title="Display properties for this object">Table Options</em>
     <mct-form
             ng-model="configuration.table.columns"
             structure="columnsForm"

--- a/platform/forms/res/templates/form.html
+++ b/platform/forms/res/templates/form.html
@@ -31,7 +31,9 @@
                                req: row.required,
                                valid: mctFormInner.$dirty && mctFormInner.$valid,
                                invalid: mctFormInner.$dirty && !mctFormInner.$valid,
-                               first: $index < 1
+                               first: $index < 1,
+                               'l-controls-first': row.layout === 'control-first',
+                               'l-input-sm': row.inputsize === 'sm'
                                }">
                     <div class='label flex-elem' title="{{row.description}}">
                         {{row.name}}


### PR DESCRIPTION
@akhenry Relates to #729, #707 and #498. Needed by work done in open707 by Andrew. Can be integrated directly into master prior to merge into open707 if desired with no adverse effects.

Subtle but significant mods via markup and CSS changes to elements related to configuration options for plot and table object types, and holder elements in the Inspector.

### Author Checklist

1. Changes address original issue? Y
2. Unit tests included and/or updated with changes? N, N/A
3. Command line build passes? Y
4. Changes have been smoke-tested? Y