### PR TITLE
[Tables] #742 Fixed digest-related bug in RTTelemetryController

### DIFF
--- a/platform/features/table/src/controllers/RTTelemetryTableController.js
+++ b/platform/features/table/src/controllers/RTTelemetryTableController.js
@@ -89,9 +89,9 @@ define(
                     datum = self.handle.getDatum(telemetryObject);
                     if (datum) {
                         row = self.table.getRowValues(telemetryObject, datum);
-                        self.$scope.rows = self.$scope.rows || [];
                         if (!self.$scope.rows){
                             self.$scope.rows = [row];
+                            self.$scope.$digest();
                         } else {
                             self.$scope.rows.push(row);
                             self.$scope.$broadcast('add:row',

--- a/platform/features/table/test/controllers/RTTelemetryTableControllerSpec.js
+++ b/platform/features/table/test/controllers/RTTelemetryTableControllerSpec.js
@@ -56,6 +56,7 @@ define(
                     '$on',
                     '$watch',
                     '$watchCollection',
+                    '$digest',
                     '$broadcast'
                 ]);
                 mockScope.$on.andCallFake(function (expression, callback){
@@ -131,6 +132,7 @@ define(
 
             it('updates table with new streaming telemetry', function () {
                 controller.subscribe();
+                mockScope.rows = [];
                 mockTelemetryHandler.handle.mostRecentCall.args[1]();
                 expect(mockScope.$broadcast).toHaveBeenCalledWith('add:row', 0);
             });


### PR DESCRIPTION
Fixed a bug that caused an error to occur when new row added to realtime table. The issue was caused by the fact that a digest does not occur in between setting the `rows` element on $scope, and when the directive is informed (via $broadcast) that a new row is available. Only occurred on tables composed of multiple telemetry objects.

### Author Checklist

1. Changes address original issue? __Y__
2. Unit tests included and/or updated with changes? __Y__
3. Command line build passes? __Y__
4. Changes have been smoke-tested? __Y__