### PR TITLE
[Tree] Rewrite tree without Angular

### DIFF
--- a/LICENSES.md
+++ b/LICENSES.md
@@ -476,6 +476,44 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 ---
 
+### Zepto
+
+#### Info
+
+* Link: http://zeptojs.com/
+
+* Version: 1.1.6
+
+* Authors: Thomas Fuchs
+
+* Description: DOM manipulation
+
+#### License
+
+Copyright (c) 2010-2016 Thomas Fuchs
+http://zeptojs.com/
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+---
+
 ### Json.NET
 
 #### Info

--- a/bower.json
+++ b/bower.json
@@ -17,6 +17,7 @@
     "screenfull": "^3.0.0",
     "node-uuid": "^1.4.7",
     "comma-separated-values": "^3.6.4",
-    "FileSaver.js": "^0.0.2"
+    "FileSaver.js": "^0.0.2",
+    "zepto": "^1.1.6"
   }
 }

--- a/main.js
+++ b/main.js
@@ -45,6 +45,9 @@ requirejs.config({
         },
         "moment-duration-format": {
             "deps": [ "moment" ]
+        },
+        "zepto": {
+            "exports": "Zepto"
         }
     }
 });

--- a/main.js
+++ b/main.js
@@ -33,7 +33,8 @@ requirejs.config({
         "saveAs": "bower_components/FileSaver.js/FileSaver.min",
         "screenfull": "bower_components/screenfull/dist/screenfull.min",
         "text": "bower_components/text/text",
-        "uuid": "bower_components/node-uuid/uuid"
+        "uuid": "bower_components/node-uuid/uuid",
+        "zepto": "bower_components/zepto/zepto.min"
     },
     "shim": {
         "angular": {

--- a/platform/commonUI/general/bundle.js
+++ b/platform/commonUI/general/bundle.js
@@ -394,7 +394,8 @@ define([
                 },
                 {
                     "key": "mctTree",
-                    "implementation": MCTTree
+                    "implementation": MCTTree,
+                    "depends": [ '$parse' ]
                 }
             ],
             "constants": [

--- a/platform/commonUI/general/bundle.js
+++ b/platform/commonUI/general/bundle.js
@@ -535,6 +535,16 @@ define([
                     "copyright": "Copyright (c) Nicolas Gallagher and Jonathan Neal",
                     "license": "license-mit",
                     "link": "https://github.com/necolas/normalize.css/blob/v1.1.2/LICENSE.md"
+                },
+                {
+                    "name": "Zepto",
+                    "version": "1.1.6",
+                    "description": "DOM manipulation",
+                    "author": "Thomas Fuchs",
+                    "website": "http://zeptojs.com/",
+                    "copyright": "Copyright (c) 2010-2016 Thomas Fuchs",
+                    "license": "license-mit",
+                    "link": "https://github.com/madrobby/zepto/blob/master/MIT-LICENSE"
                 }
             ]
         }

--- a/platform/commonUI/general/bundle.js
+++ b/platform/commonUI/general/bundle.js
@@ -395,7 +395,7 @@ define([
                 {
                     "key": "mctTree",
                     "implementation": MCTTree,
-                    "depends": [ '$parse' ]
+                    "depends": [ '$parse', 'gestureService' ]
                 }
             ],
             "constants": [

--- a/platform/commonUI/general/bundle.js
+++ b/platform/commonUI/general/bundle.js
@@ -49,6 +49,7 @@ define([
     "./src/directives/MCTScroll",
     "./src/directives/MCTSplitPane",
     "./src/directives/MCTSplitter",
+    "./src/directives/MCTTree",
     "text!./res/templates/bottombar.html",
     "text!./res/templates/controls/action-button.html",
     "text!./res/templates/controls/input-filter.html",
@@ -97,6 +98,7 @@ define([
     MCTScroll,
     MCTSplitPane,
     MCTSplitter,
+    MCTTree,
     bottombarTemplate,
     actionButtonTemplate,
     inputFilterTemplate,
@@ -389,6 +391,10 @@ define([
                 {
                     "key": "mctSplitter",
                     "implementation": MCTSplitter
+                },
+                {
+                    "key": "mctTree",
+                    "implementation": MCTTree
                 }
             ],
             "constants": [

--- a/platform/commonUI/general/res/templates/subtree.html
+++ b/platform/commonUI/general/res/templates/subtree.html
@@ -19,18 +19,6 @@
  this source code distribution or the Licensing information page available
  at runtime from the About dialog for additional information.
 -->
-<ul class="tree">
-    <li ng-if="!composition">
-        <span class="tree-item">
-            <span class="icon wait-spinner"></span>
-            <span class="title-label">Loading...</span>
-        </span>
-    </li>
-    <li ng-repeat="child in composition">
-        <mct-representation key="'tree-node'"
-                            mct-object="child"
-                            parameters="parameters"
-                            ng-model="ngModel">
-        </mct-representation>
-    </li>
-</ul>
+<mct-tree mct-object="domainObject">
+</mct-tree>
+

--- a/platform/commonUI/general/res/templates/subtree.html
+++ b/platform/commonUI/general/res/templates/subtree.html
@@ -19,6 +19,6 @@
  this source code distribution or the Licensing information page available
  at runtime from the About dialog for additional information.
 -->
-<mct-tree mct-object="domainObject">
+<mct-tree mct-object="domainObject" mct-model="ngModel.selectedObject">
 </mct-tree>
 

--- a/platform/commonUI/general/res/templates/tree/node.html
+++ b/platform/commonUI/general/res/templates/tree/node.html
@@ -1,8 +1,4 @@
 <span class="tree-item menus-to-left">
-    <span class='ui-symbol view-control flex-elem'>
-    </span>
-    <span class="rep-object-label">
-    </span>
 </span>
 <span class="tree-item-subtree">
 </span>

--- a/platform/commonUI/general/res/templates/tree/node.html
+++ b/platform/commonUI/general/res/templates/tree/node.html
@@ -1,0 +1,32 @@
+<li>
+    <span
+        class="tree-item menus-to-left"
+        ng-class="{selected: treeNode.isSelected()}"
+        >
+        <span
+                class='ui-symbol view-control flex-elem'
+                ng-class="{ 'has-children': model.composition !== undefined, expanded: toggle.isActive() }"
+                ng-click="toggle.toggle(); treeNode.trackExpansion()"
+                >
+        </span>
+        <mct-representation
+                class="rep-object-label"
+                key="'label'"
+                mct-object="domainObject"
+                parameters="{suppressMenuOnEdit: true}"
+                ng-click="treeNode.select()"
+                >
+        </mct-representation>
+    </span>
+    <span
+        class="tree-item-subtree"
+        ng-show="toggle.isActive()"
+        ng-if="model.composition !== undefined"
+        >
+        <mct-representation key="'subtree'"
+                            ng-model="ngModel"
+                            parameters="parameters"
+                            mct-object="treeNode.hasBeenExpanded() && domainObject">
+        </mct-representation>
+    </span>
+</li>

--- a/platform/commonUI/general/res/templates/tree/node.html
+++ b/platform/commonUI/general/res/templates/tree/node.html
@@ -1,32 +1,8 @@
-<li>
-    <span
-        class="tree-item menus-to-left"
-        ng-class="{selected: treeNode.isSelected()}"
-        >
-        <span
-                class='ui-symbol view-control flex-elem'
-                ng-class="{ 'has-children': model.composition !== undefined, expanded: toggle.isActive() }"
-                ng-click="toggle.toggle(); treeNode.trackExpansion()"
-                >
-        </span>
-        <mct-representation
-                class="rep-object-label"
-                key="'label'"
-                mct-object="domainObject"
-                parameters="{suppressMenuOnEdit: true}"
-                ng-click="treeNode.select()"
-                >
-        </mct-representation>
+<span class="tree-item menus-to-left">
+    <span class='ui-symbol view-control flex-elem'>
     </span>
-    <span
-        class="tree-item-subtree"
-        ng-show="toggle.isActive()"
-        ng-if="model.composition !== undefined"
-        >
-        <mct-representation key="'subtree'"
-                            ng-model="ngModel"
-                            parameters="parameters"
-                            mct-object="treeNode.hasBeenExpanded() && domainObject">
-        </mct-representation>
+    <span class="rep-object-label">
     </span>
-</li>
+</span>
+<span class="tree-item-subtree">
+</span>

--- a/platform/commonUI/general/res/templates/tree/toggle.html
+++ b/platform/commonUI/general/res/templates/tree/toggle.html
@@ -1,0 +1,2 @@
+<span class='ui-symbol view-control flex-elem'>
+</span>

--- a/platform/commonUI/general/res/templates/tree/tree-label.html
+++ b/platform/commonUI/general/res/templates/tree/tree-label.html
@@ -1,8 +1,8 @@
 <span class="rep-object-label">
     <div class="t-object-label l-flex-row flex-elem grows">
-        <div class="t-item-icon flex-elem" ng-class="{ 'l-icon-link':location.isLink() }">
-            <div class="t-item-icon-glyph">{{type.getGlyph()}}</div>
+        <div class="t-item-icon flex-elem">
+            <div class="t-item-icon-glyph"></div>
         </div>
-        <div class='t-title-label flex-elem grows'>{{model.name}}</div>
+        <div class='t-title-label flex-elem grows'></div>
     </div>
 </span>

--- a/platform/commonUI/general/res/templates/tree/tree-label.html
+++ b/platform/commonUI/general/res/templates/tree/tree-label.html
@@ -1,0 +1,8 @@
+<span class="rep-object-label">
+    <div class="t-object-label l-flex-row flex-elem grows">
+        <div class="t-item-icon flex-elem" ng-class="{ 'l-icon-link':location.isLink() }">
+            <div class="t-item-icon-glyph">{{type.getGlyph()}}</div>
+        </div>
+        <div class='t-title-label flex-elem grows'>{{model.name}}</div>
+    </div>
+</span>

--- a/platform/commonUI/general/res/templates/tree/wait-node.html
+++ b/platform/commonUI/general/res/templates/tree/wait-node.html
@@ -1,0 +1,27 @@
+<!--
+ Open MCT Web, Copyright (c) 2014-2015, United States Government
+ as represented by the Administrator of the National Aeronautics and Space
+ Administration. All rights reserved.
+
+ Open MCT Web is licensed under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ http://www.apache.org/licenses/LICENSE-2.0.
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ License for the specific language governing permissions and limitations
+ under the License.
+
+ Open MCT Web includes source code licensed under additional open source
+ licenses. See the Open Source Licenses file (LICENSES.md) included with
+ this source code distribution or the Licensing information page available
+ at runtime from the About dialog for additional information.
+-->
+<li>
+    <span class="tree-item">
+        <span class="icon wait-spinner"></span>
+        <span class="title-label">Loading...</span>
+    </span>
+</li>

--- a/platform/commonUI/general/src/directives/MCTTree.js
+++ b/platform/commonUI/general/src/directives/MCTTree.js
@@ -22,30 +22,21 @@
 /*global define*/
 
 define([
-    'text!../../res/templates/subtree.html',
-    'text!../../res/templates/tree/node.html'
-], function (subtreeTemplate, nodeTemplate) {
-    function MCTTreeController($scope, $element, $compile) {
-        var ul = $element.filter('ul'),
-            makeNode = $compile(nodeTemplate),
-            activeObject,
-            unlisten;
-
-
-
-
-        $scope.$watch('mctObject', changeObject);
-    }
-
+    'angular',
+    '../ui/TreeView'
+], function (angular, TreeView) {
     function MCTTree() {
+        function link(scope, element) {
+            var treeView = new TreeView();
+
+            element.append(angular.element(treeView.elements()));
+
+            scope.$watch('mctObject', treeView.model.bind(treeView));
+        }
+
         return {
             restrict: "E",
-            controller: [
-                '$scope',
-                '$element',
-                '$compile',
-                MCTTreeController
-            ],
+            link: link,
             require: [ "mctTree" ],
             scope: { mctObject: "=" },
             template: ""

--- a/platform/commonUI/general/src/directives/MCTTree.js
+++ b/platform/commonUI/general/src/directives/MCTTree.js
@@ -25,9 +25,9 @@ define([
     'angular',
     '../ui/TreeView'
 ], function (angular, TreeView) {
-    function MCTTree($parse) {
+    function MCTTree($parse, gestureService) {
         function link(scope, element, attrs) {
-            var treeView = new TreeView(),
+            var treeView = new TreeView(gestureService),
                 expr = $parse(attrs.mctModel),
                 unobserve = treeView.observe(function (domainObject) {
                     if (domainObject !== expr(scope.$parent)) {

--- a/platform/commonUI/general/src/directives/MCTTree.js
+++ b/platform/commonUI/general/src/directives/MCTTree.js
@@ -22,39 +22,19 @@
 /*global define*/
 
 define([
-    'text!../../res/templates/subtree.html'
-], function (subtreeTemplate) {
-    function MCTTreeController($scope, $element) {
-        var ul = elem.filter('ul'),
+    'text!../../res/templates/subtree.html',
+    'text!../../res/templates/tree/node.html'
+], function (subtreeTemplate, nodeTemplate) {
+    function MCTTreeController($scope, $element, $compile) {
+        var ul = $element.filter('ul'),
+            makeNode = $compile(nodeTemplate),
             activeObject,
             unlisten;
 
-        function addNodes(domainObjects) {
-            domainObjects.forEach(function (addNode));
-        }
 
-        function loadComposition(domainObject) {
-            activeObject = domainObject;
-            ul.empty();
-            if (domainObject.hasCapability('composition')) {
-                // TODO: Add pending indicator
-                domainObject.useCapability('composition')
-                    .then(addNodes);
-            }
-        }
 
-        function changeObject(domainObject) {
-            if (unlisten) {
-                unlisten();
-            }
 
-            unlisten = domainObject.getCapability('mutation')
-                .listen(loadComposition);
-
-            loadComposition(domainObject);
-        }
-
-        scope.$watch('mctObject', changeObject);
+        $scope.$watch('mctObject', changeObject);
     }
 
     function MCTTree() {
@@ -63,11 +43,12 @@ define([
             controller: [
                 '$scope',
                 '$element',
+                '$compile',
                 MCTTreeController
             ],
             require: [ "mctTree" ],
             scope: { mctObject: "=" },
-            template: subtreeTemplate
+            template: ""
         };
     }
 

--- a/platform/commonUI/general/src/directives/MCTTree.js
+++ b/platform/commonUI/general/src/directives/MCTTree.js
@@ -23,15 +23,51 @@
 
 define([
     'text!../../res/templates/subtree.html'
-], function () {
-    function MCTTree() {
-        function link(scope, elem) {
+], function (subtreeTemplate) {
+    function MCTTreeController($scope, $element) {
+        var ul = elem.filter('ul'),
+            activeObject,
+            unlisten;
 
+        function addNodes(domainObjects) {
+            domainObjects.forEach(function (addNode));
         }
 
+        function loadComposition(domainObject) {
+            activeObject = domainObject;
+            ul.empty();
+            if (domainObject.hasCapability('composition')) {
+                // TODO: Add pending indicator
+                domainObject.useCapability('composition')
+                    .then(addNodes);
+            }
+        }
+
+        function changeObject(domainObject) {
+            if (unlisten) {
+                unlisten();
+            }
+
+            unlisten = domainObject.getCapability('mutation')
+                .listen(loadComposition);
+
+            loadComposition(domainObject);
+        }
+
+        scope.$watch('mctObject', changeObject);
+    }
+
+    function MCTTree() {
         return {
-            link: link,
-            scope: { mctModel: "=" }
+            restrict: "E",
+            controller: [
+                '$scope',
+                '$element',
+                MCTTreeController
+            ],
+            require: [ "mctTree" ],
+            scope: { mctObject: "=" },
+            template: subtreeTemplate
         };
     }
 

--- a/platform/commonUI/general/src/directives/MCTTree.js
+++ b/platform/commonUI/general/src/directives/MCTTree.js
@@ -37,9 +37,7 @@ define([
         return {
             restrict: "E",
             link: link,
-            require: [ "mctTree" ],
-            scope: { mctObject: "=" },
-            template: ""
+            scope: { mctObject: "=" }
         };
     }
 

--- a/platform/commonUI/general/src/directives/MCTTree.js
+++ b/platform/commonUI/general/src/directives/MCTTree.js
@@ -25,13 +25,17 @@ define([
     'angular',
     '../ui/TreeView'
 ], function (angular, TreeView) {
-    function MCTTree() {
-        function link(scope, element) {
-            var treeView = new TreeView();
+    function MCTTree($parse) {
+        function link(scope, element, attrs) {
+            var treeView = new TreeView(),
+                expr = $parse(attrs.mctModel),
+                unobserve = treeView.observe(expr.assign.bind(expr, scope));
 
             element.append(angular.element(treeView.elements()));
 
+            scope.$parent.$watch(attrs.mctModel, treeView.value.bind(treeView));
             scope.$watch('mctObject', treeView.model.bind(treeView));
+            scope.$on('$destroy', unobserve);
         }
 
         return {

--- a/platform/commonUI/general/src/directives/MCTTree.js
+++ b/platform/commonUI/general/src/directives/MCTTree.js
@@ -1,0 +1,39 @@
+/*****************************************************************************
+ * Open MCT Web, Copyright (c) 2014-2015, United States Government
+ * as represented by the Administrator of the National Aeronautics and Space
+ * Administration. All rights reserved.
+ *
+ * Open MCT Web is licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * Open MCT Web includes source code licensed under additional open source
+ * licenses. See the Open Source Licenses file (LICENSES.md) included with
+ * this source code distribution or the Licensing information page available
+ * at runtime from the About dialog for additional information.
+ *****************************************************************************/
+/*global define*/
+
+define([
+    'text!../../res/templates/subtree.html'
+], function () {
+    function MCTTree() {
+        function link(scope, elem) {
+
+        }
+
+        return {
+            link: link,
+            scope: { mctModel: "=" }
+        };
+    }
+
+    return MCTTree;
+});

--- a/platform/commonUI/general/src/directives/MCTTree.js
+++ b/platform/commonUI/general/src/directives/MCTTree.js
@@ -29,8 +29,12 @@ define([
         function link(scope, element, attrs) {
             var treeView = new TreeView(),
                 expr = $parse(attrs.mctModel),
-                assign = expr.assign.bind(expr, scope.$parent),
-                unobserve = treeView.observe(assign);
+                unobserve = treeView.observe(function (domainObject) {
+                    if (domainObject !== expr(scope.$parent)) {
+                        expr.assign(scope.$parent, domainObject);
+                        scope.$apply();
+                    }
+                });
 
             element.append(angular.element(treeView.elements()));
 

--- a/platform/commonUI/general/src/directives/MCTTree.js
+++ b/platform/commonUI/general/src/directives/MCTTree.js
@@ -29,7 +29,8 @@ define([
         function link(scope, element, attrs) {
             var treeView = new TreeView(),
                 expr = $parse(attrs.mctModel),
-                unobserve = treeView.observe(expr.assign.bind(expr, scope));
+                assign = expr.assign.bind(expr, scope.$parent),
+                unobserve = treeView.observe(assign);
 
             element.append(angular.element(treeView.elements()));
 

--- a/platform/commonUI/general/src/ui/ToggleView.js
+++ b/platform/commonUI/general/src/ui/ToggleView.js
@@ -22,13 +22,13 @@
 /*global define*/
 
 define([
-    'angular',
+    'zepto',
     'text!../../res/templates/tree/toggle.html'
-], function (angular, toggleTemplate) {
+], function ($, toggleTemplate) {
     function ToggleView(state) {
         this.expanded = !!state;
         this.callbacks = [];
-        this.el = angular.element(toggleTemplate);
+        this.el = $(toggleTemplate);
         this.el.on('click', function () {
             this.model(!this.expanded);
         }.bind(this));

--- a/platform/commonUI/general/src/ui/ToggleView.js
+++ b/platform/commonUI/general/src/ui/ToggleView.js
@@ -23,7 +23,7 @@
 
 define([
     'angular',
-    'text!../../res/templates/ui/toggle.html'
+    'text!../../res/templates/tree/toggle.html'
 ], function (angular, toggleTemplate) {
     function ToggleView(state) {
         this.expanded = !!state;

--- a/platform/commonUI/general/src/ui/ToggleView.js
+++ b/platform/commonUI/general/src/ui/ToggleView.js
@@ -23,48 +23,39 @@
 
 define([
     'angular',
-    'text!../../res/templates/ui/node.html'
-], function (angular, nodeTemplate) {
-    'use strict';
-
-    var $ = angular.element.bind(angular);
-
-    function TreeNodeView(subtreeFactory) {
-        this.factory = subtreeFactory;
-        this.li = $('<li>');
-        this.expanded = false;
+    'text!../../res/templates/ui/toggle.html'
+], function (angular, toggleTemplate) {
+    function ToggleView(state) {
+        this.expanded = !!state;
+        this.callbacks = [];
+        this.el = angular.element(toggleTemplate);
+        this.el.on('click', function () {
+            this.model(!this.expanded);
+        }.bind(this));
     }
 
-    TreeNodeView.prototype.populateContents = function (domainObject) {
-        if (this.li.children().length === 0) {
-            this.li.append($(nodeTemplate));
-        }
+    ToggleView.prototype.model = function (state) {
+        this.expanded = state;
 
-
-    };
-
-    TreeNodeView.prototype.model = function (domainObject) {
-        if (this.unlisten) {
-            this.unlisten();
-        }
-
-        if (domainObject) {
-            this.unlisten = domainObject.getCapability('mutation')
-                .listen(this.populateContents.bind(this));
-            this.populateContents(domainObject);
+        if (state) {
+            this.el.addClass('expanded');
         } else {
-            this.li.empty();
+            this.el.removeClass('expanded');
         }
+
+        this.callbacks.forEach(function (callback) {
+            callback(state);
+        });
     };
 
-    /**
-     *
-     * @returns {HTMLElement[]}
-     */
-    TreeNodeView.prototype.elements = function () {
-        return this.li;
+    ToggleView.prototype.observe = function (callback) {
+        this.callbacks.push(callback);
+        return function () {
+            this.callbacks = this.callbacks.filter(function (c) {
+                return c !== callback;
+            });
+        }.bind(this);
     };
 
-
-    return TreeNodeView;
+    return ToggleView;
 });

--- a/platform/commonUI/general/src/ui/ToggleView.js
+++ b/platform/commonUI/general/src/ui/ToggleView.js
@@ -30,11 +30,11 @@ define([
         this.callbacks = [];
         this.el = $(toggleTemplate);
         this.el.on('click', function () {
-            this.model(!this.expanded);
+            this.value(!this.expanded);
         }.bind(this));
     }
 
-    ToggleView.prototype.model = function (state) {
+    ToggleView.prototype.value = function (state) {
         this.expanded = state;
 
         if (state) {

--- a/platform/commonUI/general/src/ui/TreeLabelView.js
+++ b/platform/commonUI/general/src/ui/TreeLabelView.js
@@ -22,19 +22,47 @@
 /*global define*/
 
 define([
-    'angular',
+    'zepto',
     'text!../../res/templates/ui/tree-label.html'
-], function (angular, labelTemplate) {
+], function ($, labelTemplate) {
     'use strict';
-
-    var $ = angular.element.bind(angular);
 
     function TreeLabelView() {
         this.el = $(labelTemplate);
     }
 
+    function getGlyph(domainObject) {
+        var type = domainObject.getCapability('type');
+        return type.getGlyph();
+    }
+
+    TreeLabelView.prototype.updateView = function (domainObject) {
+        var titleEl = this.el.find('.t-title-label'),
+            glyphEl = this.el.find('.t-item-icon-glyph'),
+            iconEl = this.el.find('.t-item-icon');
+
+        titleEl.text(domainObject ? domainObject.getModel().name : "");
+        glyphEl.text(domainObject ? getGlyph(domainObject) : "");
+
+        if (domainObject && isLink(domainObject)) {
+            iconEl.addClass('l-icon-link');
+        } else {
+            iconEl.removeClass('l-icon-link');
+        }
+    };
+
     TreeLabelView.prototype.model = function (domainObject) {
-        
+        if (this.unlisten) {
+            this.unlisten();
+            delete this.unlisten;
+        }
+
+        this.updateView(domainObject);
+
+        if (domainObject) {
+            this.unlisten = domainObject.getCapability('mutation')
+                .listen(this.updateView.bind(this));
+        }
     };
 
     TreeLabelView.prototype.elements = function () {

--- a/platform/commonUI/general/src/ui/TreeLabelView.js
+++ b/platform/commonUI/general/src/ui/TreeLabelView.js
@@ -66,7 +66,7 @@ define([
 
         if (domainObject) {
             this.unlisten = domainObject.getCapability('mutation')
-                .listen(this.updateView.bind(this));
+                .listen(this.updateView.bind(this, domainObject));
         }
     };
 

--- a/platform/commonUI/general/src/ui/TreeLabelView.js
+++ b/platform/commonUI/general/src/ui/TreeLabelView.js
@@ -23,7 +23,7 @@
 
 define([
     'zepto',
-    'text!../../res/templates/ui/tree-label.html'
+    'text!../../res/templates/tree/tree-label.html'
 ], function ($, labelTemplate) {
     'use strict';
 

--- a/platform/commonUI/general/src/ui/TreeLabelView.js
+++ b/platform/commonUI/general/src/ui/TreeLabelView.js
@@ -23,43 +23,23 @@
 
 define([
     'angular',
-    'text!../../res/templates/ui/toggle.html'
-], function (angular, toggleTemplate) {
-    function ToggleView(state) {
-        this.expanded = !!state;
-        this.callbacks = [];
-        this.el = angular.element(toggleTemplate);
-        this.el.on('click', function () {
-            this.model(!this.expanded);
-        }.bind(this));
+    'text!../../res/templates/ui/tree-label.html'
+], function (angular, labelTemplate) {
+    'use strict';
+
+    var $ = angular.element.bind(angular);
+
+    function TreeLabelView() {
+        this.el = $(labelTemplate);
     }
 
-    ToggleView.prototype.model = function (state) {
-        this.expanded = state;
-
-        if (state) {
-            this.el.addClass('expanded');
-        } else {
-            this.el.removeClass('expanded');
-        }
-
-        this.callbacks.forEach(function (callback) {
-            callback(state);
-        });
+    TreeLabelView.prototype.model = function (domainObject) {
+        
     };
 
-    ToggleView.prototype.observe = function (callback) {
-        this.callbacks.push(callback);
-        return function () {
-            this.callbacks = this.callbacks.filter(function (c) {
-                return c !== callback;
-            });
-        }.bind(this);
-    };
-
-    ToggleView.prototype.elements = function () {
+    TreeLabelView.prototype.elements = function () {
         return this.el;
     };
 
-    return ToggleView;
+    return TreeLabelView;
 });

--- a/platform/commonUI/general/src/ui/TreeLabelView.js
+++ b/platform/commonUI/general/src/ui/TreeLabelView.js
@@ -36,6 +36,11 @@ define([
         return type.getGlyph();
     }
 
+    function isLink(domainObject) {
+        var location = domainObject.getCapability('location');
+        return location.isLink();
+    }
+
     TreeLabelView.prototype.updateView = function (domainObject) {
         var titleEl = this.el.find('.t-title-label'),
             glyphEl = this.el.find('.t-item-icon-glyph'),

--- a/platform/commonUI/general/src/ui/TreeLabelView.js
+++ b/platform/commonUI/general/src/ui/TreeLabelView.js
@@ -27,8 +27,9 @@ define([
 ], function ($, labelTemplate) {
     'use strict';
 
-    function TreeLabelView() {
+    function TreeLabelView(gestureService) {
         this.el = $(labelTemplate);
+        this.gestureService = gestureService;
     }
 
     function getGlyph(domainObject) {
@@ -62,11 +63,22 @@ define([
             delete this.unlisten;
         }
 
+        if (this.activeGestures) {
+            this.activeGestures.destroy();
+            delete this.activeGestures;
+        }
+
         this.updateView(domainObject);
 
         if (domainObject) {
             this.unlisten = domainObject.getCapability('mutation')
                 .listen(this.updateView.bind(this, domainObject));
+
+            this.activeGestures = this.gestureService.attachGestures(
+                this.elements(),
+                domainObject,
+                [ 'info', 'menu', 'drag' ]
+            );
         }
     };
 

--- a/platform/commonUI/general/src/ui/TreeNodeView.js
+++ b/platform/commonUI/general/src/ui/TreeNodeView.js
@@ -76,6 +76,36 @@ define([
         }
     };
 
+    TreeNodeView.prototype.value = function (domainObject) {
+        var activeIdPath = getIdPath(this.activeObject),
+            selectedIdPath = getIdPath(domainObject);
+
+        if (this.onSelectionPath) {
+            this.li.find('.tree-item').eq(0).removeClass('selected');
+            if (this.subtreeView) {
+                this.subtreeView.value(undefined);
+            }
+        }
+
+        this.onSelectionPath =
+            !!domainObject &&
+            !!this.activeObject &&
+            (activeIdPath.length <= selectedIdPath.length) &&
+                activeIdPath.every(function (id, index) {
+                    return selectedIdPath[index] === id;
+                });
+
+        if (this.onSelectionPath) {
+            if (activeIdPath.length === selectedIdPath.length) {
+                this.li.find('.tree-item').eq(0).addClass('selected');
+            } else {
+                // Expand to reveal the selection
+                this.toggleView.value(true);
+                this.subtreeView.value(domainObject);
+            }
+        }
+    };
+
     /**
      *
      * @returns {HTMLElement[]}

--- a/platform/commonUI/general/src/ui/TreeNodeView.js
+++ b/platform/commonUI/general/src/ui/TreeNodeView.js
@@ -76,6 +76,16 @@ define([
         }
     };
 
+    function getIdPath(domainObject) {
+        function getId(domainObject) {
+            return domainObject.getId();
+        }
+        
+        return domainObject ?
+            domainObject.getCapability('context').getPath().map(getId) :
+            [];
+    }
+
     TreeNodeView.prototype.value = function (domainObject) {
         var activeIdPath = getIdPath(this.activeObject),
             selectedIdPath = getIdPath(domainObject);

--- a/platform/commonUI/general/src/ui/TreeNodeView.js
+++ b/platform/commonUI/general/src/ui/TreeNodeView.js
@@ -23,7 +23,7 @@
 
 define([
     'angular',
-    'text!../../res/templates/ui/node.html',
+    'text!../../res/templates/tree/node.html',
     './ToggleView'
 ], function (angular, nodeTemplate, ToggleView) {
     'use strict';

--- a/platform/commonUI/general/src/ui/TreeNodeView.js
+++ b/platform/commonUI/general/src/ui/TreeNodeView.js
@@ -29,7 +29,7 @@ define([
 ], function ($, nodeTemplate, ToggleView, TreeLabelView) {
     'use strict';
 
-    function TreeNodeView(subtreeFactory) {
+    function TreeNodeView(subtreeFactory, selectFn) {
         this.li = $('<li>');
 
         this.toggleView = new ToggleView(false);
@@ -48,6 +48,10 @@ define([
         }.bind(this));
 
         this.labelView = new TreeLabelView();
+
+        $(this.labelView.elements()).on('click', function () {
+            selectFn(this.activeObject);
+        }.bind(this));
 
         this.li.append($(nodeTemplate));
         this.li.find('span').eq(0)
@@ -80,7 +84,7 @@ define([
         function getId(domainObject) {
             return domainObject.getId();
         }
-        
+
         return domainObject ?
             domainObject.getCapability('context').getPath().map(getId) :
             [];

--- a/platform/commonUI/general/src/ui/TreeNodeView.js
+++ b/platform/commonUI/general/src/ui/TreeNodeView.js
@@ -29,7 +29,7 @@ define([
 ], function ($, nodeTemplate, ToggleView, TreeLabelView) {
     'use strict';
 
-    function TreeNodeView(subtreeFactory, selectFn) {
+    function TreeNodeView(gestureService, subtreeFactory, selectFn) {
         this.li = $('<li>');
 
         this.toggleView = new ToggleView(false);
@@ -47,7 +47,7 @@ define([
             }
         }.bind(this));
 
-        this.labelView = new TreeLabelView();
+        this.labelView = new TreeLabelView(gestureService);
 
         $(this.labelView.elements()).on('click', function () {
             selectFn(this.activeObject);

--- a/platform/commonUI/general/src/ui/TreeNodeView.js
+++ b/platform/commonUI/general/src/ui/TreeNodeView.js
@@ -22,14 +22,12 @@
 /*global define*/
 
 define([
-    'angular',
+    'zepto',
     'text!../../res/templates/tree/node.html',
     './ToggleView',
     './TreeLabelView'
-], function (angular, nodeTemplate, ToggleView, TreeLabelView) {
+], function ($, nodeTemplate, ToggleView, TreeLabelView) {
     'use strict';
-
-    var $ = angular.element.bind(angular);
 
     function TreeNodeView(subtreeFactory) {
         this.li = $('<li>');
@@ -40,6 +38,8 @@ define([
                 if (!this.subtreeView) {
                     this.subtreeView = subtreeFactory();
                     this.subtreeView.model(this.activeObject);
+                    this.li.find('.tree-item-subtree').eq(0)
+                        .append($(this.subtreeView.elements()));
                 }
                 $(this.subtreeView.elements()).removeClass('hidden');
             } else if (this.subtreeView) {
@@ -51,8 +51,8 @@ define([
 
         this.li.append($(nodeTemplate));
         this.li.find('span').eq(0)
-            .append(this.toggleView.elements())
-            .append(this.labelView.elements());
+            .append($(this.toggleView.elements()))
+            .append($(this.labelView.elements()));
 
         this.model(undefined);
     }

--- a/platform/commonUI/general/src/ui/TreeNodeView.js
+++ b/platform/commonUI/general/src/ui/TreeNodeView.js
@@ -24,8 +24,9 @@
 define([
     'angular',
     'text!../../res/templates/tree/node.html',
-    './ToggleView'
-], function (angular, nodeTemplate, ToggleView) {
+    './ToggleView',
+    './TreeLabelView'
+], function (angular, nodeTemplate, ToggleView, TreeLabelView) {
     'use strict';
 
     var $ = angular.element.bind(angular);
@@ -45,13 +46,16 @@ define([
                 $(this.subtreeView.elements()).addClass('hidden');
             }
         }.bind(this));
-    }
 
-    TreeNodeView.prototype.populateContents = function (domainObject) {
-        if (this.li.children().length === 0) {
-            this.li.append($(nodeTemplate));
-        }
-    };
+        this.labelView = new TreeLabelView();
+
+        this.li.append($(nodeTemplate));
+        this.li.find('span').eq(0)
+            .append(this.toggleView.elements())
+            .append(this.labelView.elements());
+
+        this.model(undefined);
+    }
 
     TreeNodeView.prototype.model = function (domainObject) {
         if (this.unlisten) {
@@ -60,14 +64,13 @@ define([
 
         this.activeObject = domainObject;
 
-        if (domainObject) {
-            this.unlisten = domainObject.getCapability('mutation')
-                .listen(this.populateContents.bind(this));
-            this.populateContents(domainObject);
+        if (domainObject && domainObject.hasCapability('composition')) {
+            $(this.toggleView.elements()).addClass('has-children');
         } else {
-            this.li.empty();
+            $(this.toggleView.elements()).removeClass('has-children');
         }
 
+        this.labelView.model(domainObject);
         if (this.subtreeView) {
             this.subtreeView.model(domainObject);
         }

--- a/platform/commonUI/general/src/ui/TreeView.js
+++ b/platform/commonUI/general/src/ui/TreeView.js
@@ -103,6 +103,16 @@ define([
         });
     };
 
+    TreeView.prototype.observe = function (callback) {
+        callback(this.selectedObject);
+        this.callbacks.push(callback);
+        return function () {
+            this.callbacks = this.callbacks.filter(function (c) {
+                return c !== callback;
+            });
+        }.bind(this);
+    };
+
     /**
      *
      * @returns {HTMLElement[]}

--- a/platform/commonUI/general/src/ui/TreeView.js
+++ b/platform/commonUI/general/src/ui/TreeView.js
@@ -30,6 +30,7 @@ define([
     function TreeView() {
         this.ul = $('<ul class="tree"></ul>');
         this.nodeViews = [];
+        this.callbacks = [];
     }
 
     function newTreeView() {
@@ -62,6 +63,7 @@ define([
             if (domainObject === self.activeObject) {
                 self.setSize(domainObjects.length);
                 domainObjects.forEach(addNode);
+                self.updateNodeViewSelection();
             }
         }
 
@@ -85,6 +87,20 @@ define([
         } else {
             this.setSize(0);
         }
+    };
+
+    TreeView.prototype.updateNodeViewSelection = function () {
+        this.nodeViews.forEach(function (nodeView) {
+            nodeView.value(this.selectedObject);
+        });
+    };
+
+    TreeView.prototype.value = function (domainObject) {
+        this.selectedObject = domainObject;
+        this.updateNodeViewSelection();
+        this.callbacks.forEach(function (callback) {
+            callback(domainObject);
+        });
     };
 
     /**

--- a/platform/commonUI/general/src/ui/TreeView.js
+++ b/platform/commonUI/general/src/ui/TreeView.js
@@ -27,21 +27,25 @@ define([
 ], function ($, TreeNodeView) {
     'use strict';
 
-    function TreeView() {
+    function TreeView(selectFn) {
         this.ul = $('<ul class="tree"></ul>');
         this.nodeViews = [];
         this.callbacks = [];
+        this.selectFn = selectFn || this.value.bind(this);
     }
 
-    function newTreeView() {
-        return new TreeView();
+    TreeView.prototype.newTreeView = function () {
+        return new TreeView(this.selectFn);
     }
 
     TreeView.prototype.setSize = function (sz) {
         var nodeView;
 
         while (this.nodeViews.length < sz) {
-            nodeView = new TreeNodeView(newTreeView);
+            nodeView = new TreeNodeView(
+                this.newTreeView.bind(this),
+                this.selectFn
+            );
             this.nodeViews.push(nodeView);
             this.ul.append($(nodeView.elements()));
         }
@@ -104,7 +108,6 @@ define([
     };
 
     TreeView.prototype.observe = function (callback) {
-        callback(this.selectedObject);
         this.callbacks.push(callback);
         return function () {
             this.callbacks = this.callbacks.filter(function (c) {

--- a/platform/commonUI/general/src/ui/TreeView.js
+++ b/platform/commonUI/general/src/ui/TreeView.js
@@ -22,12 +22,10 @@
 /*global define*/
 
 define([
-    'angular',
+    'zepto',
     './TreeNodeView'
-], function (angular, TreeNodeView) {
+], function ($, TreeNodeView) {
     'use strict';
-
-    var $ = angular.element.bind(angular);
 
     function TreeView() {
         this.ul = $('<ul class="tree"></ul>');

--- a/platform/commonUI/general/src/ui/TreeView.js
+++ b/platform/commonUI/general/src/ui/TreeView.js
@@ -27,22 +27,24 @@ define([
 ], function ($, TreeNodeView) {
     'use strict';
 
-    function TreeView(selectFn) {
+    function TreeView(gestureService, selectFn) {
         this.ul = $('<ul class="tree"></ul>');
         this.nodeViews = [];
         this.callbacks = [];
         this.selectFn = selectFn || this.value.bind(this);
+        this.gestureService = gestureService;
     }
 
     TreeView.prototype.newTreeView = function () {
-        return new TreeView(this.selectFn);
-    }
+        return new TreeView(this.gestureService, this.selectFn);
+    };
 
     TreeView.prototype.setSize = function (sz) {
         var nodeView;
 
         while (this.nodeViews.length < sz) {
             nodeView = new TreeNodeView(
+                this.gestureService,
                 this.newTreeView.bind(this),
                 this.selectFn
             );

--- a/platform/commonUI/general/src/ui/TreeView.js
+++ b/platform/commonUI/general/src/ui/TreeView.js
@@ -22,7 +22,8 @@
 /*global define*/
 
 define([
-    'angular'
+    'angular',
+    './TreeNodeView'
 ], function (angular, TreeNodeView) {
     'use strict';
 
@@ -34,11 +35,15 @@ define([
         this.nodeViews = [];
     }
 
+    function newTreeView() {
+        return new TreeView();
+    }
+
     TreeView.prototype.setSize = function (sz) {
         var nodeView;
 
         while (this.nodeViews.length < sz) {
-            nodeView = new TreeNodeView();
+            nodeView = new TreeNodeView(newTreeView);
             this.nodeViews.push(nodeView);
             this.ul.append($(nodeView.elements()));
         }

--- a/platform/commonUI/general/src/ui/TreeView.js
+++ b/platform/commonUI/general/src/ui/TreeView.js
@@ -23,8 +23,9 @@
 
 define([
     'zepto',
-    './TreeNodeView'
-], function ($, TreeNodeView) {
+    './TreeNodeView',
+    'text!../../res/templates/tree/wait-node.html'
+], function ($, TreeNodeView, spinnerTemplate) {
     'use strict';
 
     function TreeView(gestureService, selectFn) {
@@ -33,6 +34,7 @@ define([
         this.callbacks = [];
         this.selectFn = selectFn || this.value.bind(this);
         this.gestureService = gestureService;
+        this.pending = false;
     }
 
     TreeView.prototype.newTreeView = function () {
@@ -66,6 +68,12 @@ define([
         }
 
         function addNodes(domainObjects) {
+            if (self.pending) {
+                self.pending = false;
+                self.nodeViews = [];
+                self.ul.empty();
+            }
+
             if (domainObject === self.activeObject) {
                 self.setSize(domainObjects.length);
                 domainObjects.forEach(addNode);
@@ -73,7 +81,6 @@ define([
             }
         }
 
-        // TODO: Add pending indicator
         domainObject.useCapability('composition')
             .then(addNodes);
     };
@@ -87,6 +94,8 @@ define([
         this.ul.empty();
 
         if (domainObject && domainObject.hasCapability('composition')) {
+            this.pending = true;
+            this.ul.append($(spinnerTemplate));
             this.unlisten = domainObject.getCapability('mutation')
                 .listen(this.loadComposition.bind(this));
             this.loadComposition(domainObject);

--- a/platform/commonUI/general/src/ui/TreeView.js
+++ b/platform/commonUI/general/src/ui/TreeView.js
@@ -30,8 +30,7 @@ define([
     var $ = angular.element.bind(angular);
 
     function TreeView() {
-        this.ul = $('<ul>');
-        this.ul.addClass('tree');
+        this.ul = $('<ul class="tree"></ul>');
         this.nodeViews = [];
     }
 

--- a/platform/commonUI/general/src/ui/TreeView.js
+++ b/platform/commonUI/general/src/ui/TreeView.js
@@ -92,7 +92,7 @@ define([
     TreeView.prototype.updateNodeViewSelection = function () {
         this.nodeViews.forEach(function (nodeView) {
             nodeView.value(this.selectedObject);
-        });
+        }.bind(this));
     };
 
     TreeView.prototype.value = function (domainObject) {

--- a/platform/commonUI/general/src/ui/TreeView.js
+++ b/platform/commonUI/general/src/ui/TreeView.js
@@ -1,0 +1,98 @@
+/*****************************************************************************
+ * Open MCT Web, Copyright (c) 2014-2015, United States Government
+ * as represented by the Administrator of the National Aeronautics and Space
+ * Administration. All rights reserved.
+ *
+ * Open MCT Web is licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * Open MCT Web includes source code licensed under additional open source
+ * licenses. See the Open Source Licenses file (LICENSES.md) included with
+ * this source code distribution or the Licensing information page available
+ * at runtime from the About dialog for additional information.
+ *****************************************************************************/
+/*global define*/
+
+define([
+    'angular'
+], function (angular, TreeNodeView) {
+    'use strict';
+
+    var $ = angular.element.bind(angular);
+
+    function TreeView() {
+        this.ul = $('<ul>');
+        this.ul.addClass('tree');
+        this.nodeViews = [];
+    }
+
+    TreeView.prototype.setSize = function (sz) {
+        var nodeView;
+
+        while (this.nodeViews.length < sz) {
+            nodeView = new TreeNodeView();
+            this.nodeViews.push(nodeView);
+            this.ul.append($(nodeView.elements()));
+        }
+
+        while (this.nodeViews.length > sz) {
+            nodeView = this.nodeViews.pop();
+            $(nodeView.elements()).remove();
+        }
+    };
+
+    TreeView.prototype.loadComposition = function (domainObject) {
+        var self = this;
+
+        function addNode(domainObject, index) {
+            self.nodeViews[index].model(domainObject);
+        }
+
+        function addNodes(domainObjects) {
+            if (domainObject === self.activeObject) {
+                self.setSize(domainObjects.length);
+                domainObjects.forEach(addNode);
+            }
+        }
+
+        // TODO: Add pending indicator
+        domainObject.useCapability('composition')
+            .then(addNodes);
+    };
+
+    TreeView.prototype.model = function (domainObject) {
+        if (this.unlisten) {
+            this.unlisten();
+        }
+
+        this.activeObject = domainObject;
+        this.ul.empty();
+
+        if (domainObject && domainObject.hasCapability('composition')) {
+            this.unlisten = domainObject.getCapability('mutation')
+                .listen(this.loadComposition.bind(this));
+            this.loadComposition(domainObject);
+        } else {
+            this.setSize(0);
+        }
+    };
+
+    /**
+     *
+     * @returns {HTMLElement[]}
+     */
+    TreeView.prototype.elements = function () {
+        return this.ul;
+    };
+
+
+    return TreeView;
+});

--- a/platform/commonUI/general/test/directives/MCTTreeSpec.js
+++ b/platform/commonUI/general/test/directives/MCTTreeSpec.js
@@ -1,0 +1,92 @@
+/*****************************************************************************
+ * Open MCT Web, Copyright (c) 2014-2015, United States Government
+ * as represented by the Administrator of the National Aeronautics and Space
+ * Administration. All rights reserved.
+ *
+ * Open MCT Web is licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * Open MCT Web includes source code licensed under additional open source
+ * licenses. See the Open Source Licenses file (LICENSES.md) included with
+ * this source code distribution or the Licensing information page available
+ * at runtime from the About dialog for additional information.
+ *****************************************************************************/
+/*global define,describe,beforeEach,jasmine,it,expect*/
+
+define([
+    '../../src/directives/MCTTree'
+], function (MCTTree) {
+    describe("The mct-tree directive", function () {
+        var mockParse,
+            mockGestureService,
+            mockExpr,
+            mctTree;
+
+        beforeEach(function () {
+            mockGestureService = jasmine.createSpyObj(
+                'gestureService',
+                [ 'attachGestures' ]
+            );
+            mockParse = jasmine.createSpy('$parse');
+            mockExpr = jasmine.createSpy('expr');
+            mockExpr.assign = jasmine.createSpy('assign');
+            mockParse.andReturn(mockExpr);
+
+            mctTree = new MCTTree(mockParse, mockGestureService);
+        });
+
+        it("is applicable as an element", function () {
+            expect(mctTree.restrict).toEqual("E");
+        });
+
+        it("two-way binds to mctObject", function () {
+            expect(mctTree.scope).toEqual({ mctObject: "=" });
+        });
+
+        describe("link", function () {
+            var mockScope,
+                mockElement,
+                testAttrs;
+
+            beforeEach(function () {
+                mockScope = jasmine.createSpyObj('$scope', ['$watch', '$on']);
+                mockElement = jasmine.createSpyObj('element', ['append']);
+                testAttrs = { mctModel: "some-expression" };
+                mockScope.$parent =
+                    jasmine.createSpyObj('$scope', ['$watch', '$on']);
+                mctTree.link(mockScope, mockElement, testAttrs);
+            });
+
+            it("populates the mct-tree element", function () {
+                expect(mockElement.append).toHaveBeenCalled();
+            });
+
+            it("watches for mct-model's expression in the parent", function () {
+                expect(mockScope.$parent.$watch).toHaveBeenCalledWith(
+                    testAttrs.mctModel,
+                    jasmine.any(Function)
+                );
+            });
+
+            it("watches for changes to mct-object", function () {
+                expect(mockScope.$watch).toHaveBeenCalledWith("mctObject");
+            });
+
+            it("listens for the $destroy event", function () {
+                expect(mockScope.$on).toHaveBeenCalledWith(
+                    "$destroy",
+                    jasmine.any(Function)
+                );
+            });
+        });
+    });
+
+});

--- a/platform/commonUI/general/test/directives/MCTTreeSpec.js
+++ b/platform/commonUI/general/test/directives/MCTTreeSpec.js
@@ -77,7 +77,10 @@ define([
             });
 
             it("watches for changes to mct-object", function () {
-                expect(mockScope.$watch).toHaveBeenCalledWith("mctObject");
+                expect(mockScope.$watch).toHaveBeenCalledWith(
+                    "mctObject",
+                    jasmine.any(Function)
+                );
             });
 
             it("listens for the $destroy event", function () {

--- a/platform/commonUI/general/test/ui/TreeViewSpec.js
+++ b/platform/commonUI/general/test/ui/TreeViewSpec.js
@@ -1,0 +1,64 @@
+/*****************************************************************************
+ * Open MCT Web, Copyright (c) 2014-2015, United States Government
+ * as represented by the Administrator of the National Aeronautics and Space
+ * Administration. All rights reserved.
+ *
+ * Open MCT Web is licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * Open MCT Web includes source code licensed under additional open source
+ * licenses. See the Open Source Licenses file (LICENSES.md) included with
+ * this source code distribution or the Licensing information page available
+ * at runtime from the About dialog for additional information.
+ *****************************************************************************/
+/*global define,describe,beforeEach,jasmine,it,expect*/
+
+define([
+    '../../src/ui/TreeView'
+], function (TreeView) {
+    'use strict';
+
+    describe("TreeView", function () {
+        var mockGestureService,
+            mockSelectFn,
+            mockGestureHandle,
+            treeView;
+
+        beforeEach(function () {
+            mockGestureService = jasmine.createSpyObj(
+                'gestureService',
+                [ 'attachGestures' ]
+            );
+
+            mockSelectFn = jasmine.createSpy('select');
+
+            mockGestureHandle = jasmine.createSpyObj('gestures', ['destroy']);
+
+            mockGestureService.attachGestures.andReturn(mockGestureHandle);
+
+            treeView = new TreeView(mockGestureService, mockSelectFn);
+        });
+
+        describe("elements", function () {
+            var elements;
+
+            beforeEach(function () {
+                elements = treeView.elements();
+            });
+
+            it("is an unordered list", function () {
+                expect(elements[0].tagName.toLowerCase())
+                    .toEqual('ul');
+            });
+        });
+    });
+
+});

--- a/test-main.js
+++ b/test-main.js
@@ -53,7 +53,8 @@ requirejs.config({
         "saveAs": "bower_components/FileSaver.js/FileSaver.min",
         "screenfull": "bower_components/screenfull/dist/screenfull.min",
         "text": "bower_components/text/text",
-        "uuid": "bower_components/node-uuid/uuid"
+        "uuid": "bower_components/node-uuid/uuid",
+        "zepto": "bower_components/zepto/zepto.min"
     },
 
     "shim": {

--- a/test-main.js
+++ b/test-main.js
@@ -66,6 +66,9 @@ requirejs.config({
         },
         "moment-duration-format": {
             "deps": [ "moment" ]
+        },
+        "zepto": {
+            "exports": "Zepto"
         }
     },
 


### PR DESCRIPTION
...instead, use Zepto to handle DOM manipulations more directly in response to user actions and mutation events. Goal is to reduce the watch count associated with the tree, #732 and #315. Also serves as informative prototyping for interfaces for non-Angular UI components, #463.

Still needed for parity/completion:

- [x] Click to select nodes
- [x] Highlight selected nodes
- [x] Expand to show nodes on selection change
- [x] Allow drag
- [x] Allow context menu
- [x] Show info bubble
- [x] Wait spinner
- [ ] Refactor out commonalities of Views
- [x] Tests
- [ ] JSDoc